### PR TITLE
Mint with ETH using 1inch

### DIFF
--- a/contracts/integrations/AbstractBuyAndMint.sol
+++ b/contracts/integrations/AbstractBuyAndMint.sol
@@ -1,0 +1,77 @@
+pragma solidity 0.5.16;
+
+// Internal
+import { MassetHelpers } from "../masset/shared/MassetHelpers.sol";
+
+// Library
+import { Ownable } from "@openzeppelin/contracts/ownership/Ownable.sol";
+
+/**
+ * @title   AbstractBuyAndMint
+ * @author  Stability Labs Pty. Ltd.
+ * @notice  Abstract contract to allow buy bAsset tokens with ETH and mint mAssets tokens
+ *          from mStable.
+ */
+contract AbstractBuyAndMint is Ownable {
+
+    using MassetHelpers for address;
+
+    event MassetAdded(address indexed mAsset);
+
+    // mAsset address => exists
+    mapping(address => bool) public mAssets;
+
+    /**
+     * @dev Abstarct constructor
+     * @param _mAssets Array of valid mAsset addresses allowed to mint.
+     */
+    constructor(address[] memory _mAssets) internal {
+        require(_mAssets.length > 0, "No mAssets provided");
+        for(uint256 i = 0; i < _mAssets.length; i++) {
+            _addMasset(_mAssets[i]);
+        }
+    }
+
+    /**
+     * @dev Anyone can call and perform infinite approval for bAssets
+     * @param _bAssets An array containing bAssets addresses
+     */
+    function infiniteApprove(address _mAsset, address[] calldata _bAssets) external {
+        for(uint256 i = 0; i < _bAssets.length; i++) {
+            _bAssets[i].safeInfiniteApprove(_mAsset);
+        }
+    }
+
+    /**
+     * @dev The Owner of the contract allowed to add a new supported mAsset.
+     * @param _mAsset Address of the mAsset
+     */
+    function addMasset(address _mAsset) external onlyOwner {
+        _addMasset(_mAsset);
+    }
+
+    /**
+     * @dev Add a new mAsset to the supported mAssets list
+     * @param _mAsset Address of the mAsset
+     */
+    function _addMasset(address _mAsset) internal {
+        require(_mAsset != address(0), "mAsset address is zero");
+        require(!_massetExists(_mAsset), "mAsset already exists");
+        mAssets[_mAsset] = true;
+        emit MassetAdded(_mAsset);
+    }
+
+    /**
+     * @dev     Validate that the given mAsset supported by this contract.
+     * @notice  Only validate mAsset address. As bAsset gets validated during minting process.
+     * @param _mAsset mAsset address to validate
+     */
+    function _massetExists(address _mAsset) internal view returns (bool) {
+        return mAssets[_mAsset];
+    }
+
+    /**
+     * @dev Abstract function to get the external DEX contract address
+     */
+    function _externalDexAddress() internal view returns(address);
+}

--- a/contracts/integrations/IMintWith1Inch.sol
+++ b/contracts/integrations/IMintWith1Inch.sol
@@ -1,0 +1,23 @@
+pragma solidity 0.5.16;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title   IMintWith1Inch
+ * @author  Stability Labs Pty. Ltd.
+ * @notice  Interface to Buy bAssets and Mint the mAssets from the OneSplit (1inch exchange)
+ */
+interface IMintWith1Inch {
+    /**
+     * @dev Buy the maximum bAsset tokens from DEX and mint mAsset tokens from mStable.
+     *      ETH sent to the function used to buy bAsset tokens from DEX.
+     * @param _srcBasset Source bAsset token address
+     * @param _destMasset mAsset token address to mint
+     * @param _minBassetUnits Minimum amount of bAssets to purchase
+     * @param _distribution Distribution for different DEXes to buy bAssets from
+     * @return mAssetQtyMinted Returns the quantity of mAsset minted from mStable
+     */
+    function buyAndMint(IERC20 _srcBasset, address _destMasset, uint256 _minBassetUnits, uint256[] calldata _distribution)
+        external payable returns (uint256 mAssetQtyMinted);
+
+}

