### PR TITLE
Add minimum purchase amount on liquidations

### DIFF
--- a/contracts/masset/liquidator/ILiquidator.sol
+++ b/contracts/masset/liquidator/ILiquidator.sol
@@ -9,7 +9,8 @@ contract ILiquidator {
         address _bAsset,
         int128 _curvePosition,
         address[] calldata _uniswapPath,
-        uint256 _trancheAmount
+        uint256 _trancheAmount,
+        uint256 _minReturn
     )
         external;
 
@@ -18,7 +19,8 @@ contract ILiquidator {
         address _bAsset,
         int128 _curvePosition,
         address[] calldata _uniswapPath,
-        uint256 _trancheAmount
+        uint256 _trancheAmount,
+        uint256 _minReturn
     )
         external;
         

--- a/contracts/masset/liquidator/Liquidator.sol
+++ b/contracts/masset/liquidator/Liquidator.sol
@@ -190,6 +190,8 @@ contract Liquidator is
         require(liquidation.bAsset != address(0), "Liquidation does not exist");
 
         delete liquidations[_integration];
+        delete minReturn[_integration];
+
         emit LiquidationEnded(_integration);
     }
 
@@ -250,7 +252,8 @@ contract Liquidator is
 
         // min amount out = sellAmount * priceFloor / 1e18
         // e.g. 1e18 * 100e6 / 1e18 = 100e6
-        // e.g. 30e8 * 1e18 / 1e8 = 30e18
+        // e.g. 30e8 * 100e6 / 1e8 = 3000e6
+        // e.g. 30e18 * 100e18 / 1e18 = 3000e18
         uint256 sellTokenDec = IBasicToken(sellToken).decimals();
         uint256 minOut = sellAmount.mul(minReturn[_integration]).div(10 ** sellTokenDec);
         require(minOut > 0, "Must have some price floor");

--- a/contracts/z_mocks/shared/MockTrigger.sol
+++ b/contracts/z_mocks/shared/MockTrigger.sol
@@ -1,0 +1,11 @@
+pragma solidity 0.5.16;
+
+import { ILiquidator } from "../../masset/liquidator/ILiquidator.sol";
+
+
+contract MockTrigger {
+
+    function trigger(ILiquidator _liq, address _integration) external {
+        _liq.triggerLiquidation(_integration);
+    }
+}

