### PR TITLE
Include artifacts in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "compile": "yarn buidler compile --force",
     "generate-typings": "rimraf ./types/generated && typechain --target 'truffle-v5' --outDir types/generated './build/contracts/*.json'",
     "prettify": "prettier --write test/*.ts test/**/*.ts types/generated/*.ts types/*.ts artifacts/*.ts",
-    "flatten": "sol-merger \"./contracts/**/*.sol\" ./_flat"
+    "flatten": "sol-merger \"./contracts/**/*.sol\" ./_flat",
+    "prepublishOnly": "yarn run test-prep"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "AGPL-3.0-or-later",
   "files": [
     "/contracts/**/*.sol",
-    "!/contracts/z_mocks"
+    "!/contracts/z_mocks",
+    "/artifacts/*.json"
   ],
   "scripts": {
     "migrate": "truffle migrate --network development --reset",


### PR DESCRIPTION
Dry run output:

```
npm notice
npm notice 📦  @mstable/protocol@1.1.2
npm notice === Tarball Contents ===
npm notice 35.5kB  LICENSE
npm notice 54.1kB  artifacts/AaveIntegration.json
npm notice 53.2kB  artifacts/AaveIntegrationV2.json
npm notice 53.7kB  artifacts/AaveIntegrationV3.json
npm notice 559B    artifacts/Address.json
npm notice 14.0kB  artifacts/AdminUpgradeabilityProxy.json
npm notice 11.7kB  artifacts/BaseAdminUpgradeabilityProxy.json
npm notice 1.3kB   artifacts/BaseUpgradeabilityProxy.json
npm notice 132.7kB artifacts/BasketManager.json
npm notice 16.7kB  artifacts/ClaimableGovernor.json
npm notice 565B    artifacts/CommonHelpers.json
npm notice 53.5kB  artifacts/CompoundIntegration.json
npm notice 275B    artifacts/Context.json
npm notice 21.2kB  artifacts/DelayedClaimableGovernor.json
npm notice 38.6kB  artifacts/DelayedProxyAdmin.json
npm notice 19.9kB  artifacts/ERC20.json
npm notice 5.6kB   artifacts/ERC20Detailed.json
npm notice 31.0kB  artifacts/ERC20Mintable.json
npm notice 40.9kB  artifacts/ERC20WithFee.json
npm notice 39.0kB  artifacts/ForgeValidator.json
npm notice 1.6kB   artifacts/Governable.json
npm notice 887B    artifacts/IAaveAToken.json
npm notice 708B    artifacts/IAaveLendingPool.json
npm notice 451B    artifacts/IBasicToken.json
npm notice 14.7kB  artifacts/IBasketManager.json
npm notice 2.2kB   artifacts/ICERC20.json
npm notice 4.2kB   artifacts/IERC20.json
npm notice 7.8kB   artifacts/IForgeValidator.json
npm notice 797B    artifacts/ILendingPoolAddressesProvider.json
npm notice 5.8kB   artifacts/IMasset.json
npm notice 3.2kB   artifacts/INexus.json
npm notice 461B    artifacts/Initializable.json
npm notice 9.0kB   artifacts/InitializableAbstractIntegration.json
npm notice 17.0kB  artifacts/InitializableAdminUpgradeabilityProxy.json
npm notice 6.6kB   artifacts/InitializableGovernableWhitelist.json
npm notice 5.4kB   artifacts/InitializableModule.json
npm notice 4.6kB   artifacts/InitializableModuleKeys.json
npm notice 11.2kB  artifacts/InitializablePausableModule.json
npm notice 476B    artifacts/InitializableReentrancyGuard.json
npm notice 5.2kB   artifacts/InitializableUpgradeabilityProxy.json
npm notice 1.9kB   artifacts/IPlatformIntegration.json
npm notice 1.4kB   artifacts/ISavingsContract.json
npm notice 944B    artifacts/ISavingsManager.json
npm notice 126.3kB artifacts/Masset.json
npm notice 565B    artifacts/MassetHelpers.json
npm notice 461B    artifacts/MassetStructs.json
npm notice 6.6kB   artifacts/MassetToken.json
npm notice 4.5kB   artifacts/Migrations.json
npm notice 1.7kB   artifacts/MinterRole.json
npm notice 16.9kB  artifacts/MockAave.json
npm notice 56.3kB  artifacts/MockAaveIntegration.json
npm notice 41.3kB  artifacts/MockAToken.json
npm notice 136.2kB artifacts/MockBasketManager.json
npm notice 129.8kB artifacts/MockBasketManager1.json
npm notice 18.1kB  artifacts/MockBasketManager2.json
npm notice 134.8kB artifacts/MockBasketManager3.json
npm notice 2.6kB   artifacts/MockCommonHelpers.json
npm notice 55.2kB  artifacts/MockCompoundIntegration.json
npm notice 55.7kB  artifacts/MockCompoundIntegration2.json
npm notice 43.5kB  artifacts/MockCToken.json
npm notice 39.2kB  artifacts/MockERC20.json
npm notice 42.9kB  artifacts/MockERC20WithFee.json
npm notice 5.6kB   artifacts/MockGovernable.json
npm notice 6.2kB   artifacts/MockImplementationV1.json
npm notice 5.1kB   artifacts/MockImplementationV2.json
npm notice 5.1kB   artifacts/MockImplementationV3.json
npm notice 28.0kB  artifacts/MockInitializableModule.json
npm notice 33.4kB  artifacts/MockInitializablePausableModule.json
npm notice 40.7kB  artifacts/MockMasset.json
npm notice 40.6kB  artifacts/MockMasset1.json
npm notice 26.0kB  artifacts/MockModule.json
npm notice 70.2kB  artifacts/MockNexus.json
npm notice 13.1kB  artifacts/MockPausableModule.json
npm notice 17.0kB  artifacts/MockProxy.json
npm notice 1.2kB   artifacts/MockSavingsManager.json
npm notice 591B    artifacts/MockUSDT.json
npm notice 3.2kB   artifacts/Module.json
npm notice 5.7kB   artifacts/ModuleKeys.json
npm notice 125.6kB artifacts/MUSD.json
npm notice 58.8kB  artifacts/Nexus.json
npm notice 579B    artifacts/OpenZeppelinUpgradesAddress.json
npm notice 3.5kB   package.json
npm notice 4.3kB   artifacts/PausableModule.json
npm notice 246B    artifacts/Proxy.json
npm notice 18.3kB  artifacts/PublicStableMath.json
npm notice 283B    artifacts/ReentrancyGuard.json
npm notice 557B    artifacts/Roles.json
npm notice 561B    artifacts/SafeERC20.json
npm notice 560B    artifacts/SafeMath.json
npm notice 32.6kB  artifacts/SavingsContract.json
npm notice 53.1kB  artifacts/SavingsManager.json
npm notice 562B    artifacts/StableMath.json
npm notice 3.3kB   artifacts/UpgradeabilityProxy.json
npm notice 812B    contracts/rewards/README.md
npm notice 6.8kB   README.md
npm notice 7.6kB   contracts/masset/platform-integrations/AaveIntegration.sol
npm notice 2.4kB   contracts/integrations/AbstractBuyAndMint.sol
npm notice 29.0kB  contracts/masset/BasketManager.sol
npm notice 2.2kB   contracts/governance/ClaimableGovernor.sol
npm notice 750B    contracts/shared/CommonHelpers.sol
npm notice 8.7kB   contracts/masset/platform-integrations/CompoundIntegration.sol
npm notice 1.8kB   contracts/governance/DelayedClaimableGovernor.sol
npm notice 7.2kB   contracts/upgradability/DelayedProxyAdmin.sol
npm notice 18.6kB  contracts/masset/forge-validator/ForgeValidator.sol
npm notice 2.0kB   contracts/governance/Governable.sol
npm notice 1.6kB   contracts/meta-token/GovernedMinterRole.sol
npm notice 1.9kB   contracts/masset/platform-integrations/IAave.sol
npm notice 106B    contracts/shared/IBasicToken.sol
npm notice 2.5kB   contracts/interfaces/IBasketManager.sol
npm notice 2.2kB   contracts/masset/platform-integrations/ICompound.sol
npm notice 1.4kB   contracts/masset/forge-validator/IForgeValidator.sol
npm notice 2.0kB   contracts/interfaces/IMasset.sol
npm notice 1.0kB   contracts/interfaces/IMetaToken.sol
npm notice 992B    contracts/integrations/IMintWith1Inch.sol
npm notice 684B    contracts/interfaces/INexus.sol
npm notice 6.7kB   contracts/masset/platform-integrations/InitializableAbstractIntegration.sol
npm notice 1.8kB   contracts/shared/InitializableERC20Detailed.sol
npm notice 1.8kB   contracts/governance/InitializableGovernableWhitelist.sol
npm notice 4.0kB   contracts/shared/InitializableModule.sol
npm notice 1.9kB   contracts/shared/InitializableModuleKeys.sol
npm notice 2.0kB   contracts/shared/InitializablePausableModule.sol
npm notice 2.3kB   contracts/shared/InitializableReentrancyGuard.sol
npm notice 705B    contracts/shared/InitializableToken.sol
npm notice 779B    contracts/interfaces/IPlatformIntegration.sol
npm notice 262B    contracts/interfaces/IRewardsDistributionRecipient.sol
npm notice 374B    contracts/interfaces/ISavingsContract.sol
npm notice 305B    contracts/interfaces/ISavingsManager.sol
npm notice 28.4kB  contracts/masset/Masset.sol
npm notice 1.5kB   contracts/masset/shared/MassetHelpers.sol
npm notice 2.7kB   contracts/masset/shared/MassetStructs.sol
npm notice 1.3kB   contracts/meta-token/MetaToken.sol
npm notice 546B    contracts/Migrations.sol
npm notice 3.3kB   contracts/integrations/MintWith1Inch.sol
npm notice 3.9kB   contracts/shared/Module.sol
npm notice 1.9kB   contracts/shared/ModuleKeys.sol
npm notice 9.3kB   contracts/nexus/Nexus.sol
npm notice 1.9kB   contracts/shared/PausableModule.sol
npm notice 1.1kB   contracts/rewards/staking/PlatformTokenVendor.sol
npm notice 1.5kB   contracts/upgradability/Proxies.sol
npm notice 1.7kB   contracts/rewards/RewardsDistributionRecipient.sol
npm notice 2.9kB   contracts/rewards/RewardsDistributor.sol
npm notice 7.6kB   contracts/savings/SavingsContract.sol
npm notice 10.4kB  contracts/savings/SavingsManager.sol
npm notice 8.0kB   contracts/shared/StableMath.sol
npm notice 8.8kB   contracts/rewards/staking/StakingRewards.sol
npm notice 11.5kB  contracts/rewards/staking/StakingRewardsWithPlatformToken.sol
npm notice 2.6kB   contracts/rewards/staking/StakingTokenWrapper.sol
npm notice === Tarball Details ===
npm notice name:          @mstable/protocol
npm notice version:       1.1.2
npm notice package size:  292.9 kB
npm notice unpacked size: 2.5 MB
npm notice shasum:        29d0963d7ea4aa859a93ccb766263eca30fc6f76
npm notice integrity:     sha512-FQKfKvFuBjuqj[...]N19AYASyeJpPg==
npm notice total files:   147
npm notice
```