--- a/contracts/integrations/MintWith1Inch.sol
+++ b/contracts/integrations/MintWith1Inch.sol
@@ -1,0 +1,108 @@
+pragma solidity 0.5.16;
+
+// External
+import { AbstractBuyAndMint } from "./AbstractBuyAndMint.sol";
+import { IMintWith1Inch } from "./IMintWith1Inch.sol";
+import { IMasset } from "../interfaces/IMasset.sol";
+
+// Libs
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+
+/**
+ * @dev OneSplit Exchange interface
+ */
+contract IOneSplit {
+    function swap(
+        IERC20 fromToken,
+        IERC20 toToken,
+        uint256 amount,
+        uint256 minReturn,
+        uint256[] memory distribution,
+        uint256 flags
+    ) public payable;
+}
+
+/**
+ * @title   MintWith1Inch
+ * @author  Stability Labs Pty. Ltd.
+ * @notice  Contract integrates with 1inch (a.k.a OneSplit) contract and allows anyone to buy
+ *          bAsset tokens using ETH from the 1inch and mint mAssets.
+ */
+contract MintWith1Inch is AbstractBuyAndMint, IMintWith1Inch {
+
+    using SafeMath for uint256;
+
+    // 1inch Exchange 1Split contract address
+    IOneSplit public oneSplit;
+
+    IERC20 private constant ETH_ADDRESS = IERC20(0x0000000000000000000000000000000000000000);
+
+    /**
+     * @param _oneSplit OneSplit contract address
+     * @param _mAssets Array of mAssets addresses
+     */
+    constructor(address _oneSplit, address[] memory _mAssets)
+        public
+        AbstractBuyAndMint(_mAssets)
+    {
+        require(_oneSplit != address(0), "1inch address is zero");
+
+        oneSplit = IOneSplit(_oneSplit);
+    }
+
+    // @override
+    function _externalDexAddress() internal view returns(address) {
+        return address(oneSplit);
+    }
+
+    // NOTICE: Make the following function call off-chain to get the `distribution` and
+    // pass to this function. This is to reduce gas consumption.
+
+    // ============================================================================
+    // Offchain: To calculate the distribution to mint max mAssets with ETH amount
+    // ============================================================================
+    /*
+    // Parts = 20 (Suggested by 1inch to provide best rates)
+    uint256 parts = 20;
+    // Not disable any exchange
+    uint256 disableFlags = 0;
+    (,uint256[] memory distribution) =
+        oneSplit.getExpectedReturn(
+            ETH_ADDRESS,        //fromToken
+            IERC20(_srcBasset), //toToken
+            msg.value,          //fromAmount
+            parts,              //parts
+            disableFlags        //disableFlags
+        );
+    */
+
+    // @override
+    function buyAndMint(
+        IERC20 _srcBasset,
+        address _destMasset,
+        uint256 _minBassetUnits,
+        uint256[] calldata _distribution
+    )
+        external
+        payable
+        returns (uint256 mAssetQtyMinted)
+    {
+        require(msg.value > 0, "ETH not sent");
+        require(_massetExists(_destMasset), "Not a valid mAsset");
+
+        // 1. Buy bAsset of worth `msg.value` ETH from OneSplit
+        oneSplit.swap.value(msg.value)(
+            ETH_ADDRESS,
+            _srcBasset,
+            msg.value,
+            _minBassetUnits,
+            _distribution,
+            0
+        );
+
+        uint256 balance = _srcBasset.balanceOf(address(this));
+        // 2. Mint mAsset with all bAsset
+        mAssetQtyMinted = IMasset(_destMasset).mintTo(address(_srcBasset), balance, _msgSender());
+    }
+}

--- a/contracts/z_mocks/integrations/IBuyAndMint.sol
+++ b/contracts/z_mocks/integrations/IBuyAndMint.sol
@@ -1,0 +1,43 @@
+pragma solidity 0.5.16;
+
+/**
+ * @title   IBuyAndMint
+ * @author  Stability Labs Pty. Ltd.
+ * @notice  Interface to Buy bAssets and Mint the mAssets from the DEXes
+ */
+interface IBuyAndMint {
+    /**
+     * @dev Buy the maximum bAsset tokens from DEX and mint mAsset tokens from mStable.
+     *      ETH sent to the function used to buy bAsset tokens from DEX.
+     * @param _srcBasset Source bAsset token address
+     * @param _destMasset mAsset token address to mint
+     * @return mAssetQtyMinted Returns the quantity of mAsset minted from mStable
+     */
+    function buyAndMintMaxMasset(address _srcBasset, address _destMasset)
+        external payable returns (uint256 mAssetQtyMinted);
+
+    /**
+     * @dev Buy the required bAsset tokens from the DEX and Mint the specific amount of
+     *      mAssets from mStable. ETH sent to the function used to buy bAsset tokens from DEX.
+     * @param _srcBasset Source bAsset token address
+     * @param _destMasset mAsset token address to mint
+     * @param _amountOfBassets Expected amount of bAssets to mint from DEX and mint 1:1 from mStable
+     * @return mAssetQtyMinted Returns the quantity of mAsset minted from mStable
+     */
+    function buyAndMintGivenMasset(address _srcBasset, address _destMasset, uint256 _amountOfBassets)
+        external payable returns (uint256 mAssetQtyMinted);
+
+    /**
+     * @dev Buy the required bAssets tokens from the DEX and Mint mAssets from mStable.
+     *      ETH sent to the function used to buy bAsset tokens from DEX.
+     * @param _srcBassets Array of source bAssets token address
+     * @param _ethAmount Array of ETH amount to buy corresponding bAsset from DEX
+     * @param _destMAsset mAsset token address to mint
+     * @return mAssetQtyMinted Returns the quantity of mAsset minted from mStable
+     */
+    function buyAndMintMulti(
+        address[] calldata _srcBassets,
+        uint256[] calldata _ethAmount,
+        address _destMAsset
+    ) external payable returns (uint256 mAssetQtyMinted);
+}

