### PR TITLE
Added prerequisites and set block gas limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Found a bug? Claim a reward from our open [Bug Bounty](https://docs.mstable.org/
 
 ## Dev notes
 
+### Prerequisites
+
+* Node.js v10.22.0 (you may wish to use [nvm][1])
+* [ganache-cli][2]
+
 ### Installing dependencies
 
 ```
@@ -59,7 +64,7 @@ Deployment scripts are located in `migrations/src`. To run, start `ganache` or `
 *NB: You should locally use the latest version of `ganache-cli`, as contracts rely on recent opcodes*
 
 ```
-$ ganache-cli -p 7545
+$ ganache-cli -p 7545 -l 2000000
 $ yarn migrate
 ```
 
@@ -134,3 +139,5 @@ Codebase rules are enforced through a passing [CI](https://circleci.com) (visibl
 
 <br />
 
+[1]: https://github.com/nvm-sh/nvm
+[2]: https://github.com/trufflesuite/ganache-cli

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Deployment scripts are located in `migrations/src`. To run, start `ganache` or `
 *NB: You should locally use the latest version of `ganache-cli`, as contracts rely on recent opcodes*
 
 ```
-$ ganache-cli -p 7545 -l 2000000
+$ ganache-cli -p 7545 -l 8000000
+$ yarn test-prep
 $ yarn migrate
 ```
 


### PR DESCRIPTION
I ran into issues using Node.js v13.10.1 and found that that the LTS v10.22.0 release works. I also found that the default block gas limit is too low for the setting in `truffle-config.js`.