### PR TITLE
Redemption fee

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,11 @@ jobs:
       - run:
           name: Produce Coverage Report
           command: yarn coverage
-      - coveralls/upload
+    #   - coveralls/upload
       - store_artifacts:
-          path: /coverage
+          path: ./coverage
       - store_artifacts:
-          path: /.coverage.json
+          path: ./.coverage.json
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:

--- a/contracts/masset/Masset.sol
+++ b/contracts/masset/Masset.sol
@@ -536,6 +536,7 @@ contract Masset is
         }
         require(mAssetQuantity > 0, "Must redeem some bAssets");
 
+        // Redemption has fee? Fetch the rate
         uint256 fee = applyFee ? swapFee : 0;
 
         // Apply fees, burn mAsset and return bAsset to recipient

--- a/contracts/masset/Masset.sol
+++ b/contracts/masset/Masset.sol
@@ -58,8 +58,8 @@ contract Masset is
 
     // Basic redemption fee information
     uint256 public swapFee;
-    uint256 private MAX_FEE;
     uint256 public redemptionFee;
+    uint256 private MAX_FEE;
 
     /**
      * @dev Constructor
@@ -538,6 +538,7 @@ contract Masset is
         require(mAssetQuantity > 0, "Must redeem some bAssets");
 
         uint256 fee = applyFee ? swapFee : 0;
+
         // Apply fees, burn mAsset and return bAsset to recipient
         _settleRedemption(_recipient, mAssetQuantity, props.bAssets, _bAssetQuantities, props.indexes, props.integrators, fee);
 

--- a/contracts/masset/Masset.sol
+++ b/contracts/masset/Masset.sol
@@ -583,7 +583,7 @@ contract Masset is
      * @param _bAssetQuantities Array of bAsset quantities
      * @param _indices          Matching indices for the bAsset array
      * @param _integrators      Matching integrators for the bAsset array
-     * @param _feeRate          Apply a fee to this redemption?
+     * @param _feeRate          Fee rate to be applied to this redemption
      */
     function _settleRedemption(
         address _recipient,

--- a/contracts/masset/Masset.sol
+++ b/contracts/masset/Masset.sol
@@ -60,6 +60,9 @@ contract Masset is
     uint256 public swapFee;
     uint256 private MAX_FEE;
 
+    // RELEASE 1.1 VARS
+    uint256 public redemptionFee;
+
     /**
      * @dev Constructor
      * @notice To avoid variable shadowing appended `Arg` after arguments name.
@@ -746,8 +749,4 @@ contract Masset is
 
         return (interestCollected, totalSupply());
     }
-
-    // RELEASE 1.1 VARS
-    uint256 public redemptionFee;
-
 }

--- a/contracts/masset/Masset.sol
+++ b/contracts/masset/Masset.sol
@@ -60,10 +60,6 @@ contract Masset is
     uint256 public swapFee;
     uint256 private MAX_FEE;
 
-    // RELEASE 1.1 VARS
-    uint256 public redemptionFee;
-
-
     /**
      * @dev Constructor
      * @notice To avoid variable shadowing appended `Arg` after arguments name.
@@ -749,4 +745,8 @@ contract Masset is
 
         return (interestCollected, totalSupply());
     }
+
+    // RELEASE 1.1 VARS
+    uint256 public redemptionFee;
+
 }

--- a/contracts/masset/Masset.sol
+++ b/contracts/masset/Masset.sol
@@ -26,8 +26,8 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  * @notice  The Masset is a token that allows minting and redemption at a 1:1 ratio
  *          for underlying basket assets (bAssets) of the same peg (i.e. USD,
  *          EUR, Gold). Composition and validation is enforced via the BasketManager.
- * @dev     VERSION: 1.0
- *          DATE:    2020-05-05
+ * @dev     VERSION: 1.1
+ *          DATE:    2020-06-30
  */
 contract Masset is
     Initializable,
@@ -58,8 +58,11 @@ contract Masset is
 
     // Basic redemption fee information
     uint256 public swapFee;
-    uint256 public redemptionFee;
     uint256 private MAX_FEE;
+
+    // RELEASE 1.1 VARS
+    uint256 public redemptionFee;
+
 
     /**
      * @dev Constructor

--- a/contracts/masset/Masset.sol
+++ b/contracts/masset/Masset.sol
@@ -48,6 +48,7 @@ contract Masset is
 
     // State Events
     event SwapFeeChanged(uint256 fee);
+    event RedemptionFeeChanged(uint256 fee);
     event ForgeValidatorChanged(address forgeValidator);
 
     // Modules and connectors
@@ -58,6 +59,7 @@ contract Masset is
     // Basic redemption fee information
     uint256 public swapFee;
     uint256 private MAX_FEE;
+    uint256 public redemptionFee;
 
     /**
      * @dev Constructor
@@ -535,8 +537,9 @@ contract Masset is
         }
         require(mAssetQuantity > 0, "Must redeem some bAssets");
 
+        uint256 fee = applyFee ? swapFee : 0;
         // Apply fees, burn mAsset and return bAsset to recipient
-        _settleRedemption(_recipient, mAssetQuantity, props.bAssets, _bAssetQuantities, props.indexes, props.integrators, applyFee);
+        _settleRedemption(_recipient, mAssetQuantity, props.bAssets, _bAssetQuantities, props.indexes, props.integrators, fee);
 
         emit Redeemed(msg.sender, _recipient, mAssetQuantity, _bAssets, _bAssetQuantities);
         return mAssetQuantity;
@@ -566,7 +569,7 @@ contract Masset is
         require(redemptionValid, reason);
 
         // Apply fees, burn mAsset and return bAsset to recipient
-        _settleRedemption(_recipient, _mAssetQuantity, props.bAssets, bAssetQuantities, props.indexes, props.integrators, false);
+        _settleRedemption(_recipient, _mAssetQuantity, props.bAssets, bAssetQuantities, props.indexes, props.integrators, redemptionFee);
 
         emit RedeemedMasset(msg.sender, _recipient, _mAssetQuantity);
     }
@@ -579,7 +582,7 @@ contract Masset is
      * @param _bAssetQuantities Array of bAsset quantities
      * @param _indices          Matching indices for the bAsset array
      * @param _integrators      Matching integrators for the bAsset array
-     * @param _applyFee         Apply a fee to this redemption?
+     * @param _feeRate          Apply a fee to this redemption?
      */
     function _settleRedemption(
         address _recipient,
@@ -588,16 +591,13 @@ contract Masset is
         uint256[] memory _bAssetQuantities,
         uint8[] memory _indices,
         address[] memory _integrators,
-        bool _applyFee
+        uint256 _feeRate
     ) internal {
         // Burn the full amount of Masset
         _burn(msg.sender, _mAssetQuantity);
 
         // Reduce the amount of bAssets marked in the vault
         basketManager.decreaseVaultBalances(_indices, _integrators, _bAssetQuantities);
-
-        // Redemption has fee? Fetch the rate
-        uint256 fee = _applyFee ? swapFee : 0;
 
         // Transfer the Bassets to the recipient
         uint256 bAssetCount = _bAssets.length;
@@ -606,7 +606,7 @@ contract Masset is
             uint256 q = _bAssetQuantities[i];
             if(q > 0){
                 // Deduct the redemption fee, if any
-                q = _deductSwapFee(bAsset, q, fee);
+                q = _deductSwapFee(bAsset, q, _feeRate);
                 // Transfer the Bassets to the user
                 IPlatformIntegration(_integrators[i]).withdraw(_recipient, bAsset, q, _bAssets[i].isTransferFeeCharged);
             }
@@ -693,6 +693,20 @@ contract Masset is
         swapFee = _swapFee;
 
         emit SwapFeeChanged(_swapFee);
+    }
+
+    /**
+      * @dev Set the ecosystem fee for redeeming a mAsset
+      * @param _redemptionFee Fee calculated in (%/100 * 1e18)
+      */
+    function setRedemptionFee(uint256 _redemptionFee)
+        external
+        onlyGovernor
+    {
+        require(_redemptionFee <= MAX_FEE, "Rate must be within bounds");
+        redemptionFee = _redemptionFee;
+
+        emit RedemptionFeeChanged(_redemptionFee);
     }
 
     /**

--- a/test/masset/TestMasset.spec.ts
+++ b/test/masset/TestMasset.spec.ts
@@ -63,6 +63,7 @@ contract("Masset", async (accounts) => {
                 expect(await massetDetails.mAsset.swapFee()).bignumber.eq(
                     simpleToExactAmount(4, 15),
                 );
+                expect(await massetDetails.mAsset.redemptionFee()).bignumber.eq(new BN(0));
                 expect(await massetDetails.mAsset.decimals()).bignumber.eq(new BN(18));
                 expect(await massetDetails.mAsset.balanceOf(sa.dummy1)).bignumber.eq(new BN(0));
                 expect(await massetDetails.mAsset.name()).eq("mStable Mock");
@@ -123,6 +124,31 @@ contract("Masset", async (accounts) => {
             const feeExceedingMin = new BN(-1); // 11%
             await expectRevert(
                 massetDetails.mAsset.setSwapFee(feeExceedingMin, { from: sa.governor }),
+                "Rate must be within bounds",
+            );
+        });
+        it("should allow the redemption fee rate to be changed", async () => {
+            // update by the governor
+            const oldFee = await massetDetails.mAsset.redemptionFee();
+            const newfee = simpleToExactAmount(1, 16); // 1%
+            expect(oldFee).bignumber.not.eq(newfee);
+            await massetDetails.mAsset.setRedemptionFee(newfee, { from: sa.governor });
+            expect(await massetDetails.mAsset.redemptionFee()).bignumber.eq(newfee);
+            // rejected if not governor
+            await expectRevert(
+                massetDetails.mAsset.setRedemptionFee(newfee, { from: sa.default }),
+                "Only governor can execute",
+            );
+            // cannot exceed cap
+            const feeExceedingCap = simpleToExactAmount(11, 16); // 11%
+            await expectRevert(
+                massetDetails.mAsset.setRedemptionFee(feeExceedingCap, { from: sa.governor }),
+                "Rate must be within bounds",
+            );
+            // cannot exceed min
+            const feeExceedingMin = new BN(-1); // 11%
+            await expectRevert(
+                massetDetails.mAsset.setRedemptionFee(feeExceedingMin, { from: sa.governor }),
                 "Rate must be within bounds",
             );
         });


### PR DESCRIPTION
**Upgrade type**: Proxy contract upgrade
**Affected file**: `Masset.sol`
**Proxy address**: `0xe2f2a5C287993345a840Db3B0845fbC70f5935a5`
**New version**: 1.1


### Description

Adds a redemption fee property for use in `redeemMasset`

- New storage prop: `redemptionFee` :rotating_light:
- New function: `setRedemptionFee` - Allow fee to be updated by governance
- Changed function signature: Update signature and existing calls to `_settleRedemption`. Now accepts uint instead of bool

### Deployment plan

- [x] Write and comprehensively test the upgrade
- [x] Get external PR review from specialist
- [x] Deploy `Masset v1.1` to Ropsten/Mainnet
- [x] Use '[DiffChecker](https://www.diffchecker.com/)' to validate the prev and future contracts once verified
- [x] Call `proposeUpgrade` on the `DelayedProxyAdmin` with implementation addresses
- [x] Accept on Ropsten and test
- [x] Wait 1 week
- [x] Accept on Mainnet FORK by unlocking the gov address
- [ ] Accept on Mainnet

#### Mainnet Details

Deployed address: `0xe4c5b1765bf420016027177289908c5a3ea7668e`
ProposeUpgrade tx: 14:13 CET 08/02
AcceptUpgrade tx: 

#### Ropsten Details

Deployed address: `0x121a86dd617c0584cf1bdffc92e36d9100000ca7`
ProposeUpgrade tx: 12:13 CET 07/02
AcceptUpgrade tx:  14:07 CET 07/02