--- a/contracts/z_mocks/integrations/MintWithKyber.sol
+++ b/contracts/z_mocks/integrations/MintWithKyber.sol
@@ -1,0 +1,231 @@
+pragma solidity 0.5.16;
+
+// External
+import { AbstractBuyAndMint } from "../../integrations/AbstractBuyAndMint.sol";
+import { IBuyAndMint } from "./IBuyAndMint.sol";
+
+// Internal
+import { IMasset } from "../../interfaces/IMasset.sol";
+
+// Libs
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import { StableMath } from "../../shared/StableMath.sol";
+
+/**
+ * @title   MintWithKyber
+ * @author  Stability Labs Pty. Ltd.
+ * @notice  Contract integrates with Kyber Network Proxy contract and allows anyone to buy
+ *          bAsset tokens using ETH from the Kyber platform and mint mAsset tokens from mStable.
+ */
+contract MintWithKyber is AbstractBuyAndMint, IBuyAndMint, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+    using SafeMath for uint256;
+    using Address for address payable;
+    using StableMath for uint256;
+
+    address constant internal ETH_TOKEN_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    // TODO update FEE_COLLECTION_ADDRESS address once registered for Kyber Fee Sharing program
+    // https://developer.kyber.network/docs/Integrations-FeeSharing/
+    // TODO UPDATE THIS ADDRESS
+    address constant public FEE_COLLECTION_ADDRESS = address(0);
+
+    KyberNetworkProxyInterface public kyberNetworkProxy;
+
+    /**
+     * @dev Constructor
+     * @param _kyberNetworkProxy Kyeber Network Proxy contract address
+     * @param _mAssets Array of mAssets addresses
+     */
+    constructor(address _kyberNetworkProxy, address[] memory _mAssets)
+        public
+        AbstractBuyAndMint(_mAssets)
+    {
+        require(_kyberNetworkProxy != address(0), "Kyber proxy address is zero");
+
+        kyberNetworkProxy = KyberNetworkProxyInterface(_kyberNetworkProxy);
+    }
+
+    // @override
+    function _externalDexAddress() internal view returns(address) {
+        return address(kyberNetworkProxy);
+    }
+
+    // @override
+    function buyAndMintMaxMasset(
+        address _srcBasset,
+        address _destMasset
+    )
+        external
+        payable
+        nonReentrant
+        returns (uint256 mAssetQtyMinted)
+    {
+        require(msg.value > 0, "ETH not sent");
+        require(_massetExists(_destMasset), "Not a valid mAsset");
+
+        mAssetQtyMinted = _buyAndMint(_srcBasset, _destMasset, msg.value, _msgSender());
+    }
+
+    // @override
+    function buyAndMintGivenMasset(
+        address _srcBasset,
+        address _destMasset,
+        uint256 _amountOfBasset
+    )
+        external
+        payable
+        nonReentrant
+        returns (uint256 mAssetQtyMinted)
+    {
+        require(_massetExists(_destMasset), "Not a valid mAsset");
+
+        // Get the rate from Kyber for `_amountOfBasset`
+        // Example rate to convert from DAI => ETH
+        (uint256 expectedRate,) = kyberNetworkProxy.getExpectedRate(_srcBasset, ETH_TOKEN_ADDRESS, _amountOfBasset);
+
+        // amountOfBassets * expectedRate / 1e18
+        uint256 amountInETH = _amountOfBasset.mulTruncate(expectedRate);
+        require(msg.value >= amountInETH, "Not enough ETH sent");
+
+        // Pass the `expectedRate` ETH to Kyber
+        mAssetQtyMinted = _buyAndMint(_srcBasset, _destMasset, amountInETH, _msgSender());
+
+        // Return remaining ETH balance to the user
+        // WARNING: Reentrancy Guard used for external functions
+        msg.sender.sendValue(msg.value.sub(amountInETH));
+    }
+
+    // @override
+    function buyAndMintMulti(
+        address[] calldata _srcBassets,
+        uint256[] calldata _ethAmount,
+        address _destMasset
+    )
+        external
+        payable
+        nonReentrant
+        returns (uint256 mAssetQtyMinted)
+    {
+        require(msg.value > 0, "ETH not sent");
+        uint256 bAssetsLen = _srcBassets.length;
+        require(bAssetsLen > 0, "No array data sent");
+        require(bAssetsLen == _ethAmount.length, "Array length not matched");
+        require(_massetExists(_destMasset), "Not a valid mAsset");
+        // NOTICE: Assuming DApp validated that the `sum(_ethAmount[]) == msg.value`,
+        // otherwise tx will fail
+
+        mAssetQtyMinted = _buyAndMintMulti(_srcBassets, _ethAmount, _destMasset, _msgSender());
+    }
+
+    /**
+     * @dev Buy bAssets with ETH and Mint mAsset from mStable. Send mAssets to the user.
+     * @param _srcBasset Source bAsset to buy from Kyber
+     * @param _destMasset mAsset to mint from mStable
+     * @param _ethAmount Amount of ETH to user to buy bAssets
+     * @param _recipient Recipient of the mStable tokens
+     * @return mAssetQtyMinted Returns the total quantity of mAssets minted
+     */
+    function _buyAndMint(
+        address _srcBasset,
+        address _destMasset,
+        uint256 _ethAmount,
+        address _recipient
+    )
+        internal
+        returns (uint256 mAssetQtyMinted)
+    {
+        // 1. Buy bAsset of worth `_ethAmount` ETH from Kyber
+        uint256 bAssetQtyMinted = _buyBassetsFromKyberWithETH(_srcBasset, _ethAmount);
+
+        // 2. Mint mAsset with all bAsset
+        mAssetQtyMinted = IMasset(_destMasset).mintTo(address(_srcBasset), bAssetQtyMinted, _recipient);
+    }
+
+    /**
+     * @dev Buy multiple bAssets using corrosponding ETH amount from Kyber and mint mAssets
+     *      using these bAssets.
+     * @param _srcBassets Array of bAssets to buy from Kyber
+     * @param _ethAmounts Array of eth amount to use corrosponding bAssets
+     * @param _destMasset mAsset address to mint
+     * @param _recipient Recipient of the mStable tokens
+     * @return mAssetQtyMinted Returns the total quantity of mAssets minted
+     */
+    function _buyAndMintMulti(
+        address[] memory _srcBassets,
+        uint256[] memory _ethAmounts,
+        address _destMasset,
+        address _recipient
+    )
+        internal
+        returns (uint256 mAssetQtyMinted)
+    {
+        uint256[] memory bAssetsQtyMinted = new uint256[](_srcBassets.length);
+
+        for(uint256 i = 0; i < _srcBassets.length; i++) {
+            bAssetsQtyMinted[i] = _buyBassetsFromKyberWithETH(_srcBassets[i], _ethAmounts[i]);
+        }
+
+        mAssetQtyMinted = IMasset(_destMasset).mintMulti(_srcBassets, bAssetsQtyMinted, _recipient);
+    }
+
+    /**
+     * @dev Buy bAsset tokens worth of ETH amount sent from Kyber
+     * @param _srcBasset Source bAsset to buy from Kyber
+     * @param _ethAmount Amount of ETH to user to buy bAssets
+     * @return bAssetsQtyMinted Returns the total quantity of bAssets minted from Kyber
+     */
+    function _buyBassetsFromKyberWithETH(
+        address _srcBasset,
+        uint256 _ethAmount
+    )
+        internal
+        returns (uint256 bAssetsQtyMinted)
+    {
+        bAssetsQtyMinted =
+            kyberNetworkProxy.tradeWithHint.value(_ethAmount)(
+                ETH_TOKEN_ADDRESS,
+                _ethAmount,
+                _srcBasset,
+                address(this),
+                1 << 255,
+                0,
+                FEE_COLLECTION_ADDRESS,
+                ""
+            );
+        require(bAssetsQtyMinted > 0, "No bAsset minted");
+        require(IERC20(_srcBasset).balanceOf(address(this)) >= bAssetsQtyMinted, "bAsset token not received");
+    }
+}
+
+/**
+ * @dev Kyber Network Proxy to integrate with Kyber Network contracts
+ */
+interface KyberNetworkProxyInterface {
+    // NOTICE: Commented out unused functions
+    //function maxGasPrice() public view returns(uint);
+    //function getUserCapInWei(address user) public view returns(uint);
+    //function getUserCapInTokenWei(address user, ERC20 token) public view returns(uint);
+    //function info(bytes32 id) public view returns(uint);
+
+    //function enabled() external view returns(bool);
+
+    function getExpectedRate(
+        address src,
+        address dest,
+        uint srcQty) external view returns (uint expectedRate, uint slippageRate);
+
+    function tradeWithHint(
+        address src,
+        uint srcAmount,
+        address dest,
+        address destAddress,
+        uint maxDestAmount,
+        uint minConversionRate,
+        address walletId,
+        bytes calldata hint) external payable returns(uint);
+}

