### PR TITLE
ForgeValidator 1.1

### DIFF
--- a/test/masset/TestMassetRedemption.spec.ts
+++ b/test/masset/TestMassetRedemption.spec.ts
@@ -756,7 +756,7 @@ contract("Masset - Redeem", async (accounts) => {
                 beforeEach(async () => {
                     await runSetup(false);
                 });
-                it("should force proportional redemption no matter what", async () => {
+                it("should allow redemption as long as nothing goes overweight", async () => {
                     const { bAssets, mAsset, basketManager } = massetDetails;
                     const composition = await massetMachine.getBasketComposition(massetDetails);
                     // Expect 4 bAssets with 100 weightings
@@ -782,9 +782,11 @@ contract("Masset - Redeem", async (accounts) => {
                     // Should succeed if we redeem this
                     const bAsset = bAssets[0];
                     const bAssetDecimals = await bAsset.decimals();
+                    await assertBasicRedemption(massetDetails, 2, bAsset, true);
+                    // 30% * 93 = 27.8, meaning bAssets[1] is now overweight
                     await expectRevert(
-                        mAsset.redeem(bAsset.address, simpleToExactAmount(10, bAssetDecimals)),
-                        "Must redeem proportionately",
+                        mAsset.redeem(bAsset.address, simpleToExactAmount(5, bAssetDecimals)),
+                        "bAssets must remain below max weight",
                     );
                 });
             });

--- a/test/masset/forge-validator/TestForgeValidatorR.spec.ts
+++ b/test/masset/forge-validator/TestForgeValidatorR.spec.ts
@@ -513,7 +513,7 @@ contract("ForgeValidator", async (accounts) => {
             });
         });
         context("in a basket with bAssets nearing threshold (max weight breached)", async () => {
-            it("enforces proportional redemption", async () => {
+            it("allows redemption as long as nothing goes overweight", async () => {
                 /**
                  * TotalSupply:     100e18
                  * MaxWeights:      [  40, 40,   40, 40]
@@ -530,8 +530,19 @@ contract("ForgeValidator", async (accounts) => {
                         setBasset(40, "10.5"),
                         setBasset(40, 20),
                     ],
-                    [setArgs(0, 1)],
-                    setResult(false, "Must redeem proportionately"),
+                    [setArgs(0, 10)],
+                    setResult(true, "", true),
+                );
+                await assertRedeem(
+                    setBasket(false, 100),
+                    [
+                        setBasset(40, "39.5"),
+                        setBasset(40, 30),
+                        setBasset(40, "10.5"),
+                        setBasset(40, 20),
+                    ],
+                    [setArgs(1, 3)],
+                    setResult(false, "bAssets must remain below max weight"),
                 );
             });
             describe("and using multiple inputs", async () => {
@@ -552,8 +563,19 @@ contract("ForgeValidator", async (accounts) => {
                             setBasset(40, "10.5"),
                             setBasset(40, 20),
                         ],
-                        [setArgs(0, 1), setArgs(3, 3)],
-                        setResult(false, "Must redeem proportionately"),
+                        [setArgs(0, 5), setArgs(3, 3)],
+                        setResult(true, "", true),
+                    );
+                    await assertRedeem(
+                        setBasket(false, 100),
+                        [
+                            setBasset(40, "39.5"),
+                            setBasset(40, 30),
+                            setBasset(40, "10.5"),
+                            setBasset(40, 20),
+                        ],
+                        [setArgs(0, 1), setArgs(1, 7)],
+                        setResult(false, "bAssets must remain below max weight"),
                     );
                 });
             });


### PR DESCRIPTION
Remove the concept of a bAsset being "breached". This was when it was within 1% of its max weight and applies unnecessary constraints onto redemption.

If a bAsset is close to its max weight, then redeeming any other bAsset would naturally push it overweight.