### PR TITLE
Implemented period based yield analysis on SavingsManager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Produce Coverage Report
           command: yarn coverage
-    #   - coveralls/upload
+      - coveralls/upload
       - store_artifacts:
           path: ./coverage
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Produce Coverage Report
           command: yarn coverage
-      - coveralls/upload
+    #   - coveralls/upload
       - store_artifacts:
           path: ./coverage
       - save_cache:

--- a/contracts/savings/SavingsManager.sol
+++ b/contracts/savings/SavingsManager.sol
@@ -19,8 +19,8 @@ import { StableMath } from "../shared/StableMath.sol";
  * @author  Stability Labs Pty. Ltd.
  * @notice  Savings Manager collects interest from mAssets and sends them to the
  *          corresponding Savings Contract, performing some validation in the process.
- * @dev     VERSION: 1.0
- *          DATE:    2020-03-28
+ * @dev     VERSION: 1.1
+ *          DATE:    2020-07-29
  */
 contract SavingsManager is ISavingsManager, PausableModule {
 
@@ -36,12 +36,13 @@ contract SavingsManager is ISavingsManager, PausableModule {
     event InterestCollected(address indexed mAsset, uint256 interest, uint256 newTotalSupply, uint256 apy);
     event InterestDistributed(address indexed mAsset, uint256 amountSent);
     event InterestWithdrawnByGovernor(address indexed mAsset, address recipient, uint256 amount);
-    event WaitFor(uint256 timeRemaining);
 
     // Locations of each mAsset savings contract
     mapping(address => ISavingsContract) public savingsContracts;
     // Time at which last collection was made
+    mapping(address => uint256) public lastPeriodStart;
     mapping(address => uint256) public lastCollection;
+    mapping(address => uint256) public periodYield;
 
     // Amount of collected interest that will be sent to Savings Contract (100%)
     uint256 private savingsRate = 1e18;
@@ -49,6 +50,7 @@ contract SavingsManager is ISavingsManager, PausableModule {
     uint256 constant private SECONDS_IN_YEAR = 365 days;
     // Theoretical cap on APY to avoid excess inflation
     uint256 constant private MAX_APY = 15e18;
+    uint256 constant private TEN_BPS = 1e15;
     uint256 constant private THIRTY_MINUTES = 30 minutes;
 
     constructor(
@@ -136,58 +138,96 @@ contract SavingsManager is ISavingsManager, PausableModule {
         ISavingsContract savingsContract = savingsContracts[_mAsset];
         require(address(savingsContract) != address(0), "Must have a valid savings contract");
 
+        // Get collection details
+        uint256 recentPeriodStart = lastPeriodStart[_mAsset];
         uint256 previousCollection = lastCollection[_mAsset];
+        lastCollection[_mAsset] = now;
 
-        // 1. Only collect interest if it has been 30 mins
-        uint256 timeSinceLastCollection = now.sub(previousCollection);
+        // 1. Collect the new interest from the mAsset
+        IMasset mAsset = IMasset(_mAsset);
+        (uint256 interestCollected, uint256 totalSupply) = mAsset.collectInterest();
+
+        // 2. Update all the time stamps
+        //    Avoid division by 0 by adding a minimum elapsed time of 1 second
+        uint256 timeSincePeriodStart = StableMath.max(1, now.sub(recentPeriodStart));
+        uint256 timeSinceLastCollection = StableMath.max(1, now.sub(previousCollection));
+
+        uint256 inflationOperand = interestCollected;
+        //    If it has been 30 mins since last collection, reset period data
         if(timeSinceLastCollection > THIRTY_MINUTES) {
+            lastPeriodStart[_mAsset] = now;
+            periodYield[_mAsset] = 0;
+        }
+        //    Else if period has elapsed, start a new period from the lastCollection time
+        else if(timeSincePeriodStart > THIRTY_MINUTES) {
+            lastPeriodStart[_mAsset] = previousCollection;
+            periodYield[_mAsset] = interestCollected;
+        }
+        //    Else add yield to period yield
+        else {
+            inflationOperand = periodYield[_mAsset].add(interestCollected);
+            periodYield[_mAsset] = inflationOperand;
+        }
 
-            lastCollection[_mAsset] = now;
+        // 3. Validate that interest is collected correctly and does not exceed max APY
+        if(interestCollected > 0) {
+            require(
+                IERC20(_mAsset).balanceOf(address(this)) >= interestCollected,
+                "Must receive mUSD"
+            );
 
-            // 2. Collect the new interest from the mAsset
-            IMasset mAsset = IMasset(_mAsset);
-            (uint256 interestCollected, uint256 totalSupply) = mAsset.collectInterest();
+            uint256 extrapolatedAPY = _validateCollection(totalSupply, inflationOperand, timeSinceLastCollection);
 
-            if(interestCollected > 0) {
+            emit InterestCollected(_mAsset, interestCollected, totalSupply, extrapolatedAPY);
 
-                // 3. Validate that the interest has been collected and is within certain limits
-                require(
-                    IERC20(_mAsset).balanceOf(address(this)) >= interestCollected,
-                    "Must receive mUSD"
-                );
+            // 4. Distribute the interest
+            //    Calculate the share for savers (95e16 or 95%)
+            uint256 saversShare = interestCollected.mulTruncate(savingsRate);
 
-                // Seconds since last collection
-                uint256 secondsSinceLastCollection = now.sub(previousCollection);
-                // e.g. day: (86400 * 1e18) / 3.154e7 = 2.74..e15
-                // e.g. 30 mins: (1800 * 1e18) / 3.154e7 = 5.7..e13
-                uint256 yearsSinceLastCollection =
-                    secondsSinceLastCollection.divPrecisely(SECONDS_IN_YEAR);
-                // Percentage increase in total supply
-                // e.g. (1e20 * 1e18) / 1e24 = 1e14 (or a 0.01% increase)
-                // e.g. (5e18 * 1e18) / 1.2e24 = 4.1667e12
-                uint256 oldSupply = totalSupply.sub(interestCollected);
-                uint256 percentageIncrease = interestCollected.divPrecisely(oldSupply);
-                // e.g. 0.01% (1e14 * 1e18) / 2.74..e15 = 3.65e16 or 3.65% apr
-                // e.g. (4.1667e12 * 1e18) / 5.7..e13 = 7.1e16 or 7.1% apr
-                uint256 extrapolatedAPY = percentageIncrease.divPrecisely(yearsSinceLastCollection);
+            //    Call depositInterest on contract
+            savingsContract.depositInterest(saversShare);
 
-                require(extrapolatedAPY < MAX_APY, "Interest protected from inflating past maxAPY");
-
-                emit InterestCollected(_mAsset, interestCollected, totalSupply, extrapolatedAPY);
-
-                // 4. Distribute the interest
-                // Calculate the share for savers (95e16 or 95%)
-                uint256 saversShare = interestCollected.mulTruncate(savingsRate);
-
-                // Call depositInterest on contract
-                savingsContract.depositInterest(saversShare);
-
-                emit InterestDistributed(_mAsset, saversShare);
-            } else {
-                emit InterestCollected(_mAsset, 0, totalSupply, 0);
-            }
+            emit InterestDistributed(_mAsset, saversShare);
         } else {
-            emit WaitFor(THIRTY_MINUTES.sub(timeSinceLastCollection));
+            emit InterestCollected(_mAsset, 0, totalSupply, 0);
+        }
+    }
+
+    /**
+     * @dev Validates that an interest collection does not exceed a maximum APY. If last collection
+     * was under 30 mins ago, simply check it does not exceed 10bps
+     * @param _newSupply               New total supply of the mAsset
+     * @param _interest                Increase in total supply since last collection
+     * @param _timeSinceLastCollection Seconds since last collection
+     */
+    function _validateCollection(uint256 _newSupply, uint256 _interest, uint256 _timeSinceLastCollection)
+        internal
+        pure
+        returns (uint256 extrapolatedAPY)
+    {
+        // e.g. day: (86400 * 1e18) / 3.154e7 = 2.74..e15
+        // e.g. 30 mins: (1800 * 1e18) / 3.154e7 = 5.7..e13
+        // e.g. epoch: (1593596907 * 1e18) / 3.154e7 = 50.4..e18
+        uint256 yearsSinceLastCollection =
+            _timeSinceLastCollection.divPrecisely(SECONDS_IN_YEAR);
+
+        // Percentage increase in total supply
+        // e.g. (1e20 * 1e18) / 1e24 = 1e14 (or a 0.01% increase)
+        // e.g. (5e18 * 1e18) / 1.2e24 = 4.1667e12
+        // e.g. (1e19 * 1e18) / 1e21 = 1e16
+        uint256 oldSupply = _newSupply.sub(_interest);
+        uint256 percentageIncrease = _interest.divPrecisely(oldSupply);
+
+        // e.g. 0.01% (1e14 * 1e18) / 2.74..e15 = 3.65e16 or 3.65% apr
+        // e.g. (4.1667e12 * 1e18) / 5.7..e13 = 7.1e16 or 7.1% apr
+        // e.g. (1e16 * 1e18) / 50e18 = 2e14
+        extrapolatedAPY = percentageIncrease.divPrecisely(yearsSinceLastCollection);
+
+        //      If over 30 mins, extrapolate APY
+        if(_timeSinceLastCollection > THIRTY_MINUTES) {
+            require(extrapolatedAPY < MAX_APY, "Interest protected from inflating past maxAPY");
+        } else {
+            require(percentageIncrease < TEN_BPS, "Interest protected from inflating past 10 Bps");
         }
     }
 
@@ -203,7 +243,7 @@ contract SavingsManager is ISavingsManager, PausableModule {
      */
     function withdrawUnallocatedInterest(address _mAsset, address _recipient)
         external
-        onlyGovernor
+        onlyGovernance
     {
         IERC20 mAsset = IERC20(_mAsset);
         uint256 balance = mAsset.balanceOf(address(this));

--- a/test-utils/assertions.ts
+++ b/test-utils/assertions.ts
@@ -11,15 +11,15 @@ const { expect, assert } = envSetup.configure();
  *  @param actual The BN.js instance you received
  *  @param expected The BN.js amount you expected to receive, allowing a varience of +/- 10 units
  */
-export const assertBNClose = (actual: BN, expected: BN, variance = new BN(10)): void => {
+export const assertBNClose = (actual: BN, expected: BN, variance: BN | number = new BN(10)): void => {
     const actualDelta = actual.gt(expected) ? actual.sub(expected) : expected.sub(actual);
 
     assert.ok(
-        actual.gte(expected.sub(variance)),
+        actual.gte(expected.sub(new BN(variance))),
         `Number is too small to be close (Delta between actual and expected is ${actualDelta.toString()}, but variance was only ${variance.toString()}`,
     );
     assert.ok(
-        actual.lte(expected.add(variance)),
+        actual.lte(expected.add(new BN(variance))),
         `Number is too large to be close (Delta between actual and expected is ${actualDelta.toString()}, but variance was only ${variance.toString()})`,
     );
 };


### PR DESCRIPTION
**Upgrade type**: MODULE REPLACEMENT VIA NEXUS
**Affected file**: `SavingsManager.sol`
**Version**: 1.1

### Description

Address bug originally submitted through Bug Bounty - See [Devan - Bug bounty response.pdf](https://github.com/mstable/mStable-contracts/files/5048099/Devan.-.Bug.bounty.response.pdf)

Removes the blocker on collecting interest more than once in 30 minute period.

Retains existing 'extrapolatedAPY' calculations when it has been longer than 30 minutes since the last interest collection.

If it has been less than 30 minutes, it simply checks that the supply has not inflated by more than 0.1% (or 1e15) during that PERIOD (30 mins). At a 0.1% 'SWAP' fee, this would mean that the total supply of the mAsset would need to be swapped between the two collections, if this were to be hit.


**Mechanism**:

```
        //    If it has been 30 mins since last collection, reset period data
        //    Calculate APY from lastCollection, interest, newTotalSupply (like before)
        if(timeSinceLastCollection > THIRTY_MINUTES) {
            lastPeriodStart[_mAsset] = now;
            periodYield[_mAsset] = 0;
        }
        //    Else if period has elapsed, start a new period from the lastCollection time
        //    Its under 30 mins since last collection, so we can calculate the increase
        //    and protect it from going over 10 bps
        else if(timeSincePeriodStart > THIRTY_MINUTES) {
            lastPeriodStart[_mAsset] = previousCollection;
            periodYield[_mAsset] = interestCollected;
        }
        //    Else add yield to period yield
        //    We use the full yield for the period in the 10 bps calculation
        else {
            inflationOperand = periodYield[_mAsset].add(interestCollected);
            periodYield[_mAsset] = inflationOperand;
        }
```

```
        //   0        30        60        90        120       
        //   | - - - - | - - - - | - - - - | - - - - |
        //   ^            ^   ^    ^    ^            ^
        //  start        40   50  65    80          120
        //  @time - Description (periodStart, lastCollection, periodYield)
        //  @40 - Should start new period (40, 40, 0)
        //  @50 - Should calc in period 40-70 (40, 50, X)
        //  @65 - Should calc in period 40-70 (40, 65, X+Y)
        //  @80 - Should start new period from last collection, 65-95 (65, 80, Z)
        //  @120 - Should start new period (120, 120, 0)
```

### Deployment plan

- [x] Write and comprehensively test the upgrade
- [x] Get external PR review from specialist
  - [x] 1 approval
  - [x] 2 approval
- [x] Deploy `SavingsManager v1.1` to Ropsten/Mainnet
- [x] Use [DiffChecker](https://www.diffchecker.com/) to validate the prev and future contracts once verified
- [x] Call `proposeUpgrade` on the `Nexus` with implementation addresses
- [x] Verify proposal is in the Nexus and the keys match up
- [x] Accept on Ropsten and test
- [x] Wait 1 week
- [x] Accept on Mainnet FORK by unlocking the gov address
- [x] Accept on Mainnet


#### Mainnet Details

Deployed address: `0x7046b0bfc4c5eeb90559c0805dd9c1a6f4815370`

#### Ropsten Details

Deployed address: `0x755629d1ecad92db2b81a3a88207bf6d2b864136`