--- a/test/integrations/AbstractBuyAndMint.behaviour.ts
+++ b/test/integrations/AbstractBuyAndMint.behaviour.ts
@@ -1,0 +1,110 @@
+import * as t from "types/generated";
+import { ZERO_ADDRESS, ZERO, MAX_UINT256 } from "@utils/constants";
+import { AbstractBuyAndMintInstance } from "types/generated";
+import { StandardAccounts } from "@utils/machines";
+import { expectEvent, expectRevert } from "@openzeppelin/test-helpers";
+import envSetup from "@utils/env_setup";
+
+const { expect } = envSetup.configure();
+const MockERC20: t.MockErc20Contract = artifacts.require("MockERC20");
+
+export default function shouldBehaveLikeAbstractBuyAndMint(
+    ctx: { abstractBuyAndMint: AbstractBuyAndMintInstance },
+    sa: StandardAccounts,
+    externalDexAddress: string,
+): void {
+    context("AbstractBuyAndMint.infiniteApprove", async () => {
+        it("should allow infinite approvals", async () => {
+            // 1. Create two mock ERC20 tokens
+            const mockERC1: t.MockErc20Instance = await MockERC20.new(
+                "Mock1",
+                "MKT1",
+                18,
+                sa.default,
+                1000,
+            );
+            const mockERC2: t.MockErc20Instance = await MockERC20.new(
+                "Mock2",
+                "MKT2",
+                18,
+                sa.default,
+                1000,
+            );
+            const mockERC20s: Array<string> = [mockERC1.address, mockERC2.address];
+            const approvalTarget = sa.dummy1;
+            // 2. Get allowance from the contract to DexContract
+            const mock1AllowanceBefore: BN = await mockERC1.allowance(
+                ctx.abstractBuyAndMint.address,
+                approvalTarget,
+            );
+            const mock2AllowanceBefore: BN = await mockERC2.allowance(
+                ctx.abstractBuyAndMint.address,
+                approvalTarget,
+            );
+
+            // 3. Allowance must be ZERO
+            expect(mock1AllowanceBefore).to.bignumber.equal(ZERO as any);
+            expect(mock2AllowanceBefore).to.bignumber.equal(ZERO as any);
+
+            // 4. Perform the infiniteApproval for the two tokens
+            await ctx.abstractBuyAndMint.infiniteApprove(approvalTarget, mockERC20s);
+
+            // 5. Get allowance
+            const mock1AllowanceAfter: BN = await mockERC1.allowance(
+                ctx.abstractBuyAndMint.address,
+                approvalTarget,
+            );
+            const mock2AllowanceAfter: BN = await mockERC2.allowance(
+                ctx.abstractBuyAndMint.address,
+                approvalTarget,
+            );
+
+            // 6. Validate allowance after, must be MAX_UINT256
+            expect(mock1AllowanceAfter).to.bignumber.equal(MAX_UINT256);
+            expect(mock2AllowanceAfter).to.bignumber.equal(MAX_UINT256);
+        });
+    });
+
+    context("AbstractBuyAndMint.addMasset", async () => {
+        it("should fail when non Owner calls function", async () => {
+            await expectRevert(
+                ctx.abstractBuyAndMint.addMasset(sa.dummy1, { from: sa.other }),
+                "Ownable: caller is not the owner",
+            );
+        });
+
+        it("should fail when mAsset address is zero", async () => {
+            // 1. Try adding ZERO_ADDRESS
+            await expectRevert(
+                ctx.abstractBuyAndMint.addMasset(ZERO_ADDRESS),
+                "mAsset address is zero",
+            );
+            // 2. Validate its not added
+            expect(await ctx.abstractBuyAndMint.mAssets(ZERO_ADDRESS)).to.equal(false);
+        });
+
+        it("should fail when mAsset address already exists", async () => {
+            // 1. Add mAsset
+            await ctx.abstractBuyAndMint.addMasset(sa.dummy1);
+            // 2. Validate newly added mAsset
+            expect(await ctx.abstractBuyAndMint.mAssets(sa.dummy1)).to.equal(true);
+
+            // 3. Try to add same mAsset
+            await expectRevert(
+                ctx.abstractBuyAndMint.addMasset(sa.dummy1),
+                "mAsset already exists",
+            );
+            // 4. Validate that it still exists
+            expect(await ctx.abstractBuyAndMint.mAssets(sa.dummy1)).to.equal(true);
+        });
+
+        it("should allow adding a new mAsset address", async () => {
+            // 1. Add mAsset
+            const tx = await ctx.abstractBuyAndMint.addMasset(sa.dummy1);
+            // 2. Validate newly added mAsset
+            expect(await ctx.abstractBuyAndMint.mAssets(sa.dummy1)).to.equal(true);
+
+            expectEvent.inLogs(tx.logs, "MassetAdded", { mAsset: sa.dummy1 });
+        });
+    });
+}