--- a/contracts/z_mocks/shared/MockUniswap.sol
+++ b/contracts/z_mocks/shared/MockUniswap.sol
@@ -10,11 +10,17 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 //   out token has 18 decimals
 contract MockUniswap is IUniswapV2Router02 {
 
+    // how many tokens to give out for 1 in
+    uint256 ratio = 106;
+
+    function setRatio(uint256 _outRatio) external {
+        ratio = _outRatio;
+    }
 
     // takes input from sender, produces output
     function swapExactTokensForTokens(
         uint amountIn,
-        uint /*amountOutMin*/,
+        uint amountOutMin,
         address[] calldata path,
         address /*to*/,
         uint /*deadline*/
@@ -28,7 +34,9 @@ contract MockUniswap is IUniswapV2Router02 {
         amounts[0] = amountIn;
         IERC20(path[0]).transferFrom(msg.sender, address(this), amountIn);
 
-        uint256 output = amountIn * 106;
+        uint256 output = amountIn * ratio;
+        require(output >= amountOutMin, "UNI: Output amount not enough");
+
         amounts[len-1] = output;
         IERC20(path[len-1]).transfer(msg.sender, output);
     }
@@ -41,7 +49,7 @@ contract MockUniswap is IUniswapV2Router02 {
         view
         returns (uint[] memory amounts)
     {
-        uint256 amountIn = amountOut / 106;
+        uint256 amountIn = amountOut / ratio;
         uint256 len = path.length;
         amounts = new uint[](len);
         amounts[0] = amountIn;

--- a/test/masset/liquidator/TestLiquidatorContract.spec.ts
+++ b/test/masset/liquidator/TestLiquidatorContract.spec.ts
@@ -40,6 +40,7 @@ contract("Liquidator", async (accounts) => {
         uniswapPath?: string[];
         lastTriggered: BN;
         sellTranche: BN;
+        minReturn: BN;
     }
 
     interface Balance {
@@ -124,12 +125,14 @@ contract("Liquidator", async (accounts) => {
 
     const getLiquidation = async (addr: string): Promise<Liquidation> => {
         const liquidation = await liquidator.liquidations(addr);
+        const minReturn = await liquidator.minReturn(addr);
         return {
             sellToken: liquidation[0],
             bAsset: liquidation[1],
             curvePosition: liquidation[2],
             lastTriggered: liquidation[3],
             sellTranche: liquidation[4],
+            minReturn,
         };
     };
     const snapshotData = async (): Promise<Data> => {
@@ -157,6 +160,7 @@ contract("Liquidator", async (accounts) => {
                     1,
                     [compToken.address, ZERO_ADDRESS, bAsset.address],
                     simpleToExactAmount(1000, 18),
+                    simpleToExactAmount(70, 6),
                     { from: sa.governor },
                 );
                 const liquidation = await getLiquidation(compIntegration.address);
@@ -165,6 +169,7 @@ contract("Liquidator", async (accounts) => {
                 expect(liquidation.curvePosition).bignumber.eq(new BN(1));
                 expect(liquidation.lastTriggered).bignumber.eq(new BN(0));
                 expect(liquidation.sellTranche).bignumber.eq(simpleToExactAmount(1000, 18));
+                expect(liquidation.minReturn).bignumber.eq(simpleToExactAmount(70, 6));
             });
         });
         describe("triggering a liquidation", () => {
@@ -211,6 +216,7 @@ contract("Liquidator", async (accounts) => {
                     1,
                     [compToken.address, ZERO_ADDRESS, bAsset.address],
                     simpleToExactAmount(1, 18),
+                    simpleToExactAmount(70, 6),
                     { from: sa.governor },
                 ),
                 "Invalid inputs",
@@ -225,6 +231,7 @@ contract("Liquidator", async (accounts) => {
                     1,
                     [compToken.address, ZERO_ADDRESS, bAsset2.address],
                     simpleToExactAmount(1, 18),
+                    simpleToExactAmount(70, 6),
                     { from: sa.governor },
                 ),
                 "Invalid uniswap path",
@@ -238,6 +245,7 @@ contract("Liquidator", async (accounts) => {
                     1,
                     [compToken.address, ZERO_ADDRESS],
                     simpleToExactAmount(1, 18),
+                    simpleToExactAmount(70, 6),
                     { from: sa.governor },
                 ),
                 "Invalid uniswap path",
@@ -251,6 +259,7 @@ contract("Liquidator", async (accounts) => {
                 1,
                 [compToken.address, ZERO_ADDRESS, bAsset.address],
                 simpleToExactAmount(1000, 18),
+                simpleToExactAmount(70, 6),
                 { from: sa.governor },
             );
             const liquidation = await getLiquidation(compIntegration.address);
@@ -267,6 +276,7 @@ contract("Liquidator", async (accounts) => {
                     1,
                     [compToken.address, ZERO_ADDRESS, bAsset.address],
                     simpleToExactAmount(1000, 18),
+                    simpleToExactAmount(70, 6),
                     { from: sa.governor },
                 ),
                 "Liquidation exists for this bAsset",
@@ -283,6 +293,7 @@ contract("Liquidator", async (accounts) => {
                 1,
                 [compToken.address, ZERO_ADDRESS, bAsset.address],
                 simpleToExactAmount(1000, 18),
+                simpleToExactAmount(70, 6),
                 { from: sa.governor },
             );
         });
@@ -295,6 +306,7 @@ contract("Liquidator", async (accounts) => {
                         1,
                         [],
                         simpleToExactAmount(1, 18),
+                        simpleToExactAmount(70, 6),
                         {
                             from: sa.governor,
                         },
@@ -310,6 +322,7 @@ contract("Liquidator", async (accounts) => {
                         1,
                         [],
                         simpleToExactAmount(1, 18),
+                        simpleToExactAmount(70, 6),
                         {
                             from: sa.governor,
                         },
@@ -325,6 +338,7 @@ contract("Liquidator", async (accounts) => {
                         1,
                         [bAsset2.address],
                         simpleToExactAmount(1, 18),
+                        simpleToExactAmount(70, 6),
                         {
                             from: sa.governor,
                         },
@@ -340,6 +354,7 @@ contract("Liquidator", async (accounts) => {
                     2,
                     [compToken.address, ZERO_ADDRESS, bAsset2.address],
                     simpleToExactAmount(123, 18),
+                    simpleToExactAmount(70, 6),
                     { from: sa.governor },
                 );
                 expectEvent(tx.receipt, "LiquidationModified", {
@@ -385,6 +400,7 @@ contract("Liquidator", async (accounts) => {
                 1,
                 [compToken.address, ZERO_ADDRESS, bAsset.address],
                 simpleToExactAmount(1000, 18),
+                simpleToExactAmount(70, 6),
                 { from: sa.governor },
             );
             await compIntegration.approveRewardToken({ from: sa.governor });
@@ -410,6 +426,7 @@ contract("Liquidator", async (accounts) => {
                 1,
                 [compToken.address, ZERO_ADDRESS, bAsset.address],
                 simpleToExactAmount(1, 30),
+                simpleToExactAmount(70, 6),
                 { from: sa.governor },
             );
             // set tranche size to 1e30
@@ -434,6 +451,7 @@ contract("Liquidator", async (accounts) => {
                 1,
                 [compToken.address, ZERO_ADDRESS, bAsset.address],
                 new BN(0),
+                simpleToExactAmount(70, 6),
                 { from: sa.governor },
             );
             await expectRevert(


### PR DESCRIPTION
## What

The following changes have been made to ensure that a reasonable amount of USDC/mUSD is purchased when liquidating COMP:

- require sender to be non smart contract (i.e. enforce tx.origin == msg.sender)
- add a minimum amount of bAsset (USDC) to receive per sellToken (COMP)
- add a fix to Curve to ensure that the rate is always >= 0.95

## Deployment plan

Address: 0x35103a8fafa0c935b7a91e8356c8a05906c80210

1. [x] Deploy Liquidator
2. [x] Propose Liquidator upgrade
3. [x] Accept proposed upgrade