### PR TITLE
docs: add note about contract artifacts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Found a bug? Claim a reward from our open [Bug Bounty](https://docs.mstable.org/
 
 <br />
 
+## Artifacts
+
+We publish the contract artifacts to an npm package called [@mstable/protocol](https://www.npmjs.com/package/@mstable/protocol). You can browse them via [unpkg.com](https://unpkg.com/browse/@mstable/protocol@latest/).
+
 ## Dev notes
 
 ### Prerequisites


### PR DESCRIPTION
It's not clear that the contract artifacts are meant to be used via the `@mstable/protocol` npm package. This PR adds an explicit note for this.