--- a/test/integrations/TestMintWith1inch.spec.ts
+++ b/test/integrations/TestMintWith1inch.spec.ts
@@ -1,0 +1,135 @@
+import * as t from "types/generated";
+import { MassetDetails, MassetMachine, StandardAccounts, SystemMachine } from "@utils/machines";
+import { assertBasketIsHealthy } from "@utils/assertions";
+import { expectEvent, expectRevert } from "@openzeppelin/test-helpers";
+import { toWei } from "web3-utils";
+import { BN } from "@utils/tools";
+import { ZERO, ZERO_ADDRESS } from "@utils/constants";
+import shouldBehaveLikeAbstractBuyAndMint from "./AbstractBuyAndMint.behaviour";
+
+const MintWith1Inch: t.MintWith1InchContract = artifacts.require("MintWith1Inch");
+
+contract("MintWith1inch", async (accounts) => {
+    const ctx: { abstractBuyAndMint?: t.AbstractBuyAndMintInstance } = {};
+    const sa = new StandardAccounts(accounts);
+    let systemMachine: SystemMachine;
+    let massetMachine: MassetMachine;
+    let massetDetails: MassetDetails;
+    let mintWith1Inch: t.MintWith1InchInstance;
+
+    const runSetup = async (seedBasket = false, enableUSDTFee = false): Promise<void> => {
+        massetDetails = seedBasket
+            ? await massetMachine.deployMassetAndSeedBasket(enableUSDTFee)
+            : await massetMachine.deployMasset(enableUSDTFee);
+        await assertBasketIsHealthy(massetMachine, massetDetails);
+    };
+
+    before("Init contract", async () => {
+        systemMachine = new SystemMachine(sa.all);
+        massetMachine = new MassetMachine(systemMachine);
+
+        await runSetup();
+        let oneSplitAddress: string;
+        if (systemMachine.isGanacheFork) {
+            // KyberNetworkProxy mainnet address
+            oneSplitAddress = "0xC586BeF4a0992C495Cf22e1aeEE4E446CECDee0E";
+        } else {
+            oneSplitAddress = sa.dummy4;
+        }
+
+        mintWith1Inch = await MintWith1Inch.new(oneSplitAddress, [massetDetails.mAsset.address]);
+    });
+
+    describe("should behave like AbstractBuyAndMint", async () => {
+        beforeEach("reset contracts", async () => {
+            ctx.abstractBuyAndMint = await MintWith1Inch.new(sa.dummy4, [
+                massetDetails.mAsset.address,
+            ]);
+        });
+
+        shouldBehaveLikeAbstractBuyAndMint(ctx as Required<typeof ctx>, sa, sa.dummy4);
+
+        context("AbstractBuyAndMint.constructor", async () => {
+            it("should fail when no mAsset address provided", async () => {
+                await expectRevert(MintWith1Inch.new(sa.dummy4, []), "No mAssets provided");
+            });
+
+            it("should fail when mAsset address already exist", async () => {
+                await expectRevert(
+                    MintWith1Inch.new(sa.dummy4, [sa.dummy1, sa.dummy1]),
+                    "mAsset already exists",
+                );
+            });
+
+            it("should fail when mAsset address is zero", async () => {
+                await expectRevert(
+                    MintWith1Inch.new(sa.dummy4, [ZERO_ADDRESS]),
+                    "mAsset address is zero",
+                );
+            });
+
+            it("should fail when dex address is zero", async () => {
+                await expectRevert(
+                    MintWith1Inch.new(ZERO_ADDRESS, [sa.dummy1]),
+                    "1inch address is zero",
+                );
+            });
+        });
+    });
+
+    describe("minting mAssets with all ETH", () => {
+        // mock distribution
+        const distribution: Array<BN> = [new BN(1)];
+
+        it("should fail when zero ETH sent", async () => {
+            await Promise.all(
+                massetDetails.bAssets.map(async (bAsset) => {
+                    await expectRevert(
+                        mintWith1Inch.buyAndMint(
+                            bAsset.address,
+                            massetDetails.mAsset.address,
+                            1,
+                            distribution,
+                        ),
+                        "ETH not sent",
+                    );
+                }),
+            );
+        });
+
+        it("should fail when invalid mAsset address sent", async () => {
+            await Promise.all(
+                massetDetails.bAssets.map(async (bAsset) => {
+                    await expectRevert(
+                        mintWith1Inch.buyAndMint(bAsset.address, sa.dummy1, 1, distribution, {
+                            value: toWei(new BN(1), "ether"),
+                        }),
+                        "Not a valid mAsset",
+                    );
+                }),
+            );
+        });
+
+        it("should mint mAssets for the user", async () => {
+            // Executes only in forked Ganache network
+            if (!systemMachine.isGanacheFork) return;
+
+            const mAssetBalanceBefore = await massetDetails.mAsset.balanceOf(sa.default);
+
+            await Promise.all(
+                massetDetails.bAssets.map(async (bAsset) => {
+                    await mintWith1Inch.buyAndMint(
+                        bAsset.address,
+                        massetDetails.mAsset.address,
+                        1,
+                        distribution,
+                    );
+                }),
+            );
+
+            const mAssetBalanceAfter = await massetDetails.mAsset.balanceOf(sa.default);
+            const mAssetsMinted = mAssetBalanceAfter.sub(mAssetBalanceBefore);
+            expect(mAssetsMinted).bignumber.gt(ZERO as any);
+        });
+    });
+});

--- a/test/integrations/TestMintWithKyber.spec.ts.parked
+++ b/test/integrations/TestMintWithKyber.spec.ts.parked
@@ -1,0 +1,269 @@
+import * as t from "types/generated";
+import { MassetDetails, MassetMachine, StandardAccounts, SystemMachine } from "@utils/machines";
+import { assertBasketIsHealthy } from "@utils/assertions";
+import { expectEvent, expectRevert } from "@openzeppelin/test-helpers";
+import { toWei } from "web3-utils";
+import { BN } from "@utils/tools";
+import { ZERO, ZERO_ADDRESS } from "@utils/constants";
+import shouldBehaveLikeAbstractBuyAndMint from "./AbstractBuyAndMint.behaviour";
+
+const MintWithKyber: t.MintWithKyberContract = artifacts.require("MintWithKyber");
+
+contract("MintWithKyber", async (accounts) => {
+    const ctx: { abstractBuyAndMint?: t.AbstractBuyAndMintInstance } = {};
+    const sa = new StandardAccounts(accounts);
+    let systemMachine: SystemMachine;
+    let massetMachine: MassetMachine;
+    let massetDetails: MassetDetails;
+    let mintWithKyber: t.MintWithKyberInstance;
+    let kyberProxyAddress: string;
+
+    const runSetup = async (seedBasket = true, enableUSDTFee = false): Promise<void> => {
+        massetDetails = seedBasket
+            ? await massetMachine.deployMassetAndSeedBasket(enableUSDTFee)
+            : await massetMachine.deployMasset(enableUSDTFee);
+        await assertBasketIsHealthy(massetMachine, massetDetails);
+    };
+
+    before("Init contract", async () => {
+        systemMachine = new SystemMachine(sa.all);
+        massetMachine = new MassetMachine(systemMachine);
+
+        await runSetup();
+
+        if (systemMachine.isGanacheFork) {
+            // KyberNetworkProxy mainnet address
+            kyberProxyAddress = "0x818E6FECD516Ecc3849DAf6845e3EC868087B755";
+        } else {
+            kyberProxyAddress = sa.dummy4;
+        }
+
+        mintWithKyber = await MintWithKyber.new(kyberProxyAddress, [massetDetails.mAsset.address]);
+    });
+
+    describe("should behave like AbstractBuyAndMint", async () => {
+        beforeEach("reset contracts", async () => {
+            ctx.abstractBuyAndMint = await MintWithKyber.new(sa.dummy4, [
+                massetDetails.mAsset.address,
+            ]);
+        });
+
+        shouldBehaveLikeAbstractBuyAndMint(ctx as Required<typeof ctx>, sa, sa.dummy4);
+
+        context("AbstractBuyAndMint.constructor", async () => {
+            it("should fail when no mAsset address provided", async () => {
+                await expectRevert(MintWithKyber.new(sa.dummy4, []), "No mAssets provided");
+            });
+
+            it("should fail when mAsset address already exist", async () => {
+                await expectRevert(
+                    MintWithKyber.new(sa.dummy4, [sa.dummy1, sa.dummy1]),
+                    "mAsset already exists",
+                );
+            });
+
+            it("should fail when mAsset address is zero", async () => {
+                await expectRevert(
+                    MintWithKyber.new(sa.dummy4, [ZERO_ADDRESS]),
+                    "mAsset address is zero",
+                );
+            });
+
+            it("should fail when dex address is zero", async () => {
+                await expectRevert(
+                    MintWithKyber.new(ZERO_ADDRESS, [sa.dummy1]),
+                    "Kyber proxy address is zero",
+                );
+            });
+        });
+    });
+
+    describe("minting max mAssets with all ETH", () => {
+        it("should fail when zero ETH sent", async () => {
+            await Promise.all(
+                massetDetails.bAssets.map(async (bAsset) => {
+                    await expectRevert(
+                        mintWithKyber.buyAndMintMaxMasset(
+                            bAsset.address,
+                            massetDetails.mAsset.address,
+                        ),
+                        "ETH not sent",
+                    );
+                }),
+            );
+        });
+
+        it("should fail when invalid mAsset address sent", async () => {
+            await Promise.all(
+                massetDetails.bAssets.map(async (bAsset) => {
+                    await expectRevert(
+                        mintWithKyber.buyAndMintMaxMasset(bAsset.address, sa.dummy1, {
+                            value: toWei(new BN(1), "ether"),
+                        }),
+                        "Not a valid mAsset",
+                    );
+                }),
+            );
+        });
+
+        it("should mint mAssets for the user", async () => {
+            // Executes only in forked Ganache network
+            if (!systemMachine.isGanacheFork) return;
+
+            await Promise.all(
+                massetDetails.bAssets.map(async (bAsset) => {
+                    const ethBalanceBefore = await web3.eth.getBalance(sa.default);
+                    const mAssetBalanceBefore = await massetDetails.mAsset.balanceOf(sa.default);
+                    expect(mAssetBalanceBefore).to.bignumber.equal(ZERO);
+
+                    // Should buy bAsset from Kyber and mint mAssets
+                    await mintWithKyber.buyAndMintMaxMasset(
+                        bAsset.address,
+                        massetDetails.mAsset.address,
+                        { value: toWei(new BN(1), "ether") },
+                    );
+
+                    // ETH balance for user should decrease
+                    const ethBalanceAfter = await web3.eth.getBalance(sa.default);
+                    expect(ethBalanceBefore.sub(toWei("1", "ether"))).to.bignumber.equal(
+                        ethBalanceAfter,
+                    );
+
+                    // mAsset balance for user should increase
+                    const mAssetBalanceAfter = await massetDetails.mAsset.balanceOf(sa.default);
+                    expect(mAssetBalanceAfter).to.not.bignumber.equal(ZERO);
+                }),
+            );
+        });
+    });
+
+    describe("minting given number of mAssets", () => {
+        const mAssetAmount = new BN(100);
+
+        it("should fail when zero ETH sent", async () => {
+            await Promise.all(
+                massetDetails.bAssets.map(async (bAsset) => {
+                    await expectRevert(
+                        mintWithKyber.buyAndMintGivenMasset(
+                            bAsset.address,
+                            massetDetails.mAsset.address,
+                            mAssetAmount,
+                        ),
+                        "ETH not sent",
+                    );
+                }),
+            );
+        });
+
+        it("should fail when invalid mAsset address sent", async () => {
+            await Promise.all(
+                massetDetails.bAssets.map(async (bAsset) => {
+                    await expectRevert(
+                        mintWithKyber.buyAndMintGivenMasset(
+                            bAsset.address,
+                            sa.dummy1,
+                            mAssetAmount,
+                            {
+                                value: toWei(new BN(1), "ether"),
+                            },
+                        ),
+                        "Not a valid mAsset",
+                    );
+                }),
+            );
+        });
+
+        it("should mint given number of mAssets for the user", async () => {
+            // Executes only in forked Ganache network
+            if (!systemMachine.isGanacheFork) return;
+
+            await Promise.all(
+                massetDetails.bAssets.map(async (bAsset) => {
+                    const mAssetBalOfUserBefore = await massetDetails.mAsset.balanceOf(sa.default);
+
+                    await mintWithKyber.buyAndMintGivenMasset(
+                        bAsset.address,
+                        massetDetails.mAsset.address,
+                        mAssetAmount,
+                        {
+                            value: toWei(new BN(1), "ether"),
+                        },
+                    );
+
+                    const mAssetBalOfUserAfter = await massetDetails.mAsset.balanceOf(sa.default);
+                    const mAssetsMinted = mAssetBalOfUserAfter.sub(mAssetBalOfUserBefore);
+                    expect(mAssetAmount).to.bignumber.equal(mAssetsMinted);
+                }),
+            );
+        });
+    });
+
+    describe("minting mAssets using multiple bAssets", async () => {
+        const ONE_ETH = new BN(toWei("1", "ether"));
+        let bAssetsArray: Array<string>;
+        let ethAmountArray: Array<BN>;
+
+        beforeEach(async () => {
+            bAssetsArray = massetDetails.bAssets.map((a) => a.address);
+            const ethAmountToSend = ONE_ETH.div(new BN(bAssetsArray.length));
+            ethAmountArray = massetDetails.bAssets.map(() => ethAmountToSend);
+        });
+
+        it("should fail when zero ETH sent", async () => {
+            await expectRevert(
+                mintWithKyber.buyAndMintMulti(
+                    bAssetsArray,
+                    ethAmountArray,
+                    massetDetails.mAsset.address,
+                ),
+                "ETH not sent",
+            );
+        });
+
+        it("should fail when invalid mAsset address sent", async () => {
+            await expectRevert(
+                mintWithKyber.buyAndMintMulti(bAssetsArray, ethAmountArray, sa.dummy3, {
+                    value: ONE_ETH,
+                }),
+                "Not a valid mAsset",
+            );
+        });
+
+        it("should fail when empty array passed", async () => {
+            await expectRevert(
+                mintWithKyber.buyAndMintMulti([], [], massetDetails.mAsset.address, {
+                    value: ONE_ETH,
+                }),
+                "No array data sent",
+            );
+        });
+
+        it("should fail when array length not matched", async () => {
+            await expectRevert(
+                mintWithKyber.buyAndMintMulti(bAssetsArray, [], massetDetails.mAsset.address, {
+                    value: ONE_ETH,
+                }),
+                "Array length not matched",
+            );
+        });
+
+        it("should mint mAssets using multiMint", async () => {
+            // Executes only in forked Ganache network
+            if (!systemMachine.isGanacheFork) return;
+
+            const mAssetBalanceOfUserBefore = await massetDetails.mAsset.balanceOf(sa.default);
+            await mintWithKyber.buyAndMintMulti(
+                bAssetsArray,
+                ethAmountArray,
+                massetDetails.mAsset.address,
+                {
+                    value: ONE_ETH,
+                },
+            );
+
+            const mAssetBalanceOfUserAfter = await massetDetails.mAsset.balanceOf(sa.default);
+            const mAssetsMinted = mAssetBalanceOfUserAfter.sub(mAssetBalanceOfUserBefore);
+            expect(mAssetsMinted).bignumber.gt(ZERO as any);
+        });
+    });
+});


### PR DESCRIPTION
imple DEX integration to 1inch (a.k.a OneSplit) to enable ETH -> bAsset purchases. Use the output bAsset to mint mAsset.
