### PR TITLE
Feeder pool tests

### DIFF
--- a/contracts/z_mocks/nexus/MockNexus.sol
+++ b/contracts/z_mocks/nexus/MockNexus.sol
@@ -11,11 +11,13 @@ contract MockNexus is ModuleKeys {
 
     constructor(
         address _governorAddr,
-        address _savingsManager
+        address _savingsManager,
+        address _interestValidator
     )
     {
         governor = _governorAddr;
         modules[KEY_SAVINGS_MANAGER] = _savingsManager;
+        modules[KEY_INTEREST_VALIDATOR] = _interestValidator;
         _initialized = true;
     }
 
@@ -29,5 +31,9 @@ contract MockNexus is ModuleKeys {
 
     function setSavingsManager(address _savingsManager) external {
         modules[KEY_SAVINGS_MANAGER] = _savingsManager;
+    }
+
+    function setInterestValidator(address _interestValidator) external {
+        modules[KEY_INTEREST_VALIDATOR] = _interestValidator;
     }
 }

--- a/test-utils/machines/feederMachine.ts
+++ b/test-utils/machines/feederMachine.ts
@@ -4,40 +4,33 @@
 import { Signer } from "ethers"
 import { ethers } from "hardhat"
 import {
-    FeederLogic__factory,
-    FeederManager__factory,
-    MockInvariantValidator__factory,
     AssetProxy__factory,
-    MockNexus__factory,
-    ExposedMasset,
-    ExposedMasset__factory,
-    Masset,
-    InvariantValidator,
-    MockERC20,
-    DelayedProxyAdmin,
-    MockInitializableToken,
-    MockAaveV2__factory,
-    MockATokenV2__factory,
-    MockPlatformIntegration,
-    MockPlatformIntegration__factory,
-    IPlatformIntegration,
-    MockInitializableToken__factory,
-    MockInitializableTokenWithFee__factory,
-    Manager,
     FeederLogic,
+    FeederLogic__factory,
     FeederPool,
     FeederPool__factory,
+    FeederManager__factory,
+    MockERC20,
+    MockPlatformIntegration__factory,
+    IPlatformIntegration,
+    FeederManager,
+    InterestValidator__factory,
+    InterestValidator,
+    MockATokenV2__factory,
+    MockAaveV2__factory,
 } from "types/generated"
 import { BN, minimum, simpleToExactAmount } from "@utils/math"
-import { fullScale, MainnetAccounts, ratioScale, ZERO_ADDRESS, DEAD_ADDRESS } from "@utils/constants"
+import { MainnetAccounts, ratioScale, ZERO_ADDRESS, DEAD_ADDRESS, fullScale } from "@utils/constants"
 import { Basset } from "@utils/mstable-objects"
 import { StandardAccounts } from "./standardAccounts"
-import { ActionDetails, BasketComposition, BassetIntegrationDetails } from "../../types/machines"
+import { ActionDetails, BasketComposition } from "../../types/machines"
 import { MassetMachine, MassetDetails } from "./mAssetMachine"
 
 export interface FeederDetails {
     pool?: FeederPool
     logic?: FeederLogic
+    manager?: FeederManager
+    interestValidator?: InterestValidator
     mAsset?: MockERC20
     fAsset?: MockERC20
     // [0] = mAsset
@@ -63,48 +56,97 @@ export class FeederMachine {
         return this
     }
 
-    public async deployFeeder(seedBasket = true): Promise<FeederDetails> {
-        const mAssetDetails = await this.mAssetMachine.deployMasset(false, false, false)
+    public async deployFeeder(
+        useMockValidator = false,
+        feederWeights: Array<BN | number> = [200, 200],
+        mAssetWeights: Array<BN | number> = [2500, 2500, 2500, 2500],
+        useLendingMarkets = false,
+        useInterestValidator = false,
+    ): Promise<FeederDetails> {
+        const mAssetDetails = await this.mAssetMachine.deployMasset(useMockValidator, useLendingMarkets, false)
         // Mints 10k mAsset to begin with
-        await this.mAssetMachine.seedWithWeightings(mAssetDetails, [2500, 2500, 2500, 2500])
+        await this.mAssetMachine.seedWithWeightings(mAssetDetails, mAssetWeights)
 
-        const bBtc = await this.mAssetMachine.loadBassetProxy("Binance BTC", "bBTC", 18)
-        const bAssets = [mAssetDetails.mAsset as MockERC20, bBtc]
+        const fAsset = await this.mAssetMachine.loadBassetProxy("Binance BTC", "bBTC", 18)
+        const bAssets = [mAssetDetails.mAsset as MockERC20, fAsset]
         const feederLogic = await new FeederLogic__factory(this.sa.default.signer).deploy()
-        const manager = await new FeederManager__factory(this.sa.default.signer).deploy()
+        const feederManager = await new FeederManager__factory(this.sa.default.signer).deploy()
         const linkedAddress = {
-            __$60670dd84d06e10bb8a5ac6f99a1c0890c$__: manager.address,
+            __$60670dd84d06e10bb8a5ac6f99a1c0890c$__: feederManager.address,
             __$7791d1d5b7ea16da359ce352a2ac3a881c$__: feederLogic.address,
         }
-        const impl = await new FeederPool__factory(linkedAddress, this.sa.default.signer).deploy(DEAD_ADDRESS, mAssetDetails.mAsset.address)
+
+        // - Deploy InterestValidator contract
+        let interestValidator: InterestValidator
+        if (useInterestValidator) {
+            interestValidator = await new InterestValidator__factory(this.sa.default.signer).deploy(mAssetDetails.nexus.address)
+            await mAssetDetails.nexus.setInterestValidator(interestValidator.address)
+        }
+
+        // - Add fAsset to lending markets
+        const platformIntegration = new MockPlatformIntegration__factory(this.sa.governor.signer).attach(mAssetDetails.integrationAddress)
+        if (useLendingMarkets) {
+            //  - Deploy mock aToken for the mAsset and fAsset
+            const aTokenFactory = new MockATokenV2__factory(this.sa.default.signer)
+            const mockATokenMasset = await aTokenFactory.deploy(mAssetDetails.aavePlatformAddress, mAssetDetails.mAsset.address)
+            const mockATokenFasset = await aTokenFactory.deploy(mAssetDetails.aavePlatformAddress, fAsset.address)
+            // - Transfer some of the mAsset and fAsset supply to the mocked Aave
+            await mAssetDetails.mAsset.transfer(mAssetDetails.aavePlatformAddress, (await mAssetDetails.mAsset.totalSupply()).div(1000))
+            await fAsset.transfer(mAssetDetails.aavePlatformAddress, (await fAsset.totalSupply()).div(1000))
+
+            // - Add mAsset and fAsset to the mocked Aave platform
+            const mockAave = new MockAaveV2__factory(this.sa.default.signer).attach(mAssetDetails.aavePlatformAddress)
+            await mockAave.addAToken(mockATokenMasset.address, mAssetDetails.mAsset.address)
+            await mockAave.addAToken(mockATokenFasset.address, fAsset.address)
+
+            // - Add mAsset and fAsset to the platform integration
+            await platformIntegration.setPTokenAddress(mAssetDetails.mAsset.address, mockATokenMasset.address)
+            await platformIntegration.setPTokenAddress(fAsset.address, mockATokenFasset.address)
+        }
+
+        // Deploy feeder pool
+        const impl = await new FeederPool__factory(linkedAddress, this.sa.default.signer).deploy(
+            mAssetDetails.nexus.address,
+            mAssetDetails.mAsset.address,
+        )
         const data = impl.interface.encodeFunctionData("initialize", [
             "mStable mBTC/bBTC Feeder",
             "bBTC fPool",
             {
                 addr: mAssetDetails.mAsset.address,
-                integrator: ZERO_ADDRESS,
+                integrator: useLendingMarkets ? mAssetDetails.integrationAddress : ZERO_ADDRESS,
                 hasTxFee: false,
                 status: 0,
             },
             {
-                addr: bBtc.address,
-                integrator: ZERO_ADDRESS,
+                addr: fAsset.address,
+                integrator: useLendingMarkets ? mAssetDetails.integrationAddress : ZERO_ADDRESS,
                 hasTxFee: false,
                 status: 0,
             },
             mAssetDetails.bAssets.map((b) => b.address),
             {
-                a: simpleToExactAmount(1, 2),
+                a: BN.from(100),
                 limits: {
-                    min: simpleToExactAmount(3, 16),
-                    max: simpleToExactAmount(97, 16),
+                    min: simpleToExactAmount(3, 16), // 3%
+                    max: simpleToExactAmount(97, 16), // 97%
                 },
             },
         ])
+        // Deploy feeder pool proxy and call initialize on the feeder pool implementation
         const poolProxy = await new AssetProxy__factory(this.sa.default.signer).deploy(impl.address, DEAD_ADDRESS, data)
+        // Link the feeder pool ABI to its proxy
         const pool = await new FeederPool__factory(linkedAddress, this.sa.default.signer).attach(poolProxy.address)
-        if (seedBasket) {
-            const approvals = await Promise.all(bAssets.map((b) => this.mAssetMachine.approveMasset(b, pool, 200, this.sa.default.signer)))
+
+        // - Add feeder pool to the platform integration whitelist
+        if (useLendingMarkets) {
+            await platformIntegration.addWhitelist([pool.address])
+        }
+
+        if (feederWeights !== undefined) {
+            const approvals = await Promise.all(
+                bAssets.map((b, i) => this.mAssetMachine.approveMasset(b, pool, feederWeights[i], this.sa.default.signer)),
+            )
             await pool.mintMulti(
                 bAssets.map((b) => b.address),
                 approvals,
@@ -115,8 +157,10 @@ export class FeederMachine {
         return {
             pool,
             logic: feederLogic,
+            manager: feederManager,
+            interestValidator,
             mAsset: mAssetDetails.mAsset as MockERC20,
-            fAsset: bBtc,
+            fAsset,
             bAssets,
             mAssetDetails,
         }
@@ -152,6 +196,45 @@ export class FeederMachine {
         }))
     }
 
+    // Gets the fAsset, mAsset or mpAsset
+    public async getAsset(
+        feederDetails: FeederDetails,
+        assetAddress: string,
+    ): Promise<Basset & { isMpAsset: boolean; feederPoolOrMassetContract: MockERC20 }> {
+        let asset
+        let isMpAsset = false
+        // If a feeder asset or mStable asset
+        if (assetAddress === feederDetails.fAsset.address || assetAddress === feederDetails.mAsset.address) {
+            asset = await feederDetails.pool.getBasset(assetAddress)
+            // If a main pool asset
+        } else if (feederDetails.mAssetDetails.bAssets.map((b) => b.address).includes(assetAddress)) {
+            asset = await feederDetails.mAsset.getBasset(assetAddress)
+            isMpAsset = true
+        } else {
+            throw new Error(`Asset with address ${assetAddress} is not a fAsset, mAsset or mpAsset`)
+        }
+        const assetContract = (await ethers.getContractAt("MockERC20", asset.personal.addr, this.sa.default.signer)) as MockERC20
+        const integrator =
+            asset.personal.integrator === ZERO_ADDRESS
+                ? null
+                : (((await new MockPlatformIntegration__factory(this.sa.default.signer).attach(
+                      asset.personal.integrator,
+                  )) as unknown) as IPlatformIntegration)
+        return {
+            addr: asset.personal.addr,
+            status: asset.personal.status,
+            isTransferFeeCharged: asset.personal.hasTxFee,
+            ratio: isMpAsset ? BN.from(asset.data.ratio) : BN.from(asset.vaultData.ratio),
+            vaultBalance: isMpAsset ? BN.from(asset.data.vaultBalance) : BN.from(asset.vaultData.vaultBalance),
+            integratorAddr: asset.personal.integrator,
+            contract: assetContract,
+            pToken: integrator ? await integrator.callStatic["bAssetToPToken(address)"](asset.personal.addr) : null,
+            integrator,
+            isMpAsset,
+            feederPoolOrMassetContract: isMpAsset ? feederDetails.mAsset : feederDetails.pool,
+        }
+    }
+
     public async getBasketComposition(feederDetails: FeederDetails): Promise<BasketComposition> {
         // raw bAsset data
         const bAssets = await this.getBassets(feederDetails)
@@ -170,11 +253,7 @@ export class FeederMachine {
 
         const balances = rawBalances.map((b, i) => b.add(platformBalances[i]))
         // get overweight
-        const currentVaultUnits = bAssets.map((b) =>
-            BN.from(b.vaultBalance)
-                .mul(BN.from(b.ratio))
-                .div(ratioScale),
-        )
+        const currentVaultUnits = bAssets.map((b) => BN.from(b.vaultBalance).mul(BN.from(b.ratio)).div(ratioScale))
         // get total amount
         const sumOfBassets = currentVaultUnits.reduce((p, c) => p.add(c), BN.from(0))
         return {
@@ -195,15 +274,65 @@ export class FeederMachine {
     }
 
     public async approveFeeder(
-        bAsset: MockERC20,
+        asset: MockERC20,
         feeder: string,
-        fullMassetUnits: number | BN | string,
+        assetQuantity: number | BN | string,
         sender: Signer = this.sa.default.signer,
         inputIsBaseUnits = false,
     ): Promise<BN> {
-        const bAssetDecimals = await bAsset.decimals()
-        const approvalAmount: BN = inputIsBaseUnits ? BN.from(fullMassetUnits) : simpleToExactAmount(fullMassetUnits, bAssetDecimals)
-        await bAsset.connect(sender).approve(feeder, approvalAmount)
+        const assetDecimals = await asset.decimals()
+        const approvalAmount: BN = inputIsBaseUnits ? BN.from(assetQuantity) : simpleToExactAmount(assetQuantity, assetDecimals)
+        await asset.connect(sender).approve(feeder, approvalAmount)
         return approvalAmount
+    }
+
+    public async getPlatformInteraction(
+        pool: FeederPool,
+        type: "deposit" | "withdrawal",
+        amount: BN,
+        bAsset: Basset,
+    ): Promise<ActionDetails> {
+        const hasIntegrator = bAsset.integratorAddr === ZERO_ADDRESS
+        const integratorBalBefore = await bAsset.contract.balanceOf(bAsset.integrator ? bAsset.integratorAddr : pool.address)
+        if (hasIntegrator) {
+            return {
+                hasLendingMarket: false,
+                expectInteraction: false,
+                rawBalance: type === "deposit" ? integratorBalBefore.add(amount) : integratorBalBefore.sub(amount),
+            }
+        }
+        const hasTxFee = bAsset.isTransferFeeCharged
+        if (hasTxFee) {
+            return {
+                hasLendingMarket: true,
+                expectInteraction: true,
+                amount,
+                rawBalance: BN.from(0),
+            }
+        }
+        const totalSupply = await pool.totalSupply()
+        const { cacheSize, pendingFees } = await pool.data()
+        const maxC = totalSupply.add(pendingFees).mul(ratioScale).div(BN.from(bAsset.ratio)).mul(cacheSize).div(fullScale)
+        const newSum = BN.from(integratorBalBefore).add(amount)
+        const expectInteraction = type === "deposit" ? newSum.gte(maxC) : amount.gt(BN.from(integratorBalBefore))
+        return {
+            hasLendingMarket: true,
+            expectInteraction,
+            amount:
+                type === "deposit"
+                    ? newSum.sub(maxC.div(2))
+                    : minimum(
+                          maxC.div(2).add(amount).sub(BN.from(integratorBalBefore)),
+                          BN.from(bAsset.vaultBalance).sub(BN.from(integratorBalBefore)),
+                      ),
+            rawBalance:
+                type === "deposit"
+                    ? expectInteraction
+                        ? maxC.div(2)
+                        : newSum
+                    : expectInteraction
+                    ? minimum(maxC.div(2), BN.from(bAsset.vaultBalance).sub(amount))
+                    : BN.from(integratorBalBefore).sub(amount),
+        }
     }
 }

--- a/test-utils/machines/mAssetMachine.ts
+++ b/test-utils/machines/mAssetMachine.ts
@@ -29,9 +29,9 @@ import {
 import { BN, minimum, simpleToExactAmount } from "@utils/math"
 import { fullScale, MainnetAccounts, ratioScale, ZERO_ADDRESS, DEAD_ADDRESS } from "@utils/constants"
 import { Basset } from "@utils/mstable-objects"
+import { Address } from "types/common"
 import { StandardAccounts } from "./standardAccounts"
 import { ActionDetails, ATokenDetails, BasketComposition, BassetIntegrationDetails } from "../../types/machines"
-import { Address } from "types/common"
 
 export interface MassetDetails {
     mAsset?: ExposedMasset

--- a/test-utils/machines/standardAccounts.ts
+++ b/test-utils/machines/standardAccounts.ts
@@ -34,6 +34,8 @@ export class StandardAccounts {
 
     public mockSavingsManager: Account
 
+    public mockInterestValidator: Account
+
     public async initAccounts(signers: Signer[]): Promise<StandardAccounts> {
         this.all = await Promise.all(
             signers.map(async (s) => ({
@@ -52,6 +54,7 @@ export class StandardAccounts {
             this.fundManager,
             this.fundManager2,
             this.mockSavingsManager,
+            this.mockInterestValidator,
         ] = this.all
         return this
     }

--- a/test/feeders/admin.spec.ts
+++ b/test/feeders/admin.spec.ts
@@ -1,0 +1,717 @@
+/* eslint-disable @typescript-eslint/no-loop-func */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import { ethers } from "hardhat"
+import { expect } from "chai"
+
+import { simpleToExactAmount, BN } from "@utils/math"
+import { FeederDetails, FeederMachine, MassetMachine, StandardAccounts } from "@utils/machines"
+
+import { DEAD_ADDRESS, MAX_UINT256, ONE_DAY, ONE_HOUR, ONE_MIN, ONE_WEEK, ZERO_ADDRESS } from "@utils/constants"
+import { FeederPool, MockERC20, MockPlatformIntegration, MockPlatformIntegration__factory } from "types/generated"
+import { BassetStatus } from "@utils/mstable-objects"
+import { getTimestamp, increaseTime } from "@utils/time"
+
+describe("Feeder Admin", () => {
+    let sa: StandardAccounts
+    let mAssetMachine: MassetMachine
+    let feederMachine: FeederMachine
+    let details: FeederDetails
+
+    const runSetup = async (
+        useLendingMarkets = false,
+        useInterestValidator = false,
+        feederWeights?: Array<BN | number>,
+        mAssetWeights?: Array<BN | number>,
+    ): Promise<void> => {
+        details = await feederMachine.deployFeeder(false, feederWeights, mAssetWeights, useLendingMarkets, useInterestValidator)
+    }
+
+    before("Init contract", async () => {
+        const accounts = await ethers.getSigners()
+        mAssetMachine = await new MassetMachine().initAccounts(accounts)
+        feederMachine = await new FeederMachine(mAssetMachine)
+        sa = mAssetMachine.sa
+    })
+
+    describe("using basic setters", async () => {
+        const newSize = simpleToExactAmount(1, 16) // 1%
+        let pool: FeederPool
+        before("set up", async () => {
+            await runSetup()
+            pool = await details.pool.connect(sa.governor.signer)
+        })
+        describe("should allow changing of the cache size to ", () => {
+            it("zero", async () => {
+                const tx = pool.setCacheSize(0)
+                await expect(tx).to.emit(pool, "CacheSizeChanged").withArgs(0)
+                const poolData = await pool.data()
+                expect(poolData.cacheSize).eq(0)
+            })
+            it("1%", async () => {
+                let poolData = await pool.data()
+                const oldSize = poolData.cacheSize
+                expect(oldSize).not.eq(newSize)
+                const tx = pool.setCacheSize(newSize)
+                await expect(tx).to.emit(pool, "CacheSizeChanged").withArgs(newSize)
+                poolData = await pool.data()
+                expect(poolData.cacheSize).eq(newSize)
+            })
+            it("20% (cap limit)", async () => {
+                const capLimit = simpleToExactAmount(20, 16) // 20%
+                const tx = pool.setCacheSize(capLimit)
+                await expect(tx).to.emit(pool, "CacheSizeChanged").withArgs(capLimit)
+                const poolData = await pool.data()
+                expect(poolData.cacheSize).eq(capLimit)
+            })
+        })
+        describe("should fail changing the cache size if", () => {
+            it("not governor", async () => {
+                await expect(details.pool.connect(sa.default.signer).setCacheSize(newSize)).to.be.revertedWith("Only governor can execute")
+                await expect(details.pool.connect(sa.dummy1.signer).setCacheSize(newSize)).to.be.revertedWith("Only governor can execute")
+            })
+            it("just over cap", async () => {
+                const feeExceedingCap = BN.from("200000000000000001")
+                await expect(pool.setCacheSize(feeExceedingCap)).to.be.revertedWith("Must be <= 20%")
+            })
+            it("exceed cap by 1%", async () => {
+                const feeExceedingCap = simpleToExactAmount(21, 16) // 21%
+                await expect(pool.setCacheSize(feeExceedingCap)).to.be.revertedWith("Must be <= 20%")
+            })
+            it("exceeding cap with max number", async () => {
+                await expect(pool.setCacheSize(MAX_UINT256)).to.be.revertedWith("Must be <= 20%")
+            })
+        })
+        describe("should change swap and redemption fees to", () => {
+            it("0.5% and 0.25%", async () => {
+                let poolData = await pool.data()
+                const newSwapFee = simpleToExactAmount(0.5, 16)
+                const newRedemptionFee = simpleToExactAmount(0.25, 16)
+                expect(poolData.swapFee).not.eq(newSwapFee)
+                expect(poolData.redemptionFee).not.eq(newRedemptionFee)
+                const tx = pool.setFees(newSwapFee, newRedemptionFee)
+                await expect(tx).to.emit(pool, "FeesChanged").withArgs(newSwapFee, newRedemptionFee)
+                poolData = await pool.data()
+                expect(poolData.swapFee).eq(newSwapFee)
+                expect(poolData.redemptionFee).eq(newRedemptionFee)
+            })
+            it("1% (limit)", async () => {
+                const newFee = simpleToExactAmount(1, 16)
+                await pool.setFees(newFee, newFee)
+                const tx = pool.setFees(newFee, newFee)
+                await expect(tx).to.emit(pool, "FeesChanged").withArgs(newFee, newFee)
+                const poolData = await pool.data()
+                expect(poolData.swapFee).eq(newFee)
+                expect(poolData.redemptionFee).eq(newFee)
+            })
+        })
+        describe("should fail to change swap fee rate when", () => {
+            it("not governor", async () => {
+                const fee = simpleToExactAmount(2, 16)
+                await expect(details.pool.setFees(fee, fee)).to.be.revertedWith("Only governor can execute")
+            })
+            it("Swap rate just exceeds 1% cap", async () => {
+                await expect(pool.setFees("10000000000000001", "10000000000000000")).to.be.revertedWith("Swap rate oob")
+            })
+            it("Redemption rate just exceeds 1% cap", async () => {
+                await expect(pool.setFees("10000000000000000", "10000000000000001")).to.be.revertedWith("Redemption rate oob")
+            })
+            it("2% rate exceeds 1% cap", async () => {
+                const fee = simpleToExactAmount(2, 16) // 2%
+                await expect(pool.setFees(fee, fee)).to.be.revertedWith("Swap rate oob")
+            })
+            it("max rate", async () => {
+                const fee = MAX_UINT256
+                await expect(pool.setFees(fee, fee)).to.be.revertedWith("Swap rate oob")
+            })
+        })
+        it("should set weights", async () => {
+            let poolData = await pool.data()
+            const beforeWeightLimits = poolData.weightLimits
+            const newMinWeight = simpleToExactAmount(30, 16)
+            const newMaxWeight = simpleToExactAmount(70, 16)
+            const tx = pool.setWeightLimits(newMinWeight, newMaxWeight)
+            await expect(tx, "WeightLimitsChanged event").to.emit(pool, "WeightLimitsChanged").withArgs(newMinWeight, newMaxWeight)
+            await tx
+            poolData = await pool.data()
+            const afterWeightLimits = poolData.weightLimits
+            expect(afterWeightLimits.min, "before and after min weight not equal").not.to.eq(beforeWeightLimits.min)
+            expect(afterWeightLimits.max, "before and after max weight not equal").not.to.eq(beforeWeightLimits.max)
+            expect(afterWeightLimits.min, "min weight set").to.eq(newMinWeight)
+            expect(afterWeightLimits.max, "max weight set").to.eq(newMaxWeight)
+        })
+        describe("failed set max weight", () => {
+            const newMinWeight = simpleToExactAmount(1, 16)
+            const newMaxWeight = simpleToExactAmount(620, 15)
+            it("should fail setWeightLimits with default signer", async () => {
+                await expect(pool.connect(sa.default.signer).setWeightLimits(newMinWeight, newMaxWeight)).to.revertedWith(
+                    "Only governor can execute",
+                )
+            })
+            it("should fail setWeightLimits with dummy signer", async () => {
+                await expect(pool.connect(sa.dummy1.signer).setWeightLimits(newMinWeight, newMaxWeight)).to.revertedWith(
+                    "Only governor can execute",
+                )
+            })
+            it("should fail setWeightLimits with max weight too small", async () => {
+                await expect(pool.setWeightLimits(newMinWeight, simpleToExactAmount(699, 15))).to.revertedWith("Weights oob")
+            })
+            it("should fail setWeightLimits with min weight too large", async () => {
+                await expect(pool.setWeightLimits(simpleToExactAmount(299, 15), newMaxWeight)).to.revertedWith("Weights oob")
+            })
+        })
+    })
+    context("getters without setters", () => {
+        before("init basset", async () => {
+            await runSetup()
+        })
+        it("get config", async () => {
+            const { pool } = details
+            const config = await pool.getConfig()
+            expect(config.limits.min, "minWeight").to.eq(simpleToExactAmount(3, 16))
+            expect(config.limits.max, "maxWeight").to.eq(simpleToExactAmount(97, 16))
+            expect(config.a, "a value").to.eq(10000)
+        })
+        it("should get mStable asset", async () => {
+            const { pool, mAsset } = details
+            const asset = await pool.getBasset(mAsset.address)
+            expect(asset.personal.addr, "personal.addr").to.eq(mAsset.address)
+            expect(asset.personal.hasTxFee, "personal.hasTxFee").to.false
+            expect(asset.personal.integrator, "personal.integrator").to.eq(ZERO_ADDRESS)
+            expect(asset.personal.status, "personal.status").to.eq(BassetStatus.Normal)
+            expect(asset.vaultData.ratio).to.eq(simpleToExactAmount(1, 8)) // 26 - 18
+            expect(asset.vaultData.vaultBalance, "vaultData.vaultBalance").to.gt(0)
+        })
+        it("should get feeder asset", async () => {
+            const { pool, fAsset } = details
+            const asset = await pool.getBasset(fAsset.address)
+            expect(asset.personal.addr, "personal.addr").to.eq(fAsset.address)
+            expect(asset.personal.hasTxFee, "personal.hasTxFee").to.false
+            expect(asset.personal.integrator, "personal.integrator").to.eq(ZERO_ADDRESS)
+            expect(asset.personal.status, "personal.status").to.eq(BassetStatus.Normal)
+            expect(asset.vaultData.ratio).to.eq(simpleToExactAmount(1, 8)) // 26 - 18
+            expect(asset.vaultData.vaultBalance, "vaultData.vaultBalance").to.gt(0)
+        })
+        it("should fail to get bAsset with address 0x0", async () => {
+            await expect(details.pool.getBasset(ZERO_ADDRESS)).to.revertedWith("Invalid asset")
+        })
+        it("should fail to get bAsset not in basket", async () => {
+            await expect(details.pool.getBasset(sa.dummy1.address)).to.revertedWith("Invalid asset")
+        })
+    })
+    describe("Amplification coefficient", () => {
+        before(async () => {
+            await runSetup()
+        })
+        it("should succeed in starting increase over 2 weeks", async () => {
+            const pool = details.pool.connect(sa.governor.signer)
+            const ampDataBefore = (await pool.data()).ampData
+
+            // default values
+            expect(ampDataBefore.initialA, "before initialA").to.eq(10000)
+            expect(ampDataBefore.targetA, "before targetA").to.eq(10000)
+            expect(ampDataBefore.rampStartTime, "before rampStartTime").to.eq(0)
+            expect(ampDataBefore.rampEndTime, "before rampEndTime").to.eq(0)
+
+            const startTime = await getTimestamp()
+            const endTime = startTime.add(ONE_WEEK.mul(2))
+            const tx = pool.startRampA(120, endTime)
+            await expect(tx).to.emit(pool, "StartRampA").withArgs(10000, 12000, startTime.add(1), endTime)
+
+            // after values
+            const ampDataAfter = (await pool.data()).ampData
+            expect(ampDataAfter.initialA, "after initialA").to.eq(10000)
+            expect(ampDataAfter.targetA, "after targetA").to.eq(12000)
+            expect(ampDataAfter.rampStartTime, "after rampStartTime").to.eq(startTime.add(1))
+            expect(ampDataAfter.rampEndTime, "after rampEndTime").to.eq(endTime)
+        })
+        context("increasing A by 20 over 10 day period", () => {
+            let startTime: BN
+            let endTime: BN
+            let pool: FeederPool
+            before(async () => {
+                await runSetup()
+                pool = details.pool.connect(sa.governor.signer)
+                startTime = await getTimestamp()
+                endTime = startTime.add(ONE_DAY.mul(10))
+                await pool.startRampA(120, endTime)
+            })
+            it("should succeed getting A just after start", async () => {
+                const config = await pool.getConfig()
+                expect(config.a).to.eq(10000)
+            })
+            const testsData = [
+                {
+                    // 60 * 60 * 24 * 10 / 2000 = 432
+                    desc: "just under before increment",
+                    elapsedSeconds: 431,
+                    expectedValaue: 10000,
+                },
+                {
+                    desc: "just under after increment",
+                    elapsedSeconds: 434,
+                    expectedValaue: 10001,
+                },
+                {
+                    desc: "after 1 day",
+                    elapsedSeconds: ONE_DAY.add(1),
+                    expectedValaue: 10200,
+                },
+                {
+                    desc: "after 9 days",
+                    elapsedSeconds: ONE_DAY.mul(9).add(1),
+                    expectedValaue: 11800,
+                },
+                {
+                    desc: "just under 10 days",
+                    elapsedSeconds: ONE_DAY.mul(10).sub(2),
+                    expectedValaue: 11999,
+                },
+                {
+                    desc: "after 10 days",
+                    elapsedSeconds: ONE_DAY.mul(10),
+                    expectedValaue: 12000,
+                },
+                {
+                    desc: "after 11 days",
+                    elapsedSeconds: ONE_DAY.mul(11),
+                    expectedValaue: 12000,
+                },
+            ]
+            for (const testData of testsData) {
+                it(`should succeed getting A ${testData.desc}`, async () => {
+                    const currentTime = await getTimestamp()
+                    const incrementSeconds = startTime.add(testData.elapsedSeconds).sub(currentTime)
+                    await increaseTime(incrementSeconds)
+                    const config = await pool.getConfig()
+                    expect(config.a).to.eq(testData.expectedValaue)
+                })
+            }
+        })
+        context("A target changes just in range", () => {
+            let currentA: BN
+            let startTime: BN
+            let endTime: BN
+            beforeEach(async () => {
+                await runSetup()
+                const config = await details.pool.getConfig()
+                currentA = config.a
+                startTime = await getTimestamp()
+                endTime = startTime.add(ONE_DAY.mul(7))
+            })
+            it("should increase target A 10x", async () => {
+                const { pool } = details
+                const ampDataBefore = (await details.pool.data()).ampData
+                expect(ampDataBefore.initialA, "before initialA").to.eq(currentA)
+                expect(ampDataBefore.targetA, "before targetA").to.eq(currentA)
+
+                const targetA = currentA.mul(10).div(100)
+                const tx = details.pool.connect(sa.governor.signer).startRampA(targetA, endTime)
+                await expect(tx).to.emit(pool, "StartRampA")
+
+                const ampDataAfter = (await details.pool.data()).ampData
+                expect(ampDataAfter.initialA, "after initialA").to.eq(currentA)
+                expect(ampDataAfter.targetA, "after targetA").to.eq(currentA.mul(10))
+            })
+            it("should decrease target A 10x", async () => {
+                const { pool } = details
+                const ampDataBefore = (await details.pool.data()).ampData
+                expect(ampDataBefore.initialA, "before initialA").to.eq(currentA)
+                expect(ampDataBefore.targetA, "before targetA").to.eq(currentA)
+
+                const targetA = currentA.div(10).div(100)
+                const tx = details.pool.connect(sa.governor.signer).startRampA(targetA, endTime)
+                await expect(tx).to.emit(pool, "StartRampA")
+
+                const ampDataAfter = (await details.pool.data()).ampData
+                expect(ampDataAfter.initialA, "after initialA").to.eq(currentA)
+                expect(ampDataAfter.targetA, "after targetA").to.eq(currentA.div(10))
+            })
+        })
+        context("decreasing A by 50 over 5 days", () => {
+            let startTime: BN
+            let endTime: BN
+            let pool: FeederPool
+            before(async () => {
+                await runSetup()
+                pool = details.pool.connect(sa.governor.signer)
+                startTime = await getTimestamp()
+                endTime = startTime.add(ONE_DAY.mul(5))
+                await pool.startRampA(50, endTime)
+            })
+            it("should succeed getting A just after start", async () => {
+                const config = await pool.getConfig()
+                expect(config.a).to.eq(10000)
+            })
+            const testsData = [
+                {
+                    // 60 * 60 * 24 * 5 / 5000 = 86
+                    desc: "just under before increment",
+                    elapsedSeconds: 84,
+                    expectedValaue: 10000,
+                },
+                {
+                    desc: "just under after increment",
+                    elapsedSeconds: 88,
+                    expectedValaue: 9999,
+                },
+                {
+                    desc: "after 1 day",
+                    elapsedSeconds: ONE_DAY.add(1),
+                    expectedValaue: 9000,
+                },
+                {
+                    desc: "after 4 days",
+                    elapsedSeconds: ONE_DAY.mul(4).add(1),
+                    expectedValaue: 6000,
+                },
+                {
+                    desc: "just under 5 days",
+                    elapsedSeconds: ONE_DAY.mul(5).sub(2),
+                    expectedValaue: 5001,
+                },
+                {
+                    desc: "after 5 days",
+                    elapsedSeconds: ONE_DAY.mul(5),
+                    expectedValaue: 5000,
+                },
+                {
+                    desc: "after 6 days",
+                    elapsedSeconds: ONE_DAY.mul(6),
+                    expectedValaue: 5000,
+                },
+            ]
+            for (const testData of testsData) {
+                it(`should succeed getting A ${testData.desc}`, async () => {
+                    const currentTime = await getTimestamp()
+                    const incrementSeconds = startTime.add(testData.elapsedSeconds).sub(currentTime)
+                    await increaseTime(incrementSeconds)
+                    const config = await pool.getConfig()
+                    expect(config.a).to.eq(testData.expectedValaue)
+                })
+            }
+        })
+        describe("should fail to start ramp A", () => {
+            before(async () => {
+                await runSetup()
+            })
+            it("when ramp up time only 1 hour", async () => {
+                await expect(details.pool.connect(sa.governor.signer).startRampA(12000, ONE_HOUR)).to.revertedWith("Ramp time too short")
+            })
+            it("when ramp up time just less than 1 day", async () => {
+                await expect(details.pool.connect(sa.governor.signer).startRampA(12000, ONE_DAY.sub(1))).to.revertedWith(
+                    "Ramp time too short",
+                )
+            })
+            it("when A target too big", async () => {
+                const startTime = await getTimestamp()
+                const endTime = startTime.add(ONE_DAY.mul(7))
+                await expect(details.pool.connect(sa.governor.signer).startRampA(1000000, endTime)).to.revertedWith(
+                    "A target out of bounds",
+                )
+            })
+            it("when A target increase greater than 10x", async () => {
+                const config = await details.pool.getConfig()
+                const currentA = config.a
+                // target = current * 10 / 100
+                // the 100 is the precision
+                const targetA = currentA.div(10).add(1)
+                const startTime = await getTimestamp()
+                const endTime = startTime.add(ONE_DAY.mul(7))
+                await expect(details.pool.connect(sa.governor.signer).startRampA(targetA, endTime)).to.revertedWith(
+                    "A target increase too big",
+                )
+            })
+            it("when A target decrease greater than 10x", async () => {
+                const config = await details.pool.getConfig()
+                const currentA = config.a
+                // target = current / 100 / 10
+                // the 100 is the precision
+                const targetA = currentA.div(1000).sub(1)
+                const startTime = await getTimestamp()
+                const endTime = startTime.add(ONE_DAY.mul(7))
+                await expect(details.pool.connect(sa.governor.signer).startRampA(targetA, endTime)).to.revertedWith(
+                    "A target decrease too big",
+                )
+            })
+            it("when A target is zero", async () => {
+                const startTime = await getTimestamp()
+                const endTime = startTime.add(ONE_DAY.mul(7))
+                await expect(details.pool.connect(sa.governor.signer).startRampA(0, endTime)).to.revertedWith("A target out of bounds")
+            })
+            it("when starting just less than a day after the last finished", async () => {
+                const pool = details.pool.connect(sa.governor.signer)
+                const startTime = await getTimestamp()
+                const endTime = startTime.add(ONE_DAY.mul(2))
+                await pool.startRampA(130, endTime)
+
+                // increment 1 day
+                await increaseTime(ONE_HOUR.mul(20))
+
+                const secondStartTime = await getTimestamp()
+                const secondEndTime = secondStartTime.add(ONE_DAY.mul(7))
+                await expect(pool.startRampA(150, secondEndTime)).to.revertedWith("Sufficient period of previous ramp has not elapsed")
+            })
+        })
+        context("stop ramp A", () => {
+            let startTime: BN
+            let endTime: BN
+            let pool: FeederPool
+            before(async () => {
+                await runSetup()
+                pool = details.pool.connect(sa.governor.signer)
+                startTime = await getTimestamp()
+                endTime = startTime.add(ONE_DAY.mul(5))
+                await pool.startRampA(50, endTime)
+            })
+            it("should stop decreasing A after a day", async () => {
+                // increment 1 day
+                await increaseTime(ONE_DAY)
+
+                let config = await details.pool.getConfig()
+                const currentA = config.a
+                const currentTime = await getTimestamp()
+                const tx = pool.stopRampA()
+                await expect(tx).to.emit(pool, "StopRampA").withArgs(currentA, currentTime.add(1))
+                config = await details.pool.getConfig()
+                expect(config.a).to.eq(currentA)
+
+                const ampDataAfter = (await pool.data()).ampData
+                expect(ampDataAfter.initialA, "after initialA").to.eq(currentA)
+                expect(ampDataAfter.targetA, "after targetA").to.eq(currentA)
+                expect(ampDataAfter.rampStartTime.toNumber(), "after rampStartTime").to.within(
+                    currentTime.toNumber(),
+                    currentTime.add(2).toNumber(),
+                )
+                expect(ampDataAfter.rampEndTime.toNumber(), "after rampEndTime").to.within(
+                    currentTime.toNumber(),
+                    currentTime.add(2).toNumber(),
+                )
+
+                // increment another 2 days
+                await increaseTime(ONE_DAY.mul(2))
+                config = await details.pool.getConfig()
+                expect(config.a).to.eq(currentA)
+            })
+        })
+        describe("should fail to stop ramp A", () => {
+            before(async () => {
+                await runSetup()
+                const pool = details.pool.connect(sa.governor.signer)
+                const startTime = await getTimestamp()
+                const endTime = startTime.add(ONE_DAY.mul(2))
+                await pool.startRampA(50, endTime)
+            })
+            it("After ramp has complete", async () => {
+                // increment 2 days
+                await increaseTime(ONE_DAY.mul(2).add(1))
+                await expect(details.pool.connect(sa.governor.signer).stopRampA()).to.revertedWith("Amplification not changing")
+            })
+        })
+    })
+    context("Collect interest", async () => {
+        context("mocking the interest validator", () => {
+            before(async () => {
+                // Deploy feeder pool using lending market
+                await runSetup(true)
+            })
+            it("Should collect zero platform interest", async () => {
+                const { pool } = details
+                const tx = pool.connect(sa.mockInterestValidator.signer).collectPlatformInterest()
+                await expect(tx).to.emit(pool, "MintedMulti")
+            })
+            it("Should collect interest from mAsset", async () => {
+                const { pool, mAsset } = details
+
+                // increase the test chain by 12 hours + 20 seconds
+                await increaseTime(ONE_HOUR.mul(12).add(20))
+
+                // Mint mAsset to generate some interest in the lending market
+                await feederMachine.approveFeeder(mAsset, pool.address, 1000)
+                await pool.mint(mAsset.address, simpleToExactAmount(500), 0, sa.default.address)
+
+                const tx = pool.connect(sa.mockInterestValidator.signer).collectPlatformInterest()
+                await expect(tx).to.emit(pool, "MintedMulti")
+            })
+            it("Should collect interest from fAsset", async () => {
+                const { fAsset, pool } = details
+
+                // increase the test chain by 12 hours + 20 seconds
+                await increaseTime(ONE_HOUR.mul(12).add(20))
+
+                // Mint fAsset to generate some interest in the lending market
+                await feederMachine.approveFeeder(fAsset, pool.address, 1000)
+                await pool.mint(fAsset.address, simpleToExactAmount(500), 0, sa.default.address)
+
+                const tx = pool.connect(sa.mockInterestValidator.signer).collectPlatformInterest()
+                await expect(tx).to.emit(pool, "MintedMulti")
+            })
+            it("Should collect interest from mAsset and fAsset", async () => {
+                const { fAsset, pool, mAsset } = details
+
+                // increase the test chain by 12 hours + 20 seconds
+                await increaseTime(ONE_HOUR.mul(12).add(20))
+
+                // Mint mAsset to generate some interest in the lending market
+                await feederMachine.approveFeeder(mAsset, pool.address, 1000)
+                await pool.mint(mAsset.address, simpleToExactAmount(500), 0, sa.default.address)
+                // Mint fAsset to generate some interest in the lending market
+                await feederMachine.approveFeeder(fAsset, pool.address, 1000)
+                await pool.mint(fAsset.address, simpleToExactAmount(500), 0, sa.default.address)
+
+                const tx = pool.connect(sa.mockInterestValidator.signer).collectPlatformInterest()
+                await expect(tx).to.emit(pool, "MintedMulti")
+            })
+            context("should fail to collect interest when sender is", () => {
+                it("governor", async () => {
+                    await expect(details.pool.connect(sa.governor.signer).collectPlatformInterest()).to.revertedWith("Only validator")
+                })
+                it("default", async () => {
+                    await expect(details.pool.connect(sa.default.signer).collectPlatformInterest()).to.revertedWith("Only validator")
+                })
+                it("fundManager", async () => {
+                    await expect(details.pool.connect(sa.fundManager.signer).collectPlatformInterest()).to.revertedWith("Only validator")
+                })
+            })
+        })
+        context("using the interest validator contract and lending markets", () => {
+            before(async () => {
+                // Deploy interest validation contract with the feeder pool and lending market
+                await runSetup(true, true)
+            })
+            it("should collect zero platform interest", async () => {
+                const { interestValidator, pool } = details
+
+                const tx = interestValidator.collectAndValidateInterest([pool.address])
+                await expect(tx).to.emit(interestValidator, "InterestCollected")
+                await expect(tx).to.emit(pool, "MintedMulti")
+            })
+            it("should collect platform interest", async () => {
+                const { interestValidator, fAsset, pool } = details
+
+                // increase the test chain by 12 hours + 20 seconds
+                await increaseTime(ONE_HOUR.mul(12).add(20))
+
+                // Mint to generate some interest in the lending market
+                await feederMachine.approveFeeder(fAsset, pool.address, 1000)
+                await pool.mint(fAsset.address, simpleToExactAmount(500), 0, sa.default.address)
+
+                const tx = interestValidator.collectAndValidateInterest([pool.address])
+                await expect(tx).to.emit(interestValidator, "InterestCollected")
+                await expect(tx).to.emit(pool, "MintedMulti")
+            })
+            it("should fail to collect platform interest twice in 12 hours", async () => {
+                const { interestValidator, pool } = details
+                const tx = interestValidator.collectAndValidateInterest([pool.address])
+                await expect(tx).to.revertedWith("Cannot collect twice in 12 hours")
+            })
+            it("should fail to collect platform interest twice just before 12 hours", async () => {
+                const { interestValidator, fAsset, pool } = details
+
+                // Mint to generate some interest in the lending markets
+                await feederMachine.approveFeeder(fAsset, pool.address, 1000)
+                await pool.mint(fAsset.address, simpleToExactAmount(500), 0, sa.default.address)
+
+                // increase the test chain by 12 hours - 20 seconds
+                await increaseTime(ONE_HOUR.mul(12).sub(20))
+
+                const tx = interestValidator.collectAndValidateInterest([pool.address])
+                await expect(tx).to.revertedWith("Cannot collect twice in 12 hours")
+            })
+            it("should collect platform interest after 12 hours", async () => {
+                const { interestValidator, pool } = details
+
+                await increaseTime(ONE_MIN)
+
+                const tx = interestValidator.collectAndValidateInterest([pool.address])
+                await expect(tx).to.emit(interestValidator, "InterestCollected")
+                await expect(tx).to.emit(pool, "MintedMulti")
+            })
+        })
+    })
+    context("Collect pending fees", async () => {
+        before(async () => {
+            await runSetup()
+        })
+        it("should not collect any fees if no swaps or redemptions", async () => {
+            const { pool } = details
+            const tx = pool.connect(sa.mockInterestValidator.signer).collectPendingFees()
+            await expect(tx).to.not.emit(pool, "MintedMulti")
+        })
+        it("should collect gov fee as the interest validator", async () => {
+            const { pool, fAsset, mAsset } = details
+
+            // Swap mAsset for fAsset to generate some gov fees
+            await feederMachine.approveFeeder(mAsset, pool.address, simpleToExactAmount(10), sa.default.signer, true)
+            const swapTx = await pool.swap(mAsset.address, fAsset.address, simpleToExactAmount(10), 0, sa.default.address)
+            const swapReceipt = await swapTx.wait()
+            expect(swapReceipt.events[3].event).to.eq("Swapped")
+            const swapFee = swapReceipt.events[3].args.fee
+
+            const tx = details.pool.connect(sa.mockInterestValidator.signer).collectPendingFees()
+            await expect(tx).to.emit(pool, "MintedMulti")
+            const receipt = await (await tx).wait()
+            expect(receipt.events[1].event).to.eq("MintedMulti")
+            expect(receipt.events[1].args.minter).to.eq(details.pool.address)
+            expect(receipt.events[1].args.recipient).to.eq(sa.mockInterestValidator.address)
+            // gov fee is 10% of the swap fee - 1
+            expect(receipt.events[1].args.output).to.eq(swapFee.div(10).sub(1))
+            expect(receipt.events[1].args.inputs).to.length(0)
+            expect(receipt.events[1].args.inputQuantities).to.length(0)
+        })
+        it("should not collect any fees if already collected pending fees", async () => {
+            const { pool } = details
+            const tx = pool.connect(sa.mockInterestValidator.signer).collectPendingFees()
+            await expect(tx).to.not.emit(pool, "MintedMulti")
+        })
+        context("should fail to collect pending fees when sender is", () => {
+            it("governor", async () => {
+                await expect(details.pool.connect(sa.governor.signer).collectPendingFees()).to.revertedWith("Only validator")
+            })
+            it("default", async () => {
+                await expect(details.pool.connect(sa.default.signer).collectPendingFees()).to.revertedWith("Only validator")
+            })
+            it("fundManager", async () => {
+                await expect(details.pool.connect(sa.fundManager.signer).collectPendingFees()).to.revertedWith("Only validator")
+            })
+        })
+    })
+    describe("when going from no platform to a platform", () => {
+        let newMigration: MockPlatformIntegration
+        let transferringAsset: MockERC20
+        before(async () => {
+            await runSetup()
+            const lendingDetail = await mAssetMachine.loadATokens(details.bAssets)
+            ;[, transferringAsset] = details.bAssets
+            newMigration = await (await new MockPlatformIntegration__factory(sa.default.signer)).deploy(
+                DEAD_ADDRESS,
+                lendingDetail.aavePlatformAddress,
+                details.bAssets.map((b) => b.address),
+                lendingDetail.aTokens.map((a) => a.aToken),
+            )
+            await newMigration.addWhitelist([details.pool.address])
+        })
+        it("should migrate everything correctly", async () => {
+            const { pool } = details
+            // get balances before
+            const rawBalBefore = await (await pool.getBasset(transferringAsset.address))[1][1]
+            const integratorAddress = (await pool.getBasset(transferringAsset.address))[0][1]
+            expect(integratorAddress).eq(ZERO_ADDRESS)
+            // call migrate
+            const tx = pool.connect(sa.governor.signer).migrateBassets([transferringAsset.address], newMigration.address)
+            // emits BassetsMigrated
+            await expect(tx).to.emit(pool, "BassetsMigrated").withArgs([transferringAsset.address], newMigration.address)
+            // moves all bAssets from old to new
+            const migratedBal = await newMigration.callStatic.checkBalance(transferringAsset.address)
+            expect(migratedBal).eq(0)
+            const migratedRawBal = await transferringAsset.balanceOf(newMigration.address)
+            expect(migratedRawBal).eq(rawBalBefore)
+            // old balances should be empty
+            const newRawBal = await transferringAsset.balanceOf(pool.address)
+            expect(newRawBal).eq(0)
+            // updates the integrator address
+            const [[, newIntegratorAddress]] = await pool.getBasset(transferringAsset.address)
+            expect(newIntegratorAddress).eq(newMigration.address)
+        })
+    })
+})

--- a/test/feeders/basic-fns.spec.ts
+++ b/test/feeders/basic-fns.spec.ts
@@ -2,7 +2,7 @@ import { ethers } from "hardhat"
 import { expect } from "chai"
 
 import { assertBNClosePercent } from "@utils/assertions"
-import { simpleToExactAmount } from "@utils/math"
+import { BN, simpleToExactAmount } from "@utils/math"
 import { MassetMachine, StandardAccounts, FeederMachine, FeederDetails } from "@utils/machines"
 
 describe("Feeder Pools", () => {
@@ -10,8 +10,13 @@ describe("Feeder Pools", () => {
     let feederMachine: FeederMachine
     let feeder: FeederDetails
 
-    const runSetup = async (seedBasket = true): Promise<void> => {
-        feeder = await feederMachine.deployFeeder(seedBasket)
+    const runSetup = async (
+        useLendingMarkets = false,
+        useInterestValidator = false,
+        feederWeights?: Array<BN | number>,
+        mAssetWeights?: Array<BN | number>,
+    ): Promise<void> => {
+        feeder = await feederMachine.deployFeeder(false, feederWeights, mAssetWeights, useLendingMarkets, useInterestValidator)
     }
 
     before("Init contract", async () => {
@@ -25,7 +30,7 @@ describe("Feeder Pools", () => {
 
     describe("testing some mints", () => {
         before(async () => {
-            await runSetup(true)
+            await runSetup()
         })
         it("should mint multi locally", async () => {
             const { bAssets, pool } = feeder

--- a/test/feeders/mint.spec.ts
+++ b/test/feeders/mint.spec.ts
@@ -1,0 +1,754 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+/* eslint-disable no-await-in-loop */
+
+import { expect } from "chai"
+import { Signer } from "ethers"
+import { ethers } from "hardhat"
+
+import { BN, simpleToExactAmount } from "@utils/math"
+import { Account, FeederDetails, FeederMachine, MassetMachine, StandardAccounts } from "@utils/machines"
+import { ZERO_ADDRESS } from "@utils/constants"
+import { FeederPool, MockERC20 } from "types/generated"
+import { BassetStatus } from "@utils/mstable-objects"
+
+interface MintOutput {
+    outputQuantity: BN
+    senderBassetBalBefore: BN
+    senderBassetBalAfter: BN
+    recipientBalBefore: BN
+    recipientBalAfter: BN
+}
+
+describe("Feeder - Mint", () => {
+    let sa: StandardAccounts
+    let feederMachine: FeederMachine
+    let details: FeederDetails
+
+    const runSetup = async (
+        useLendingMarkets = false,
+        useInterestValidator = false,
+        feederWeights?: Array<BN | number>,
+        mAssetWeights?: Array<BN | number>,
+    ): Promise<void> => {
+        details = await feederMachine.deployFeeder(false, feederWeights, mAssetWeights, useLendingMarkets, useInterestValidator)
+    }
+
+    before("Init contract", async () => {
+        const accounts = await ethers.getSigners()
+        const mAssetMachine = await new MassetMachine().initAccounts(accounts)
+        feederMachine = await new FeederMachine(mAssetMachine)
+        sa = mAssetMachine.sa
+    })
+
+    const assertFailedMint = async (
+        expectedReason: string,
+        poolContract: FeederPool,
+        inputAsset: MockERC20,
+        inputAssetQuantity: BN | number | string,
+        outputExpected: BN | number | string = undefined,
+        minOutputQuantity: BN | number | string = 0,
+        sender: Signer = sa.default.signer,
+        recipient: string = sa.default.address,
+        quantitiesAreExact = true,
+        approval = true,
+    ): Promise<void> => {
+        const pool = poolContract.connect(sender)
+        if (approval) {
+            await feederMachine.approveFeeder(inputAsset, pool.address, inputAssetQuantity, sender, quantitiesAreExact)
+        }
+
+        const inputAssetDecimals = await inputAsset.decimals()
+        const inputAssetQuantityExact = quantitiesAreExact
+            ? BN.from(inputAssetQuantity)
+            : simpleToExactAmount(inputAssetQuantity, inputAssetDecimals)
+        const minOutputQuantityExact = quantitiesAreExact ? BN.from(minOutputQuantity) : simpleToExactAmount(minOutputQuantity, 18)
+
+        await expect(
+            pool.mint(inputAsset.address, inputAssetQuantityExact, minOutputQuantityExact, recipient),
+            `mint tx should revert with "${expectedReason}"`,
+        ).to.be.revertedWith(expectedReason)
+
+        if (outputExpected === undefined) {
+            await expect(
+                pool.getMintOutput(inputAsset.address, inputAssetQuantityExact),
+                `getMintOutput call should revert with "${expectedReason}"`,
+            ).to.be.revertedWith(expectedReason)
+        } else {
+            const outputExpectedExact = quantitiesAreExact ? BN.from(outputExpected) : simpleToExactAmount(outputExpected, 18)
+            const outputActual = await pool.getMintOutput(inputAsset.address, inputAssetQuantityExact)
+            expect(outputActual, "getMintOutput call output").eq(outputExpectedExact)
+        }
+    }
+
+    const assertFailedMintMulti = async (
+        expectedReason: string,
+        poolContract: FeederPool,
+        inputAssets: (MockERC20 | string)[],
+        inputAssetQuantities: (BN | number | string)[],
+        minOutputQuantity: BN | number | string = 0,
+        approval = true,
+        sender: Signer = sa.default.signer,
+        recipient: string = sa.default.address,
+        outputExpected: BN | number | string = undefined,
+        quantitiesAreExact = false,
+    ): Promise<void> => {
+        const pool = poolContract.connect(sender)
+        if (approval) {
+            const approvePromises = inputAssets.map((b, i) =>
+                typeof b === "string"
+                    ? Promise.resolve(BN.from(0))
+                    : feederMachine.approveFeeder(b, pool.address, inputAssetQuantities[i], sender, quantitiesAreExact),
+            )
+            await Promise.all(approvePromises)
+        }
+
+        const inputAssetAddresses = inputAssets.map((asset) => (typeof asset === "string" ? asset : asset.address))
+        const inputAssetDecimals = await Promise.all(
+            inputAssets.map((asset) => (typeof asset === "string" ? Promise.resolve(18) : asset.decimals())),
+        )
+
+        // Convert to exact quantities
+        const inputAssetQuantitiesExact = quantitiesAreExact
+            ? inputAssetQuantities.map((q) => BN.from(q))
+            : inputAssetQuantities.map((q, i) => simpleToExactAmount(q, inputAssetDecimals[i]))
+        const minOutputQuantityExact = quantitiesAreExact ? BN.from(minOutputQuantity) : simpleToExactAmount(minOutputQuantity, 18)
+
+        await expect(
+            pool.mintMulti(inputAssetAddresses, inputAssetQuantitiesExact, minOutputQuantityExact, recipient),
+            `mintMulti tx should revert with "${expectedReason}"`,
+        ).to.be.revertedWith(expectedReason)
+
+        if (outputExpected === undefined) {
+            await expect(
+                pool.getMintMultiOutput(inputAssetAddresses, inputAssetQuantitiesExact),
+                `getMintMultiOutput call should revert with "${expectedReason}"`,
+            ).to.be.revertedWith(expectedReason)
+        } else {
+            const outputExpectedExact = quantitiesAreExact ? BN.from(outputExpected) : simpleToExactAmount(outputExpected, 18)
+            const outputActual = await pool.getMintMultiOutput(inputAssetAddresses, inputAssetQuantitiesExact)
+            expect(outputActual, "getMintMultiOutput call output").eq(outputExpectedExact)
+        }
+    }
+
+    // Helper to assert basic minting conditions, i.e. balance before and after
+    const assertBasicMint = async (
+        fd: FeederDetails,
+        inputAsset: MockERC20,
+        inputAssetQuantity: BN | number | string = simpleToExactAmount(1),
+        outputQuantity: BN | number | string,
+        minOutputAssetQuantity: BN | number | string = 0,
+        recipient: string = sa.default.address,
+        sender: Account = sa.default,
+        quantitiesAreExact = true,
+    ): Promise<MintOutput> => {
+        const pool = fd.pool.connect(sender.signer)
+
+        // Get before balances
+        const senderAssetBalBefore = await inputAsset.balanceOf(sender.address)
+        const recipientBalBefore = await pool.balanceOf(recipient)
+        const assetBefore = await feederMachine.getAsset(details, inputAsset.address)
+
+        // Convert to exact quantities
+        const assetQuantityExact = quantitiesAreExact
+            ? BN.from(inputAssetQuantity)
+            : simpleToExactAmount(inputAssetQuantity, await inputAsset.decimals())
+        const minMassetQuantityExact = quantitiesAreExact
+            ? BN.from(minOutputAssetQuantity)
+            : simpleToExactAmount(minOutputAssetQuantity, 18)
+        const outputQuantityExact = quantitiesAreExact ? BN.from(outputQuantity) : simpleToExactAmount(outputQuantity, 18)
+
+        const platformInteraction = await feederMachine.getPlatformInteraction(pool, "deposit", assetQuantityExact, assetBefore)
+        const integratorBalBefore = await assetBefore.contract.balanceOf(
+            assetBefore.integrator ? assetBefore.integratorAddr : assetBefore.feederPoolOrMassetContract.address,
+        )
+
+        await feederMachine.approveFeeder(inputAsset, pool.address, assetQuantityExact, sender.signer, true)
+
+        const feederOutput = await pool.getMintOutput(inputAsset.address, assetQuantityExact)
+        expect(feederOutput, "mAssetOutput").to.eq(outputQuantityExact)
+
+        const tx = pool.mint(inputAsset.address, assetQuantityExact, minMassetQuantityExact, recipient)
+
+        await expect(tx, "Minted event")
+            .to.emit(pool, "Minted")
+            .withArgs(sender.address, recipient, outputQuantityExact, inputAsset.address, assetQuantityExact)
+
+        // Transfers to lending platform
+        if (!assetBefore.isMpAsset) {
+            await expect(tx, "Transfer event")
+                .to.emit(inputAsset, "Transfer")
+                .withArgs(sender.address, assetBefore.integrator ? assetBefore.integratorAddr : pool.address, assetQuantityExact)
+        }
+
+        // Mint feeder pool token
+        await expect(tx, "Transfer event").to.emit(pool, "Transfer").withArgs(ZERO_ADDRESS, recipient, outputQuantityExact)
+
+        // Deposits into lending platform
+        const integratorBalAfter = await assetBefore.contract.balanceOf(
+            assetBefore.integrator ? assetBefore.integratorAddr : assetBefore.feederPoolOrMassetContract.address,
+        )
+        // If not a main pool asset, so only a fAsset or mAsset
+        // and expecting a deposit into lending markets
+        if (!assetBefore.isMpAsset && platformInteraction.expectInteraction) {
+            await expect(tx)
+                .to.emit(fd.mAssetDetails.platform, "Deposit")
+                .withArgs(
+                    assetBefore.isMpAsset ? fd.mAsset.address : inputAsset.address,
+                    assetBefore.isMpAsset ? fd.mAsset.address : assetBefore.pToken,
+                    platformInteraction.amount,
+                )
+            // TODO this check is not working for mAssets or fAssets using a lending market
+            // expect(integratorBalAfter, "integrator balance after").eq(integratorBalBefore.add(platformInteraction.amount))
+        } else {
+            expect(integratorBalAfter, "integrator balance after").eq(integratorBalBefore.add(assetQuantityExact))
+        }
+
+        // Recipient should have pool quantity after
+        const recipientBalAfter = await pool.balanceOf(recipient)
+        expect(recipientBalAfter, "recipient balance after").eq(recipientBalBefore.add(outputQuantityExact))
+        // Sender should have less asset after
+        const senderAssetBalAfter = await inputAsset.balanceOf(sender.address)
+        expect(senderAssetBalAfter, "sender balance after").eq(senderAssetBalBefore.sub(assetQuantityExact))
+        // VaultBalance should update for this asset
+        const assetAfter = await feederMachine.getAsset(details, inputAsset.address)
+        expect(BN.from(assetAfter.vaultBalance), "vault balance after").eq(BN.from(assetBefore.vaultBalance).add(assetQuantityExact))
+
+        return {
+            outputQuantity: outputQuantityExact,
+            senderBassetBalBefore: senderAssetBalBefore,
+            senderBassetBalAfter: senderAssetBalAfter,
+            recipientBalBefore,
+            recipientBalAfter,
+        }
+    }
+
+    // Helper to assert basic minting conditions, i.e. balance before and after
+    const assertMintMulti = async (
+        fd: FeederDetails,
+        inputAssets: Array<MockERC20>,
+        inputAssetQuantities: Array<BN | number>,
+        outputQuantity: BN | number | string,
+        minOutputQuantity: BN | number | string = 0,
+        quantitiesAreExact = false,
+        recipient: string = sa.default.address,
+        sender: Account = sa.default,
+    ): Promise<void> => {
+        const { pool: poolContract } = fd
+        const pool = poolContract.connect(sender.signer)
+
+        const inputAssetAddresses = inputAssets.map((asset) => (typeof asset === "string" ? asset : asset.address))
+        const inputAssetDecimals = await Promise.all(inputAssets.map((asset) => asset.decimals()))
+
+        // Convert to exact quantities
+        const inputAssetQuantitiesExact = quantitiesAreExact
+            ? inputAssetQuantities.map((q) => BN.from(q))
+            : inputAssetQuantities.map((q, i) => simpleToExactAmount(q, inputAssetDecimals[i]))
+        const minOutputQuantityExact = quantitiesAreExact ? BN.from(minOutputQuantity) : simpleToExactAmount(minOutputQuantity, 18)
+        const outputQuantityExact = quantitiesAreExact ? BN.from(outputQuantity) : simpleToExactAmount(outputQuantity, 18)
+
+        const senderAssetsBalBefore = await Promise.all(inputAssets.map((asset) => asset.balanceOf(sender.address)))
+        const recipientBalBefore = await pool.balanceOf(recipient)
+        const assetsBefore = await Promise.all(inputAssets.map((asset) => feederMachine.getAsset(details, asset.address)))
+
+        await Promise.all(
+            inputAssets.map((a, i) => feederMachine.approveFeeder(a, pool.address, inputAssetQuantitiesExact[i], sender.signer, true)),
+        )
+
+        const feederOutput = await pool.getMintMultiOutput(inputAssetAddresses, inputAssetQuantitiesExact)
+        expect(feederOutput, "get mint multi output").to.eq(outputQuantityExact)
+
+        const tx = pool.mintMulti(inputAssetAddresses, inputAssetQuantitiesExact, minOutputQuantityExact, recipient)
+
+        await expect(tx)
+            .to.emit(pool, "MintedMulti")
+            .withArgs(sender.address, recipient, outputQuantityExact, inputAssetAddresses, inputAssetQuantitiesExact)
+
+        // Recipient should have mAsset quantity after
+        const recipientBalAfter = await pool.balanceOf(recipient)
+        expect(recipientBalAfter, "recipient balance after").eq(recipientBalBefore.add(outputQuantityExact))
+        // Sender should have less asset balance after
+        const senderAssetsBalAfter = await Promise.all(inputAssets.map((asset) => asset.balanceOf(sender.address)))
+        senderAssetsBalAfter.map((asset, i) =>
+            expect(asset, `sender ${i} balance after`).eq(senderAssetsBalBefore[i].sub(inputAssetQuantitiesExact[i])),
+        )
+
+        // VaultBalance should updated for this bAsset
+        const assetsAfter = await Promise.all(inputAssets.map((asset) => feederMachine.getAsset(details, asset.address)))
+        assetsAfter.forEach((assetAfter, i) => {
+            expect(BN.from(assetAfter.vaultBalance), "vault balance after").eq(
+                BN.from(assetsBefore[i].vaultBalance).add(inputAssetQuantitiesExact[i]),
+            )
+        })
+    }
+
+    describe("minting with a single asset", () => {
+        context("when the basket is balanced", () => {
+            context("passing invalid arguments", async () => {
+                before(async () => {
+                    await runSetup()
+                })
+                it("should fail if recipient is 0x0", async () => {
+                    await assertFailedMint(
+                        "Invalid recipient",
+                        details.pool,
+                        details.fAsset,
+                        simpleToExactAmount(1),
+                        "999987654550171574",
+                        0,
+                        sa.default.signer,
+                        ZERO_ADDRESS,
+                    )
+                })
+                it("should fail when 0 quantity", async () => {
+                    const { fAsset, pool } = details
+                    await assertFailedMint("Qty==0", pool, fAsset, 0)
+                })
+                it("should fail when sender doesn't have enough balance", async () => {
+                    const bAsset = details.bAssets[0]
+                    const sender = sa.dummy1
+                    expect(await bAsset.balanceOf(sender.address)).eq(0)
+                    await assertFailedMint(
+                        "ERC20: transfer amount exceeds balance",
+                        details.pool,
+                        bAsset,
+                        simpleToExactAmount(100),
+                        "99896928139875953237",
+                        0,
+                        sender.signer,
+                        sender.address,
+                    )
+                })
+                it("should fail to mint mStable asset when sender doesn't give approval", async () => {
+                    const { mAsset, pool } = details
+                    const sender = sa.dummy2
+                    await mAsset.transfer(sender.address, 10000)
+                    expect(await mAsset.allowance(sender.address, pool.address)).eq(0)
+                    expect(await mAsset.balanceOf(sender.address)).eq(10000)
+                    await assertFailedMint(
+                        "ERC20: transfer amount exceeds balance",
+                        pool,
+                        mAsset,
+                        simpleToExactAmount(100),
+                        "99896928139875953237",
+                        0,
+                        sender.signer,
+                        sender.address,
+                    )
+                })
+                it("should fail to mint feeder asset when sender doesn't give approval", async () => {
+                    const { fAsset, pool } = details
+                    const sender = sa.dummy2
+                    await fAsset.transfer(sender.address, 10000)
+                    expect(await fAsset.allowance(sender.address, pool.address)).eq(0)
+                    expect(await fAsset.balanceOf(sender.address)).eq(10000)
+                    await assertFailedMint(
+                        "ERC20: transfer amount exceeds balance",
+                        pool,
+                        fAsset,
+                        simpleToExactAmount(100),
+                        "99896928139875953237",
+                        0,
+                        sender.signer,
+                        sender.address,
+                    )
+                })
+                it("should fail when the asset does not exist", async () => {
+                    const newBasset = await feederMachine.mAssetMachine.loadBassetProxy("Mock", "MKK", 18, sa.default.address, 1000)
+                    await assertFailedMint("Invalid asset", details.pool, newBasset, 1)
+                })
+                it("should fail to mint if too much slippage", async () => {
+                    await assertFailedMint(
+                        "Mint quantity < min qty",
+                        details.pool,
+                        details.bAssets[0],
+                        simpleToExactAmount(1),
+                        "999987654550171574",
+                        simpleToExactAmount(1),
+                    )
+                })
+                context("when feeder pool is paused", () => {
+                    before(async () => {
+                        const { pool } = details
+                        expect(await pool.paused(), "before pause").to.be.false
+                        await pool.connect(sa.governor.signer).pause()
+                        expect(await pool.paused(), "after pause").to.be.true
+                    })
+                    after(async () => {
+                        const { pool } = details
+                        expect(await pool.paused(), "before unpause").to.be.true
+                        await pool.connect(sa.governor.signer).unpause()
+                        expect(await pool.paused(), "after unpause").to.be.false
+                    })
+                    it("should fail to mint feeder asset", async () => {
+                        await assertFailedMint("Unhealthy", details.pool, details.fAsset, simpleToExactAmount(1), "999987654550171574")
+                    })
+                    it("should fail to mint mStable asset", async () => {
+                        await assertFailedMint("Unhealthy", details.pool, details.mAsset, simpleToExactAmount(1), "999987654550171574")
+                    })
+                    it("should fail to mint a main pool assets", async () => {
+                        await assertFailedMint("Unhealthy", details.pool, details.bAssets[0], simpleToExactAmount(1), "999987654550171574")
+                    })
+                })
+            })
+            context("using bAssets with no transfer fees", async () => {
+                context("reset before each", () => {
+                    beforeEach(async () => {
+                        await runSetup()
+                    })
+                    it("should mint a single mStable asset", async () => {
+                        await assertBasicMint(details, details.mAsset, simpleToExactAmount(1), "999987654550171574")
+                    })
+                    it("should mint a single feeder asset", async () => {
+                        await assertBasicMint(details, details.fAsset, simpleToExactAmount(1), "999987654550171574")
+                    })
+                    it("should mint a single main pool asset", async () => {
+                        await assertBasicMint(details, details.mAssetDetails.bAssets[0], simpleToExactAmount(1), "999986169784657127")
+                    })
+                    it("should mint the smallest unit of fp token", async () => {
+                        await assertBasicMint(details, details.fAsset, 1, 1, 1)
+                    })
+                })
+                context("when a main pool asset has broken below peg", () => {
+                    before(async () => {
+                        await runSetup()
+                    })
+                    before(async () => {
+                        const { mAsset, mAssetDetails } = details
+                        await mAsset.connect(sa.governor.signer).handlePegLoss(mAssetDetails.bAssets[0].address, true)
+                        const newBasset = await mAsset.getBasset(mAssetDetails.bAssets[0].address)
+                        expect(newBasset.personal.status).to.eq(BassetStatus.BrokenBelowPeg)
+                    })
+                    after(async () => {
+                        const { mAsset, mAssetDetails } = details
+                        await mAsset.connect(sa.governor.signer).negateIsolation(mAssetDetails.bAssets[0].address)
+                        const newBasset = await mAsset.getBasset(mAssetDetails.bAssets[0].address)
+                        expect(newBasset.personal.status).to.eq(BassetStatus.Normal)
+                    })
+                    it("should fail to mint a main pool asset", async () => {
+                        await assertFailedMint(
+                            "VM Exception while processing transaction: revert",
+                            details.pool,
+                            details.mAssetDetails.bAssets[0],
+                            simpleToExactAmount(1),
+                            "999986169784657127",
+                        )
+                    })
+                    it("should mint a single mStable asset", async () => {
+                        await assertBasicMint(details, details.mAsset, simpleToExactAmount(1), "999987654550171574")
+                    })
+                    it("should mint a single feeder asset", async () => {
+                        await assertBasicMint(details, details.fAsset, simpleToExactAmount(1), "1000012345449828426")
+                    })
+                })
+            })
+        })
+        context("when the basket is 95% mAsset, 5% fAsset", () => {
+            beforeEach(async () => {
+                await runSetup(false, false, [950, 50])
+            })
+            it("should mint the smallest unit of mAsset", async () => {
+                await assertBasicMint(details, details.mAsset, 1, 1, 1)
+            })
+            it("should mint mAsset to just under max weight", async () => {
+                await assertBasicMint(details, details.mAsset, simpleToExactAmount(650), "614493814881213241322")
+            })
+            it("should fail mint mAsset over max weight", async () => {
+                await assertFailedMint("Exceeds weight limits", details.pool, details.mAsset, simpleToExactAmount(1000))
+            })
+            context("mAsset is overweight", () => {
+                beforeEach(async () => {
+                    // set new weight limits to 10% and 90% so the mAsset is overweight
+                    await details.pool.connect(sa.governor.signer).setWeightLimits(simpleToExactAmount(10, 16), simpleToExactAmount(90, 16))
+                })
+                it("should fail to mint the overweight mAsset", async () => {
+                    await assertFailedMint("Exceeds weight limits", details.pool, details.mAsset, 1)
+                })
+                it("should fail to mint fAsset if mAsset is still overweight", async () => {
+                    await assertFailedMint("Exceeds weight limits", details.pool, details.mAsset, simpleToExactAmount(1))
+                })
+                it("should mint fAsset so mAsset is underweight", async () => {
+                    await assertBasicMint(details, details.fAsset, simpleToExactAmount(200), "216835953177287466623")
+                })
+            })
+        })
+        context("when using lending markets", async () => {
+            context("deposit to lending markets", () => {
+                beforeEach(async () => {
+                    // Use lending market
+                    await runSetup(true)
+                })
+                it("should mint a single mStable asset", async () => {
+                    await assertBasicMint(details, details.mAsset, simpleToExactAmount(500), "498023970010016562116")
+                })
+                it("should mint a single feeder asset", async () => {
+                    await assertBasicMint(details, details.fAsset, simpleToExactAmount(500), "498023970010016562116")
+                })
+                it("should mint a single main pool asset", async () => {
+                    await assertBasicMint(details, details.mAssetDetails.bAssets[0], simpleToExactAmount(500), "497690614261621180942")
+                })
+            })
+        })
+    })
+    describe("minting with multiple bAssets", () => {
+        context("when the weights are within the ForgeValidator limit", () => {
+            context("passing invalid arguments", async () => {
+                before(async () => {
+                    await runSetup()
+                })
+                it("should fail to multi mint if recipient is 0x0", async () => {
+                    await assertFailedMintMulti(
+                        "Invalid recipient",
+                        details.pool,
+                        details.bAssets,
+                        [1, 1],
+                        0,
+                        true,
+                        sa.default.signer,
+                        ZERO_ADDRESS,
+                        2,
+                        false,
+                    )
+                })
+                context("with incorrect bAsset array", async () => {
+                    it("should fail if both input arrays are empty", async () => {
+                        await assertFailedMintMulti("Input array mismatch", details.pool, [], [])
+                    })
+                    it("should fail if the bAsset input array is empty", async () => {
+                        await assertFailedMintMulti("Input array mismatch", details.pool, [], [1])
+                    })
+                    it("should fail if there is a length mismatch", async () => {
+                        await assertFailedMintMulti("Input array mismatch", details.pool, [details.bAssets[0].address], [1, 1])
+                    })
+                    it("should fail if there is a length mismatch", async () => {
+                        await assertFailedMintMulti("Input array mismatch", details.pool, [details.bAssets[0].address], [1, 1, 1, 1])
+                    })
+                    it("should fail if there are duplicate bAsset addresses", async () => {
+                        const { bAssets } = details
+                        await assertFailedMintMulti("Duplicate asset", details.pool, [bAssets[0].address, bAssets[0].address], [1, 1])
+                    })
+                    it("should multi mint a single main pool asset", async () => {
+                        await assertFailedMintMulti("Invalid asset", details.pool, [details.mAssetDetails.bAssets[0]], [1])
+                    })
+                })
+                context("when all quantities are zero", () => {
+                    it("should fail to mint fAsset and mAsset", async () => {
+                        await assertFailedMintMulti(
+                            "Zero mAsset quantity",
+                            details.pool,
+                            details.bAssets,
+                            [0, 0],
+                            0,
+                            true,
+                            sa.default.signer,
+                            sa.default.address,
+                            0,
+                        )
+                    })
+                    it("should fail to mint feeder asset", async () => {
+                        await assertFailedMintMulti(
+                            "Zero mAsset quantity",
+                            details.pool,
+                            [details.fAsset],
+                            [0],
+                            0,
+                            true,
+                            sa.default.signer,
+                            sa.default.address,
+                            0,
+                        )
+                    })
+                    it("should fail to mint mStable asset", async () => {
+                        await assertFailedMintMulti(
+                            "Zero mAsset quantity",
+                            details.pool,
+                            [details.mAsset],
+                            [0],
+                            0,
+                            true,
+                            sa.default.signer,
+                            sa.default.address,
+                            0,
+                        )
+                    })
+                })
+                it("should fail to multi mint if slippage just too big", async () => {
+                    const { bAssets, pool } = details
+                    const bAsset = bAssets[0]
+                    const sender = sa.default
+                    await feederMachine.approveFeeder(bAsset, pool.address, 101, sender.signer)
+                    await assertFailedMintMulti(
+                        "Mint quantity < min qty",
+                        pool,
+                        [bAsset.address],
+                        ["100000000000000000000"], // 100
+                        "100000000000000000001", // just over 100
+                        true,
+                        sender.signer,
+                        sender.address,
+                        "99896928139875953237", // 100
+                        true,
+                    )
+                })
+                it("should fail if sender doesn't have balance", async () => {
+                    const { bAssets, pool } = details
+                    const bAsset = bAssets[0]
+                    const sender = sa.dummy2
+                    expect(await bAsset.balanceOf(sender.address)).eq(0)
+                    await assertFailedMintMulti(
+                        "ERC20: transfer amount exceeds balance",
+                        pool,
+                        bAssets,
+                        [100, 100],
+                        0,
+                        false,
+                        sender.signer,
+                        sender.address,
+                        200,
+                        false,
+                    )
+                })
+                it("should fail when sender doesn't have enough balance", async () => {
+                    const { bAssets, pool } = details
+                    const bAsset = bAssets[0]
+                    const sender = sa.dummy1
+                    expect(await bAsset.balanceOf(sender.address)).eq(0)
+                    await assertFailedMintMulti(
+                        "ERC20: transfer amount exceeds balance",
+                        pool,
+                        bAssets,
+                        [100, 100],
+                        0,
+                        true,
+                        sender.signer,
+                        sender.address,
+                        200,
+                        false,
+                    )
+                })
+                it("should fail to mint mStable asset when sender doesn't give approval", async () => {
+                    const { bAssets, mAsset, pool } = details
+                    const sender = sa.dummy2
+                    await mAsset.transfer(sender.address, 10000)
+                    expect(await mAsset.allowance(sender.address, pool.address)).eq(0)
+                    expect(await mAsset.balanceOf(sender.address)).eq(10000)
+                    await assertFailedMintMulti(
+                        "ERC20: transfer amount exceeds balance",
+                        pool,
+                        bAssets,
+                        [100, 100],
+                        0,
+                        false,
+                        sender.signer,
+                        sender.address,
+                        200,
+                        false,
+                    )
+                })
+                it("should fail to mint feeder asset when sender doesn't give approval", async () => {
+                    const { bAssets, fAsset, pool } = details
+                    const sender = sa.dummy2
+                    await fAsset.transfer(sender.address, 10000)
+                    expect(await fAsset.allowance(sender.address, pool.address)).eq(0)
+                    expect(await fAsset.balanceOf(sender.address)).eq(10000)
+                    await assertFailedMintMulti(
+                        "ERC20: transfer amount exceeds balance",
+                        pool,
+                        bAssets,
+                        [100, 100],
+                        0,
+                        false,
+                        sender.signer,
+                        sender.address,
+                        200,
+                        false,
+                    )
+                })
+                it("should fail when the asset does not exist", async () => {
+                    const newBasset = await feederMachine.mAssetMachine.loadBassetProxy("Mock", "MKK", 18, sa.default.address, 1000)
+                    await assertFailedMintMulti("Invalid asset", details.pool, [newBasset], [1])
+                })
+                context("when feeder pool is paused", () => {
+                    before(async () => {
+                        const { pool } = details
+                        expect(await pool.paused(), "before pause").to.be.false
+                        await pool.connect(sa.governor.signer).pause()
+                        expect(await pool.paused(), "after pause").to.be.true
+                    })
+                    after(async () => {
+                        const { pool } = details
+                        expect(await pool.paused(), "before unpause").to.be.true
+                        await pool.connect(sa.governor.signer).unpause()
+                        expect(await pool.paused(), "after unpause").to.be.false
+                    })
+                    it("should fail to multi mint feeder asset", async () => {
+                        await assertFailedMintMulti(
+                            "Unhealthy",
+                            details.pool,
+                            [details.fAsset],
+                            [simpleToExactAmount(1)],
+                            0,
+                            true,
+                            sa.default.signer,
+                            sa.default.address,
+                            "999987654550171574",
+                            true,
+                        )
+                    })
+                    it("should fail to multi mint mStable asset", async () => {
+                        await assertFailedMintMulti(
+                            "Unhealthy",
+                            details.pool,
+                            [details.mAsset],
+                            [simpleToExactAmount(1)],
+                            0,
+                            true,
+                            sa.default.signer,
+                            sa.default.address,
+                            "999987654550171574",
+                            true,
+                        )
+                    })
+                })
+            })
+            context("using bAssets with no transfer fees", async () => {
+                context("reset before each", () => {
+                    beforeEach(async () => {
+                        await runSetup()
+                    })
+                    it("should multi mint a single mStable asset", async () => {
+                        await assertMintMulti(details, [details.mAsset], [simpleToExactAmount(1)], "999987654550171574", 0, true)
+                    })
+                    it("should multi mint a single feeder asset", async () => {
+                        await assertMintMulti(details, [details.fAsset], [simpleToExactAmount(1)], "999987654550171574", 0, true)
+                    })
+                })
+                context("when a main pool asset has broken below peg", () => {
+                    before(async () => {
+                        await runSetup()
+                    })
+                    before(async () => {
+                        const { mAsset, mAssetDetails } = details
+                        await mAsset.connect(sa.governor.signer).handlePegLoss(mAssetDetails.bAssets[0].address, true)
+                        const newBasset = await mAsset.getBasset(mAssetDetails.bAssets[0].address)
+                        expect(newBasset.personal.status).to.eq(BassetStatus.BrokenBelowPeg)
+                    })
+                    after(async () => {
+                        const { mAsset, mAssetDetails } = details
+                        await mAsset.connect(sa.governor.signer).negateIsolation(mAssetDetails.bAssets[0].address)
+                        const newBasset = await mAsset.getBasset(mAssetDetails.bAssets[0].address)
+                        expect(newBasset.personal.status).to.eq(BassetStatus.Normal)
+                    })
+                    it("should multi mint a single mStable asset", async () => {
+                        await assertMintMulti(details, [details.mAsset], [simpleToExactAmount(1)], "999987654550171574", 0, true)
+                    })
+                    it("should multi mint a single feeder asset", async () => {
+                        await assertMintMulti(details, [details.fAsset], [simpleToExactAmount(1)], "1000012345449828426", 0, true)
+                    })
+                    it("should multi mint mStable and feeder assets", async () => {
+                        await assertMintMulti(details, details.bAssets, [1, 1], 2)
+                    })
+                })
+            })
+        })
+    })
+})

--- a/test/feeders/redeem.spec.ts
+++ b/test/feeders/redeem.spec.ts
@@ -1,0 +1,844 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+/* eslint-disable no-await-in-loop */
+
+import { expect } from "chai"
+import { Signer } from "ethers"
+import { ethers } from "hardhat"
+
+import { BN, simpleToExactAmount } from "@utils/math"
+import { Account, FeederDetails, FeederMachine, MassetMachine, StandardAccounts } from "@utils/machines"
+import { ZERO_ADDRESS } from "@utils/constants"
+import { FeederPool, Masset, MockERC20 } from "types/generated"
+import { BassetStatus } from "@utils/mstable-objects"
+
+interface RedeemOutput {
+    outputQuantity: BN
+    senderBassetBalBefore: BN
+    senderBassetBalAfter: BN
+    recipientBalBefore: BN
+    recipientBalAfter: BN
+}
+
+describe("Feeder - Redeem", () => {
+    let sa: StandardAccounts
+    let feederMachine: FeederMachine
+    let details: FeederDetails
+
+    const runSetup = async (
+        useLendingMarkets = false,
+        useInterestValidator = false,
+        feederWeights?: Array<BN | number>,
+        mAssetWeights?: Array<BN | number>,
+    ): Promise<void> => {
+        details = await feederMachine.deployFeeder(false, feederWeights, mAssetWeights, useLendingMarkets, useInterestValidator)
+    }
+
+    before("Init contract", async () => {
+        const accounts = await ethers.getSigners()
+        const mAssetMachine = await new MassetMachine().initAccounts(accounts)
+        feederMachine = await new FeederMachine(mAssetMachine)
+        sa = mAssetMachine.sa
+    })
+
+    const assertFailedRedeem = async (
+        expectedReason: string,
+        poolContract: FeederPool,
+        outputAsset: MockERC20,
+        fpTokenQuantity: BN | number | string,
+        outputExpected: BN | number | string = undefined,
+        minOutputQuantity: BN | number | string = 0,
+        sender: Signer = sa.default.signer,
+        recipient: string = sa.default.address,
+        quantitiesAreExact = true,
+    ): Promise<void> => {
+        const pool = poolContract.connect(sender)
+
+        const outputAssetDecimals = await outputAsset.decimals()
+        const fpTokenQuantityExact = quantitiesAreExact
+            ? BN.from(fpTokenQuantity)
+            : simpleToExactAmount(fpTokenQuantity, outputAssetDecimals)
+        const minOutputQuantityExact = quantitiesAreExact ? BN.from(minOutputQuantity) : simpleToExactAmount(minOutputQuantity, 18)
+
+        await expect(
+            pool.redeem(outputAsset.address, fpTokenQuantityExact, minOutputQuantityExact, recipient),
+            `redeem tx should revert with "${expectedReason}"`,
+        ).to.be.revertedWith(expectedReason)
+
+        if (outputExpected === undefined) {
+            await expect(
+                pool.getRedeemOutput(outputAsset.address, fpTokenQuantityExact),
+                `getRedeemOutput call should revert with "${expectedReason}"`,
+            ).to.be.revertedWith(expectedReason)
+        } else {
+            const outputExpectedExact = quantitiesAreExact ? BN.from(outputExpected) : simpleToExactAmount(outputExpected, 18)
+            const outputActual = await pool.getRedeemOutput(outputAsset.address, fpTokenQuantityExact)
+            expect(outputActual, "getRedeemOutput call output").eq(outputExpectedExact)
+        }
+    }
+
+    const assertFailedRedeemExact = async (
+        expectedReason: string,
+        poolContract: FeederPool,
+        outputAssets: (MockERC20 | string)[],
+        outputQuantities: (BN | number | string)[],
+        fpTokenQuantityExpected: BN | number | string = undefined,
+        maxFpTokenQuantity: BN | number | string = simpleToExactAmount(100),
+        sender: Signer = sa.default.signer,
+        recipient: string = sa.default.address,
+        quantitiesAreExact = true,
+    ): Promise<void> => {
+        const pool = poolContract.connect(sender)
+
+        const outputAssetAddresses = outputAssets.map((asset) => (typeof asset === "string" ? asset : asset.address))
+        const outputAssetDecimals = await Promise.all(
+            outputAssets.map((asset) => (typeof asset === "string" ? Promise.resolve(18) : asset.decimals())),
+        )
+
+        // Convert to exact quantities
+        const outputQuantitiesExact = quantitiesAreExact
+            ? outputQuantities.map((q) => BN.from(q))
+            : outputQuantities.map((q, i) => simpleToExactAmount(q, outputAssetDecimals[i]))
+        const maxFpTokenQuantityExact = quantitiesAreExact ? BN.from(maxFpTokenQuantity) : simpleToExactAmount(maxFpTokenQuantity)
+
+        await expect(
+            pool.redeemExactBassets(outputAssetAddresses, outputQuantitiesExact, maxFpTokenQuantityExact, recipient),
+            `redeem exact tx should revert with "${expectedReason}"`,
+        ).to.be.revertedWith(expectedReason)
+
+        if (fpTokenQuantityExpected === undefined) {
+            await expect(
+                pool.getRedeemExactBassetsOutput(outputAssetAddresses, outputQuantitiesExact),
+                `redeem exact call should revert with "${expectedReason}"`,
+            ).to.be.revertedWith(expectedReason)
+        } else {
+            const fpTokenQuantityExpectedExact = quantitiesAreExact
+                ? BN.from(fpTokenQuantityExpected)
+                : simpleToExactAmount(fpTokenQuantityExpected)
+            const fpTokenQuantityActual = await pool.getRedeemExactBassetsOutput(outputAssetAddresses, outputQuantitiesExact)
+            expect(fpTokenQuantityActual, "redeem exact fp token qty").eq(fpTokenQuantityExpectedExact)
+        }
+    }
+
+    const assertFailedRedeemProportionately = async (
+        expectedReason: string,
+        poolContract: FeederPool,
+        fpTokenQuantity: BN | number | string,
+        minOutputQuantities: [BN | number | string, BN | number | string] = [0, 0],
+        sender: Signer = sa.default.signer,
+        recipient: string = sa.default.address,
+        quantitiesAreExact = true,
+    ): Promise<void> => {
+        const pool = poolContract.connect(sender)
+
+        const fpTokenQuantityExact = quantitiesAreExact ? BN.from(fpTokenQuantity) : simpleToExactAmount(fpTokenQuantity)
+        const minOutputQuantityExact = minOutputQuantities.map((qty) => (quantitiesAreExact ? BN.from(qty) : simpleToExactAmount(qty)))
+
+        await expect(
+            pool.redeemProportionately(fpTokenQuantityExact, minOutputQuantityExact, recipient),
+            `redeemProportionately tx should revert with "${expectedReason}"`,
+        ).to.be.revertedWith(expectedReason)
+    }
+
+    const assertBasicRedeem = async (
+        fd: FeederDetails,
+        outputAsset: MockERC20,
+        fpTokenQuantity: BN | number | string = simpleToExactAmount(1),
+        outputQuantityExpected: BN | number | string = -1,
+        minOutputQuantity: BN | number | string = 0,
+        recipient: string = sa.default.address,
+        sender: Account = sa.default,
+        quantitiesAreExact = true,
+    ): Promise<RedeemOutput> => {
+        const pool = fd.pool.connect(sender.signer)
+
+        const outputAssetDecimals = await outputAsset.decimals()
+
+        // Get before balances
+        const senderFpTokenBalBefore = await pool.balanceOf(sender.address)
+        const recipientBalBefore = await outputAsset.balanceOf(recipient)
+        const assetBefore = await feederMachine.getAsset(details, outputAsset.address)
+
+        // Convert to exact quantities
+        const fpTokenQuantityExact = quantitiesAreExact ? BN.from(fpTokenQuantity) : simpleToExactAmount(fpTokenQuantity)
+        const minOutputQuantityExact = quantitiesAreExact
+            ? BN.from(minOutputQuantity)
+            : simpleToExactAmount(minOutputQuantity, outputAssetDecimals)
+        const outputQuantityExpectedExact = quantitiesAreExact
+            ? BN.from(outputQuantityExpected)
+            : simpleToExactAmount(outputQuantityExpected, outputAssetDecimals)
+
+        const platformInteraction = await feederMachine.getPlatformInteraction(pool, "withdrawal", fpTokenQuantityExact, assetBefore)
+        const integratorBalBefore = await assetBefore.contract.balanceOf(
+            assetBefore.integrator ? assetBefore.integratorAddr : assetBefore.feederPoolOrMassetContract.address,
+        )
+
+        const outputActual = await pool.getRedeemOutput(outputAsset.address, fpTokenQuantityExact)
+        if (outputQuantityExpectedExact.gte(0)) {
+            expect(outputActual, "redeem output").to.eq(outputQuantityExpectedExact)
+        }
+
+        const tx = pool.redeem(outputAsset.address, fpTokenQuantityExact, minOutputQuantityExact, recipient)
+        const receipt = await (await tx).wait()
+
+        await expect(tx, "Redeem event").to.emit(pool, "Redeemed")
+        // TODO replace when Waffle supports withNamedArgs
+        const redeemEvent = receipt.events.find((event) => event.event === "Redeemed" && event.address === pool.address)
+        expect(redeemEvent).to.exist
+        expect(redeemEvent.args.redeemer, "redeemer in Redeemer event").to.eq(sender.address)
+        expect(redeemEvent.args.recipient, "recipient in Redeemer event").to.eq(recipient)
+        expect(redeemEvent.args.mAssetQuantity, "mAssetQuantity in Redeemer event").to.eq(fpTokenQuantityExact)
+        expect(redeemEvent.args.output, "output in Redeemer event").to.eq(outputAsset.address)
+        if (outputQuantityExpectedExact.gte(0)) {
+            expect(redeemEvent.args.outputQuantity, "outputQuantity in Redeemer event").to.eq(outputQuantityExpectedExact)
+        }
+        expect(redeemEvent.args.scaledFee, "scaledFee in Redeemer event").to.gt(0)
+
+        // Burn feeder pool token
+        await expect(tx, "Transfer event").to.emit(pool, "Transfer").withArgs(sender.address, ZERO_ADDRESS, fpTokenQuantityExact)
+
+        // Transfers from lending platform or feeder pool to recipient
+        await expect(tx, "Transfer event")
+            .to.emit(outputAsset, "Transfer")
+            .withArgs(
+                assetBefore.integrator ? assetBefore.integratorAddr : assetBefore.feederPoolOrMassetContract.address,
+                recipient,
+                outputQuantityExpectedExact,
+            )
+
+        // Withdraw from lending platform, feeder pool or main pool
+        const integratorBalAfter = await assetBefore.contract.balanceOf(
+            assetBefore.integrator ? assetBefore.integratorAddr : assetBefore.feederPoolOrMassetContract.address,
+        )
+        // TODO Expected "199000412397088284203" to be equal 199000000000000000000
+        // ALEX - should be outputQuantityExpectedExact?
+        expect(integratorBalAfter, "integrator balance after").eq(integratorBalBefore.sub(outputQuantityExpected))
+        if (platformInteraction.expectInteraction) {
+            await expect(tx)
+                .to.emit(fd.mAssetDetails.platform, "Withdraw")
+                .withArgs(outputAsset.address, assetBefore.pToken, platformInteraction.amount)
+        }
+
+        // Recipient should have redeemed asset after
+        const recipientBalAfter = await outputAsset.balanceOf(recipient)
+        expect(recipientBalAfter, "recipient balance after").eq(recipientBalBefore.add(outputQuantityExpectedExact))
+        // Sender should have less asset after
+        const senderFpTokenBalAfter = await pool.balanceOf(sender.address)
+        expect(senderFpTokenBalAfter, "sender balance after").eq(senderFpTokenBalBefore.sub(fpTokenQuantityExact))
+        // VaultBalance should update for this asset
+        const assetAfter = await feederMachine.getAsset(details, outputAsset.address)
+        expect(BN.from(assetAfter.vaultBalance), "vault balance after").eq(
+            BN.from(assetBefore.vaultBalance).sub(outputQuantityExpectedExact),
+        )
+
+        return {
+            outputQuantity: outputQuantityExpectedExact,
+            senderBassetBalBefore: senderFpTokenBalBefore,
+            senderBassetBalAfter: senderFpTokenBalAfter,
+            recipientBalBefore,
+            recipientBalAfter,
+        }
+    }
+
+    const assertRedeemExact = async (
+        fd: FeederDetails,
+        outputAssets: Array<MockERC20>,
+        outputQuantities: Array<BN | number>,
+        inputQuantityExpected: BN | number | string,
+        maxFpTokenQuantity: BN | number | string = simpleToExactAmount(100),
+        recipient: string = sa.default.address,
+        sender: Account = sa.default,
+        quantitiesAreExact = true,
+    ): Promise<void> => {
+        const { pool: poolContract } = fd
+        const pool = poolContract.connect(sender.signer)
+
+        const outputAssetAddresses = outputAssets.map((asset) => asset.address)
+        const outputAssetDecimals = await Promise.all(outputAssets.map((asset) => asset.decimals()))
+
+        // Convert to exact quantities
+        const outputQuantitiesExact = quantitiesAreExact
+            ? outputQuantities.map((q) => BN.from(q))
+            : outputQuantities.map((q, i) => simpleToExactAmount(q, outputAssetDecimals[i]))
+        const maxFpTokenQuantityExact = quantitiesAreExact ? BN.from(maxFpTokenQuantity) : simpleToExactAmount(maxFpTokenQuantity)
+        const inputQuantityExpectedExact = quantitiesAreExact ? BN.from(inputQuantityExpected) : simpleToExactAmount(inputQuantityExpected)
+
+        const senderAssetsBalBefore = await pool.balanceOf(sender.address)
+        const recipientOutputBalancesBefore = await Promise.all(outputAssets.map((b) => b.balanceOf(recipient)))
+        const assetsBefore = await Promise.all(outputAssets.map((asset) => feederMachine.getAsset(details, asset.address)))
+
+        const inputQuantityActual = await pool.getRedeemExactBassetsOutput(outputAssetAddresses, outputQuantitiesExact)
+        expect(inputQuantityActual, "get redeem exact input").to.eq(inputQuantityExpectedExact)
+
+        const tx = pool.redeemExactBassets(outputAssetAddresses, outputQuantitiesExact, maxFpTokenQuantityExact, recipient)
+        const receipt = await (await tx).wait()
+
+        await expect(tx).to.emit(pool, "RedeemedMulti")
+        // TODO replace when Waffle supports withNamedArgs
+        const redeemEvent = receipt.events.find((event) => event.event === "RedeemedMulti" && event.address === pool.address)
+        expect(redeemEvent).to.exist
+        expect(redeemEvent.args.redeemer, "redeemer in RedeemedMulti event").to.eq(sender.address)
+        expect(redeemEvent.args.recipient, "recipient in RedeemedMulti event").to.eq(recipient)
+        expect(redeemEvent.args.mAssetQuantity, "mAssetQuantity in RedeemedMulti event").to.eq(inputQuantityExpectedExact)
+        expect(redeemEvent.args.outputs, "outputs in RedeemedMulti event").to.deep.eq(outputAssetAddresses)
+        expect(redeemEvent.args.outputQuantity, "outputQuantity in RedeemedMulti event").to.deep.eq(outputQuantitiesExact)
+
+        // Recipient should have mAsset quantity after
+        const recipientOutputBalancesAfter = await Promise.all(outputAssets.map((b) => b.balanceOf(recipient)))
+        recipientOutputBalancesAfter.forEach((balanceAfter, i) => {
+            expect(balanceAfter, `recipient asset[${i}] balance after`).eq(recipientOutputBalancesBefore[i].add(outputQuantitiesExact[i]))
+        })
+
+        // Sender should have less feeder pool tokens after
+        const senderAssetsBalAfter = await pool.balanceOf(sender.address)
+        expect(senderAssetsBalAfter, `sender fp tokens after`).eq(senderAssetsBalBefore.sub(inputQuantityExpected))
+
+        // VaultBalance should updated for this bAsset
+        const assetsAfter = await Promise.all(outputAssets.map((asset) => feederMachine.getAsset(details, asset.address)))
+        assetsAfter.forEach((assetAfter, i) => {
+            expect(BN.from(assetAfter.vaultBalance), "vault balance after").eq(
+                BN.from(assetsBefore[i].vaultBalance).sub(outputQuantitiesExact[i]),
+            )
+        })
+    }
+
+    const assertRedeemProportionately = async (
+        fd: FeederDetails,
+        fpTokenQuantity: BN | number | string = simpleToExactAmount(1),
+        outputQuantitiesExpected: (BN | number | string)[] = undefined,
+        minOutputQuantities: (BN | number | string)[] = [0, 0],
+        recipient: string = sa.default.address,
+        sender: Account = sa.default,
+        quantitiesAreExact = true,
+    ): Promise<void> => {
+        const { bAssets } = fd
+        const pool = fd.pool.connect(sender.signer)
+
+        const outputAssetAddresses = bAssets.map((asset) => asset.address)
+        const outputAssetDecimals = await Promise.all(bAssets.map((asset) => asset.decimals()))
+
+        // Get before balances
+        const senderFpTokenBalBefore = await pool.balanceOf(sender.address)
+        const recipientOutputBalancesBefore = await Promise.all(bAssets.map((b) => b.balanceOf(recipient)))
+        const assetsBefore = await Promise.all(bAssets.map((asset) => feederMachine.getAsset(details, asset.address)))
+
+        // Convert to exact quantities
+        const fpTokenQuantityExact = quantitiesAreExact ? BN.from(fpTokenQuantity) : simpleToExactAmount(fpTokenQuantity)
+        const minOutputQuantitiesExact = minOutputQuantities.map((qty) => (quantitiesAreExact ? BN.from(qty) : simpleToExactAmount(qty)))
+        const outputQuantitiesExpectedExact = outputQuantitiesExpected.map((qty, i) =>
+            quantitiesAreExact ? BN.from(qty) : simpleToExactAmount(qty, outputAssetDecimals[i]),
+        )
+
+        const tx = pool.redeemProportionately(fpTokenQuantityExact, minOutputQuantitiesExact, recipient)
+        const receipt = await (await tx).wait()
+
+        await expect(tx).to.emit(pool, "RedeemedMulti")
+        // TODO replace when Waffle supports withNamedArgs
+        const redeemEvent = receipt.events.find((event) => event.event === "RedeemedMulti" && event.address === pool.address)
+        expect(redeemEvent).to.exist
+        expect(redeemEvent.args.redeemer, "redeemer in RedeemedMulti event").to.eq(sender.address)
+        expect(redeemEvent.args.recipient, "recipient in RedeemedMulti event").to.eq(recipient)
+        expect(redeemEvent.args.mAssetQuantity, "mAssetQuantity in RedeemedMulti event").to.eq(fpTokenQuantityExact)
+        expect(redeemEvent.args.outputs, "outputs in RedeemedMulti event").to.deep.eq(outputAssetAddresses)
+        expect(redeemEvent.args.outputQuantity, "outputQuantity in RedeemedMulti event").to.deep.eq(outputQuantitiesExpectedExact)
+        expect(redeemEvent.args.scaledFee, "scaledFee in RedeemedMulti event").to.gt(0)
+
+        // Recipient should have asset quantity after
+        const recipientOutputBalancesAfter = await Promise.all(bAssets.map((b) => b.balanceOf(recipient)))
+        recipientOutputBalancesAfter.forEach((balanceAfter, i) => {
+            expect(balanceAfter, `recipient asset[${i}] balance after`).eq(
+                recipientOutputBalancesBefore[i].add(outputQuantitiesExpected[i]),
+            )
+        })
+
+        // Sender should have less feeder pool tokens after
+        const senderAssetsBalAfter = await pool.balanceOf(sender.address)
+        expect(senderAssetsBalAfter, `sender fp tokens after`).eq(senderFpTokenBalBefore.sub(fpTokenQuantity))
+
+        // VaultBalance should updated for this bAsset
+        const assetsAfter = await Promise.all(bAssets.map((asset) => feederMachine.getAsset(details, asset.address)))
+        assetsAfter.forEach((assetAfter, i) => {
+            expect(BN.from(assetAfter.vaultBalance), "vault balance after").eq(
+                BN.from(assetsBefore[i].vaultBalance).sub(outputQuantitiesExpectedExact[i]),
+            )
+        })
+    }
+
+    describe("Redeeming with a single asset", () => {
+        context("when the basket is balanced", () => {
+            context("passing invalid arguments", async () => {
+                before(async () => {
+                    await runSetup()
+                })
+                it("should fail if recipient is 0x0", async () => {
+                    const { pool, fAsset } = details
+                    await assertFailedRedeem(
+                        "Invalid recipient",
+                        pool,
+                        fAsset,
+                        simpleToExactAmount(1),
+                        "999587602911715797",
+                        0,
+                        sa.default.signer,
+                        ZERO_ADDRESS,
+                    )
+                })
+                it("should fail when zero fp token quantity", async () => {
+                    const { fAsset, pool } = details
+                    await assertFailedRedeem("Qty==0", pool, fAsset, 0)
+                })
+                it("should fail when input too small to redeem anything", async () => {
+                    const { fAsset, pool } = details
+                    await assertFailedRedeem("Output == 0", pool, fAsset, 1, 0, 0)
+                })
+                it("should fail to redeem if slippage just too big", async () => {
+                    const { pool, fAsset } = details
+                    await assertFailedRedeem(
+                        "bAsset qty < min qty",
+                        pool,
+                        fAsset,
+                        simpleToExactAmount(1),
+                        "999587602911715797",
+                        "999587602911715798", // just over the expected output
+                    )
+                })
+                it("should fail when sender doesn't have enough balance", async () => {
+                    const { bAssets, pool } = details
+                    const bAsset = bAssets[0]
+                    const sender = sa.dummy1
+                    expect(await bAsset.balanceOf(sender.address)).eq(0)
+                    await assertFailedRedeem(
+                        "ERC20: burn amount exceeds balance",
+                        pool,
+                        bAsset,
+                        simpleToExactAmount(100),
+                        "99775801309797227274",
+                        0,
+                        sender.signer,
+                        sender.address,
+                    )
+                })
+                it("should fail to redeem mStable asset when sender doesn't give approval", async () => {
+                    const { mAsset, pool } = details
+                    const sender = sa.dummy2
+                    await mAsset.transfer(sender.address, 10000)
+                    expect(await mAsset.allowance(sender.address, pool.address)).eq(0)
+                    expect(await mAsset.balanceOf(sender.address)).eq(10000)
+                    await assertFailedRedeem(
+                        "ERC20: burn amount exceeds balance",
+                        pool,
+                        mAsset,
+                        simpleToExactAmount(100),
+                        "99775801309797227274",
+                        0,
+                        sender.signer,
+                        sender.address,
+                    )
+                })
+                it("should fail to redeem feeder asset when sender doesn't give approval", async () => {
+                    const { fAsset, pool } = details
+                    const sender = sa.dummy2
+                    await fAsset.transfer(sender.address, 10000)
+                    expect(await fAsset.allowance(sender.address, pool.address)).eq(0)
+                    expect(await fAsset.balanceOf(sender.address)).eq(10000)
+                    await assertFailedRedeem(
+                        "ERC20: burn amount exceeds balance",
+                        pool,
+                        fAsset,
+                        simpleToExactAmount(100),
+                        "99775801309797227274",
+                        0,
+                        sender.signer,
+                        sender.address,
+                    )
+                })
+                it("should fail when the asset does not exist", async () => {
+                    const { pool } = details
+                    const invalidAsset = await feederMachine.mAssetMachine.loadBassetProxy("Mock", "MKK", 18, sa.default.address, 1000)
+                    await assertFailedRedeem("Invalid asset", pool, invalidAsset, simpleToExactAmount(1))
+                })
+
+                context("when feeder pool is paused", () => {
+                    before(async () => {
+                        const { pool } = details
+                        expect(await pool.paused(), "before pause").to.be.false
+                        await pool.connect(sa.governor.signer).pause()
+                        expect(await pool.paused(), "after pause").to.be.true
+                    })
+                    after(async () => {
+                        const { pool } = details
+                        expect(await pool.paused(), "before unpause").to.be.true
+                        await pool.connect(sa.governor.signer).unpause()
+                        expect(await pool.paused(), "after unpause").to.be.false
+                    })
+                    it("should fail to redeem feeder asset", async () => {
+                        const { fAsset, pool } = details
+                        await assertFailedRedeem("Unhealthy", pool, fAsset, simpleToExactAmount(1), "999587602911715797")
+                    })
+                    it("should fail to redeem mStable asset", async () => {
+                        const { mAsset, pool } = details
+                        await assertFailedRedeem("Unhealthy", pool, mAsset, simpleToExactAmount(1), "999587602911715797")
+                    })
+                    it("should fail to redeem a main pool assets", async () => {
+                        const { bAssets, pool } = details
+                        await assertFailedRedeem("Unhealthy", pool, bAssets[0], simpleToExactAmount(1), "999587602911715797", 0)
+                    })
+                })
+            })
+            context("reset before each", () => {
+                beforeEach(async () => {
+                    await runSetup()
+                })
+                it("should redeem a single mStable asset", async () => {
+                    const { mAsset } = details
+                    await assertBasicRedeem(details, mAsset, simpleToExactAmount(1), "999587602911715797", "999587602911715797")
+                })
+                it("should redeem a single feeder asset", async () => {
+                    const { fAsset } = details
+                    await assertBasicRedeem(details, fAsset, simpleToExactAmount(1), "999587602911715797", "999587602911715797")
+                })
+                it("should redeem a single main pool asset", async () => {
+                    const { mAssetDetails } = details
+                    await assertBasicRedeem(
+                        details,
+                        mAssetDetails.bAssets[0],
+                        simpleToExactAmount(1),
+                        "998986367865085229",
+                        "998986367865085229",
+                    )
+                })
+            })
+            context("when a main pool asset has broken below peg", () => {
+                before(async () => {
+                    await runSetup()
+                })
+                before(async () => {
+                    const { mAsset, mAssetDetails } = details
+                    await mAsset.connect(sa.governor.signer).handlePegLoss(mAssetDetails.bAssets[0].address, true)
+                    const newBasset = await mAsset.getBasset(mAssetDetails.bAssets[0].address)
+                    expect(newBasset.personal.status).to.eq(BassetStatus.BrokenBelowPeg)
+                })
+                after(async () => {
+                    const { mAsset, mAssetDetails } = details
+                    await mAsset.connect(sa.governor.signer).negateIsolation(mAssetDetails.bAssets[0].address)
+                    const newBasset = await mAsset.getBasset(mAssetDetails.bAssets[0].address)
+                    expect(newBasset.personal.status).to.eq(BassetStatus.Normal)
+                })
+                it("should fail to redeem a main pool asset", async () => {
+                    const { mAssetDetails, pool } = details
+                    await assertFailedRedeem(
+                        "VM Exception while processing transaction: revert",
+                        pool,
+                        mAssetDetails.bAssets[0],
+                        simpleToExactAmount(1),
+                        "998986367865085229",
+                    )
+                })
+                it("should redeem a single mStable asset", async () => {
+                    const { mAsset } = details
+                    await assertBasicRedeem(details, mAsset, simpleToExactAmount(1), "999587602911715797")
+                })
+                it("should redeem a single feeder asset", async () => {
+                    const { fAsset } = details
+                    await assertBasicRedeem(details, fAsset, simpleToExactAmount(1), "999613298982922415")
+                })
+            })
+        })
+        context("when the basket is 95% mAsset, 5% fAsset", () => {
+            beforeEach(async () => {
+                await runSetup(false, false, [950, 50])
+            })
+            it("should fail redeem as zero output", async () => {
+                const { fAsset, pool } = details
+                await assertFailedRedeem("Output == 0", pool, fAsset, 1, 0)
+            })
+            it("should redeem fAsset to just over min weight of 3%", async () => {
+                const { mAsset } = details
+                await assertBasicRedeem(details, mAsset, simpleToExactAmount(20), "20854727086699605851")
+            })
+            it("should fail redeem fAsset as just under min weight of 3%", async () => {
+                const { pool, fAsset } = details
+                await assertFailedRedeem("Exceeds weight limits", pool, fAsset, simpleToExactAmount(35))
+            })
+        })
+    })
+    describe("redeem exact amount of assets", () => {
+        context("when the weights are within the ForgeValidator limit", () => {
+            context("passing invalid arguments", async () => {
+                before(async () => {
+                    await runSetup()
+                })
+                it("should fail to redeem exact if recipient is 0x0", async () => {
+                    const { pool, bAssets } = details
+                    await assertFailedRedeemExact(
+                        "Invalid recipient",
+                        pool,
+                        bAssets,
+                        [simpleToExactAmount(1), simpleToExactAmount(1)],
+                        "2000800320128051221",
+                        simpleToExactAmount(21, 17),
+                        sa.default.signer,
+                        ZERO_ADDRESS,
+                    )
+                })
+                context("with incorrect asset array", async () => {
+                    it("should fail if both input arrays are empty", async () => {
+                        const { pool } = details
+                        await assertFailedRedeemExact("Invalid array input", pool, [], [])
+                    })
+                    it("should fail if the bAsset input array is empty", async () => {
+                        const { pool } = details
+                        await assertFailedRedeemExact("Invalid array input", pool, [], [simpleToExactAmount(1)])
+                    })
+                    it("should fail if there is a length mismatch", async () => {
+                        const { pool, bAssets } = details
+                        await assertFailedRedeemExact(
+                            "Invalid array input",
+                            pool,
+                            [bAssets[0].address],
+                            [simpleToExactAmount(1), simpleToExactAmount(1)],
+                        )
+                    })
+                    it("should fail if there is a length mismatch", async () => {
+                        const { pool, bAssets } = details
+                        await assertFailedRedeemExact("Invalid array input", pool, [bAssets[0].address], [10000, 10000, 10000, 10000])
+                    })
+                    it("should fail if there are duplicate bAsset addresses", async () => {
+                        const { pool, bAssets } = details
+                        await assertFailedRedeemExact("Duplicate asset", pool, [bAssets[0].address, bAssets[0].address], [10000, 10000])
+                    })
+                    it("should multi redeem a single main pool asset", async () => {
+                        const { mAssetDetails, pool } = details
+                        await assertFailedRedeemExact("Invalid asset", pool, [mAssetDetails.bAssets[0]], [10000])
+                    })
+                })
+                context("when all quantities are zero", () => {
+                    it("should fail to redeem exact fAsset and mAsset", async () => {
+                        const { bAssets, pool } = details
+                        await assertFailedRedeemExact("Must redeem some mAssets", pool, bAssets, [0, 0], 0)
+                    })
+                    it("should fail to redeem exact feeder asset", async () => {
+                        const { fAsset, pool } = details
+                        await assertFailedRedeemExact("Must redeem some mAssets", pool, [fAsset], [0], 0)
+                    })
+                    it("should fail to redeem exact mStable asset", async () => {
+                        const { mAsset, pool } = details
+                        await assertFailedRedeemExact("Must redeem some mAssets", pool, [mAsset], [0], 0)
+                    })
+                })
+                it("should fail if zero max feed pool token quantity", async () => {
+                    const { bAssets, pool } = details
+                    const bAsset = bAssets[0]
+                    const sender = sa.default
+                    await feederMachine.approveFeeder(bAsset, pool.address, 101, sender.signer)
+                    await assertFailedRedeemExact(
+                        "Qty==0",
+                        pool,
+                        [bAsset.address],
+                        ["100000000000000000000"], // 100
+                        "100225391632663607816",
+                        0, // max feeder pool tokens
+                        sender.signer,
+                        sender.address,
+                    )
+                })
+                it("should fail if slippage just too big", async () => {
+                    const { bAssets, pool } = details
+                    const bAsset = bAssets[0]
+                    const sender = sa.default
+                    await feederMachine.approveFeeder(bAsset, pool.address, 101, sender.signer)
+                    await assertFailedRedeemExact(
+                        "Redeem mAsset qty > max quantity",
+                        pool,
+                        [bAsset.address],
+                        ["100000000000000000000"], // 100
+                        "100225391632663607816",
+                        "100000000000000000001", // just over 100
+                        sender.signer,
+                        sender.address,
+                    )
+                })
+                it("should fail if sender doesn't have enough balance", async () => {
+                    const { bAssets, pool } = details
+                    const sender = sa.dummy2
+                    expect(await pool.balanceOf(sender.address)).eq(0)
+                    await assertFailedRedeemExact(
+                        "ERC20: burn amount exceeds balance",
+                        pool,
+                        bAssets,
+                        [simpleToExactAmount(100), simpleToExactAmount(100)],
+                        "200080032012805122049",
+                        simpleToExactAmount(201),
+                        sender.signer,
+                        sender.address,
+                        true,
+                    )
+                })
+                it("should fail when the asset does not exist", async () => {
+                    const { pool } = details
+                    const newBasset = await feederMachine.mAssetMachine.loadBassetProxy("Mock", "MKK", 18, sa.default.address, 1000)
+                    await assertFailedRedeemExact("Invalid asset", pool, [newBasset], [1])
+                })
+                context("when feeder pool is paused", () => {
+                    before(async () => {
+                        const { pool } = details
+                        expect(await pool.paused(), "before pause").to.be.false
+                        await pool.connect(sa.governor.signer).pause()
+                        expect(await pool.paused(), "after pause").to.be.true
+                    })
+                    after(async () => {
+                        const { pool } = details
+                        expect(await pool.paused(), "before unpause").to.be.true
+                        await pool.connect(sa.governor.signer).unpause()
+                        expect(await pool.paused(), "after unpause").to.be.false
+                    })
+                    it("should fail to redeem exact feeder asset", async () => {
+                        const { fAsset, pool } = details
+                        await assertFailedRedeemExact("Unhealthy", pool, [fAsset], [simpleToExactAmount(1)], "1000412572361491063")
+                    })
+                    it("should fail to redeem exact mStable asset", async () => {
+                        const { mAsset, pool } = details
+                        await assertFailedRedeemExact("Unhealthy", pool, [mAsset], [simpleToExactAmount(1)], "1000412572361491063")
+                    })
+                })
+            })
+            context("reset before each", () => {
+                beforeEach(async () => {
+                    await runSetup()
+                })
+                it("should redeem exact single mStable asset", async () => {
+                    const { mAsset } = details
+                    await assertRedeemExact(details, [mAsset], [simpleToExactAmount(1)], "1000412572361491063", simpleToExactAmount(11, 17))
+                })
+                it("should redeem exact a single feeder asset", async () => {
+                    const { fAsset } = details
+                    await assertRedeemExact(details, [fAsset], [simpleToExactAmount(1)], "1000412572361491063", simpleToExactAmount(11, 17))
+                })
+                it("should redeem smallest bAsset unit", async () => {
+                    const { fAsset } = details
+                    await assertRedeemExact(details, [fAsset], [1], 2, 2)
+                })
+            })
+            context("when a main pool asset has broken below peg", () => {
+                before(async () => {
+                    await runSetup()
+                    const { mAsset, mAssetDetails } = details
+                    await mAsset.connect(sa.governor.signer).handlePegLoss(mAssetDetails.bAssets[0].address, true)
+                    const newBasset = await mAsset.getBasset(mAssetDetails.bAssets[0].address)
+                    expect(newBasset.personal.status).to.eq(BassetStatus.BrokenBelowPeg)
+                })
+                after(async () => {
+                    const { mAsset, mAssetDetails } = details
+                    await mAsset.connect(sa.governor.signer).negateIsolation(mAssetDetails.bAssets[0].address)
+                    const newBasset = await mAsset.getBasset(mAssetDetails.bAssets[0].address)
+                    expect(newBasset.personal.status).to.eq(BassetStatus.Normal)
+                })
+                it("should redeem exact a single mStable asset", async () => {
+                    const { mAsset } = details
+                    await assertRedeemExact(details, [mAsset], [simpleToExactAmount(1)], "1000412572361491063")
+                })
+                it("should redeem exact a single feeder asset", async () => {
+                    const { fAsset } = details
+                    await assertRedeemExact(details, [fAsset], [simpleToExactAmount(1)], "1000386844788655296")
+                })
+                it("should redeem exact mStable and feeder asset", async () => {
+                    const { bAssets } = details
+                    await assertRedeemExact(details, bAssets, [simpleToExactAmount(1), simpleToExactAmount(1)], "2000796703680600580")
+                })
+            })
+        })
+    })
+    describe("Proportionately redeeming feeder and mStable assets", () => {
+        context("when the basket is balanced", () => {
+            context("passing invalid arguments", async () => {
+                before(async () => {
+                    await runSetup()
+                })
+                it("should fail if recipient is 0x0", async () => {
+                    const { pool } = details
+                    await assertFailedRedeemProportionately(
+                        "Invalid recipient",
+                        pool,
+                        simpleToExactAmount(1),
+                        [0, 0],
+                        sa.default.signer,
+                        ZERO_ADDRESS,
+                    )
+                })
+                it("should fail when zero fp token quantity", async () => {
+                    const { pool } = details
+                    await assertFailedRedeemProportionately("Qty==0", pool, 0)
+                })
+                it("should fail if slippage too big", async () => {
+                    const { bAssets, pool } = details
+                    const bAsset = bAssets[0]
+                    const sender = sa.default
+                    await feederMachine.approveFeeder(bAsset, pool.address, 101, sender.signer)
+                    await assertFailedRedeemProportionately("bAsset qty < min qty", pool, simpleToExactAmount(1), [
+                        simpleToExactAmount(5, 17),
+                        simpleToExactAmount(5, 17),
+                    ])
+                })
+                it("should fail when sender doesn't have enough balance", async () => {
+                    const { bAssets, pool } = details
+                    const bAsset = bAssets[0]
+                    const sender = sa.dummy1
+                    expect(await bAsset.balanceOf(sender.address)).eq(0)
+                    await assertFailedRedeemProportionately(
+                        "ERC20: burn amount exceeds balance",
+                        pool,
+                        simpleToExactAmount(100),
+                        [0, 0],
+                        sender.signer,
+                        sender.address,
+                    )
+                })
+                context("when feeder pool is paused", () => {
+                    before(async () => {
+                        const { pool } = details
+                        expect(await pool.paused(), "before pause").to.be.false
+                        await pool.connect(sa.governor.signer).pause()
+                        expect(await pool.paused(), "after pause").to.be.true
+                    })
+                    after(async () => {
+                        const { pool } = details
+                        expect(await pool.paused(), "before unpause").to.be.true
+                        await pool.connect(sa.governor.signer).unpause()
+                        expect(await pool.paused(), "after unpause").to.be.false
+                    })
+                    it("should fail to redeem proportionately", async () => {
+                        const { pool } = details
+                        await assertFailedRedeemProportionately("Unhealthy", pool, simpleToExactAmount(1))
+                    })
+                })
+            })
+            context("reset before each", () => {
+                beforeEach(async () => {
+                    await runSetup()
+                })
+                it("should redeem proportionately", async () => {
+                    await assertRedeemProportionately(details, simpleToExactAmount(1), ["499799999999999999", "499799999999999999"])
+                })
+            })
+            context("when a main pool asset has broken below peg", () => {
+                before(async () => {
+                    await runSetup()
+                })
+                before(async () => {
+                    const { mAsset, mAssetDetails } = details
+                    await mAsset.connect(sa.governor.signer).handlePegLoss(mAssetDetails.bAssets[0].address, true)
+                    const newBasset = await mAsset.getBasset(mAssetDetails.bAssets[0].address)
+                    expect(newBasset.personal.status).to.eq(BassetStatus.BrokenBelowPeg)
+                })
+                after(async () => {
+                    const { mAsset, mAssetDetails } = details
+                    await mAsset.connect(sa.governor.signer).negateIsolation(mAssetDetails.bAssets[0].address)
+                    const newBasset = await mAsset.getBasset(mAssetDetails.bAssets[0].address)
+                    expect(newBasset.personal.status).to.eq(BassetStatus.Normal)
+                })
+                it("should redeem proportionately", async () => {
+                    await assertRedeemProportionately(details, simpleToExactAmount(1), ["499799999999999999", "499799999999999999"])
+                })
+            })
+        })
+    })
+})

--- a/test/feeders/swap.spec.ts
+++ b/test/feeders/swap.spec.ts
@@ -1,0 +1,343 @@
+import { Signer } from "ethers"
+import { ethers } from "hardhat"
+import { expect } from "chai"
+
+import { simpleToExactAmount, BN } from "@utils/math"
+import { MassetMachine, StandardAccounts, Account, FeederMachine, FeederDetails } from "@utils/machines"
+import { FeederPool, MockERC20 } from "types/generated"
+import { ZERO_ADDRESS } from "@utils/constants"
+
+describe("Feeder - Swap", () => {
+    let sa: StandardAccounts
+    let feederMachine: FeederMachine
+    let details: FeederDetails
+
+    const runSetup = async (
+        useLendingMarkets = false,
+        useInterestValidator = false,
+        feederWeights?: Array<BN | number>,
+        mAssetWeights?: Array<BN | number>,
+    ): Promise<void> => {
+        details = await feederMachine.deployFeeder(false, feederWeights, mAssetWeights, useLendingMarkets, useInterestValidator)
+    }
+
+    before("Init contract", async () => {
+        const accounts = await ethers.getSigners()
+        const mAssetMachine = await new MassetMachine().initAccounts(accounts)
+        feederMachine = await new FeederMachine(mAssetMachine)
+        sa = mAssetMachine.sa
+    })
+
+    /**
+     * @dev Asserts that both 'swap' and 'getSwapOutput' fail for a given reason
+     * @param expectedReason What is the failure response of the contract?
+     * @param poolContract FeederPool instance upon which to call swap
+     * @param inputAsset feeder, mStable or main pool asset to swap from sender and into the pool
+     * @param outputAsset feeder, mStable or main pool asset to swap to sender and out of the pool
+     * @param inputQuantity amount of the input asset.
+     * @param minOutputQuantity minimum amount of the output asset
+     * @param outputExpected expected amount of output assets
+     * @param swapOutputRevertExpected Should 'getSwapOutput' revert? If so, set this to true
+     * @param quantitiesAreExact false (default) if the input, min output and output expected quantities need to be converted to base units
+     * @param sender Who should send the tx? Or default
+     * @param recipient Who should receive the output? Or default
+     * @param approvals true (default) if the swap sender has and approves the feeder pool to spend the amount the input asset
+     */
+    const assertFailedSwap = async (
+        expectedReason: string,
+        poolContract: FeederPool,
+        inputAsset: MockERC20,
+        outputAsset: MockERC20,
+        inputQuantity: BN | number | string,
+        minOutputQuantity: BN | number | string = 0,
+        outputExpected: BN | number | string = undefined,
+        quantitiesAreExact = false,
+        sender: Signer = sa.default.signer,
+        recipient: string = sa.default.address,
+        approval = true,
+    ): Promise<void> => {
+        const pool = poolContract.connect(sender)
+        if (approval) {
+            await feederMachine.approveFeeder(inputAsset, pool.address, inputQuantity, sender, quantitiesAreExact)
+        }
+        const inputAssetDecimals = await inputAsset.decimals()
+        const inputQuantityExact = quantitiesAreExact ? BN.from(inputQuantity) : simpleToExactAmount(inputQuantity, inputAssetDecimals)
+        const outputDecimals = await outputAsset.decimals()
+        const minOutputQuantityExact = quantitiesAreExact
+            ? BN.from(minOutputQuantity)
+            : simpleToExactAmount(minOutputQuantity, outputDecimals)
+
+        // Expect the swap to revert
+        await expect(
+            pool.swap(inputAsset.address, outputAsset.address, inputQuantityExact, minOutputQuantityExact, recipient),
+            `swap tx should revert with "${expectedReason}"`,
+        ).to.be.revertedWith(expectedReason)
+
+        if (outputExpected === undefined) {
+            await expect(
+                pool.getSwapOutput(inputAsset.address, outputAsset.address, inputQuantityExact),
+                `getSwapOutput call should revert with "${expectedReason}"`,
+            ).to.be.revertedWith(expectedReason)
+        } else {
+            const outputExpectedExact = quantitiesAreExact ? BN.from(outputExpected) : simpleToExactAmount(outputExpected, outputDecimals)
+            const output = await pool.getSwapOutput(inputAsset.address, outputAsset.address, inputQuantityExact)
+            expect(output, "getSwapOutput call output").eq(outputExpectedExact)
+        }
+    }
+
+    /**
+     * @dev Asserts that a swap meets the basic validation conditions, i.e. updates
+     * state and affects actors balances in the correct manner
+     * @param fd Object containing relevant base level contract info on system
+     * @param poolContract FeederPool instance upon which to call swap
+     * @param inputAsset feeder, mStable or main pool asset to swap from sender and into the pool
+     * @param outputAsset feeder, mStable or main pool asset to swap to sender and out of the pool
+     * @param inputQuantity amount of the input asset.
+     * @param outputExpected expected amount of output assets
+     * @param minOutputQuantity minimum amount of the output asset
+     * @param quantitiesAreExact false (default) if the input, min output and output expected quantities need to be converted to base units
+     * @param sender Who should send the tx? Or default
+     * @param recipient Who should receive the output? Or default
+     * @param expectSwapFee Should this swap incur a fee?
+     */
+    const assertSwap = async (
+        fd: FeederDetails,
+        inputAsset: MockERC20,
+        outputAsset: MockERC20,
+        inputQuantity: BN | number | string,
+        outputExpected: BN | number | string,
+        minOutputQuantity: BN | number | string = 0,
+        quantitiesAreExact = true,
+        recipient: string = sa.default.address,
+        sender: Account = sa.default,
+    ): Promise<BN> => {
+        const pool = fd.pool.connect(sender.signer)
+
+        const inputAssetDecimals = await inputAsset.decimals()
+        const inputQuantityExact = quantitiesAreExact ? BN.from(inputQuantity) : simpleToExactAmount(inputQuantity, inputAssetDecimals)
+        const outputDecimals = await outputAsset.decimals()
+        const outputExpectedExact = quantitiesAreExact ? BN.from(outputExpected) : simpleToExactAmount(outputExpected, outputDecimals)
+        const minOutputQuantityExact = quantitiesAreExact
+            ? BN.from(minOutputQuantity)
+            : simpleToExactAmount(minOutputQuantity, outputDecimals)
+
+        //    Get basic before data about the actors balances
+        const swapperInputBalBefore = await inputAsset.balanceOf(sender.address)
+        const recipientOutputBalBefore = await outputAsset.balanceOf(recipient)
+
+        //    Get basic before data on the swap assets
+        const inputAssetBefore = await feederMachine.getAsset(details, inputAsset.address)
+        const outputAssetBefore = await feederMachine.getAsset(details, outputAsset.address)
+
+        // 2. Do the necessary approvals and make the calls
+        await feederMachine.approveFeeder(inputAsset, pool.address, inputQuantityExact, sender.signer, true)
+
+        //    Call the swap output function to check if results match
+        const swapOutput = await pool.getSwapOutput(inputAsset.address, outputAsset.address, inputQuantityExact)
+        expect(swapOutput, "swap output").to.eq(outputExpectedExact)
+
+        //     Expect to be used in cache
+        const platformInteractionIn = await feederMachine.getPlatformInteraction(pool, "deposit", inputQuantityExact, inputAssetBefore)
+        const platformInteractionOut = await feederMachine.getPlatformInteraction(
+            pool,
+            "withdrawal",
+            outputExpectedExact,
+            outputAssetBefore,
+        )
+
+        // FIXME can await when Waffle 3.2.2 is included in @nomiclabs/hardhat-waffle
+        // https://github.com/EthWorks/Waffle/issues/119
+        const swapTx = pool.swap(inputAsset.address, outputAsset.address, inputQuantityExact, minOutputQuantityExact, recipient)
+        // 4. Validate any basic events that should occur
+        await expect(swapTx).to.emit(pool, "Swapped")
+        // .withArgs(sender.address, inputAsset.address, outputAsset.address, outputExpectedExact, scaledFee, recipient)
+        // Input Transfer event
+        await expect(swapTx, "Transfer event for input asset from sender to platform integration or mAsset")
+            .to.emit(inputAsset, "Transfer")
+            .withArgs(sender.address, inputAssetBefore.integrator ? inputAssetBefore.integratorAddr : pool.address, inputQuantityExact)
+        await expect(swapTx, "Transfer event for output asset from platform integration or mAsset to recipient")
+            .to.emit(outputAsset, "Transfer")
+            .withArgs(outputAssetBefore.integrator ? outputAssetBefore.integratorAddr : pool.address, recipient, outputExpectedExact)
+        await swapTx
+
+        const inputIntegratorBalAfter = await inputAssetBefore.contract.balanceOf(
+            inputAssetBefore.integrator ? inputAssetBefore.integratorAddr : pool.address,
+        )
+        expect(inputIntegratorBalAfter, "Input destination raw balance").eq(platformInteractionIn.rawBalance)
+        const outputIntegratorBalAfter = await outputAssetBefore.contract.balanceOf(
+            outputAssetBefore.integrator ? outputAssetBefore.integratorAddr : pool.address,
+        )
+        expect(outputIntegratorBalAfter, "Output source raw balance").eq(platformInteractionOut.rawBalance)
+
+        // 5. Validate output state
+        //  Input
+        //    Lending market
+        // if (platformInteractionIn.expectInteraction) {
+        //     await expect(swapTx)
+        //         .to.emit(platform, "Deposit")
+        //         .withArgs(inputAsset.address, inputAssetBefore.pToken, platformInteractionIn.amount)
+        // }
+        //    Sender should have less input bAsset after
+        const swapperAssetBalAfter = await inputAsset.balanceOf(sender.address)
+        expect(swapperAssetBalAfter, "swapper input asset balance after").eq(swapperInputBalBefore.sub(inputQuantityExact))
+        //    VaultBalance should update for input asset
+        const inputAssetAfter = await feederMachine.getAsset(details, inputAsset.address)
+        expect(BN.from(inputAssetAfter.vaultBalance), "input asset balance after").eq(
+            BN.from(inputAssetBefore.vaultBalance).add(inputQuantityExact),
+        )
+
+        //  Output
+        //    Lending market
+        // if (platformInteractionOut.expectInteraction) {
+        //     await expect(swapTx)
+        //         .to.emit(platform, "PlatformWithdrawal")
+        //         .withArgs(outputAsset.address, outputAssetBefore.pToken, platformInteractionOut.amount, expectedOutputValue)
+        // } else if (platformInteractionOut.hasLendingMarket) {
+        //     await expect(swapTx).to.emit(platform, "Withdrawal").withArgs(outputAsset.address, ZERO_ADDRESS, expectedOutputValue)
+        // }
+        //    Recipient should have output asset quantity after (minus fee)
+        const recipientBalAfter = await outputAsset.balanceOf(recipient)
+        expect(recipientBalAfter, "recipientBalAfter").eq(recipientOutputBalBefore.add(outputExpectedExact))
+        //    Swap estimation should match up
+        expect(outputExpectedExact, "expectedOutputValue").eq(recipientBalAfter.sub(recipientOutputBalBefore))
+        //    VaultBalance should update for output asset
+        const outputAssetAfter = await feederMachine.getAsset(details, outputAsset.address)
+        expect(BN.from(outputAssetAfter.vaultBalance), "output asset after").eq(
+            BN.from(outputAssetBefore.vaultBalance).sub(outputExpectedExact),
+        )
+
+        return outputExpectedExact
+    }
+
+    describe("swapping assets", () => {
+        context("when within the invariant validator limits", () => {
+            context("and different quantities", () => {
+                before(async () => {
+                    await runSetup()
+                })
+                const inputQuantities = [1, 10, 14]
+                const expectedOutputQuantities = ["999950496287036808", "9994044878708993648", "13974622869405262771"]
+                inputQuantities.forEach((qty, i) => {
+                    it(`should swap using ${qty} quantity`, async () => {
+                        const { bAssets } = details
+                        await assertSwap(details, bAssets[1], bAssets[0], simpleToExactAmount(qty), expectedOutputQuantities[i])
+                    })
+                })
+            })
+            context("swapping different assets", () => {
+                beforeEach(async () => {
+                    await runSetup()
+                })
+                it("should swap feeder asset for mStable asset", async () => {
+                    const { fAsset, mAsset } = details
+                    await assertSwap(details, fAsset, mAsset, simpleToExactAmount(10), "9995039810682797447")
+                })
+                it("should swap mStable asset for feeder asset", async () => {
+                    const { fAsset, mAsset } = details
+                    await assertSwap(details, mAsset, fAsset, simpleToExactAmount(10), "9987044852367306793")
+                })
+                it.skip("should swap feeder asset for main pool asset with 18 decimals", async () => {
+                    const { mAssetDetails, fAsset } = details
+                    await assertSwap(details, fAsset, mAssetDetails.bAssets[0], simpleToExactAmount(10), "9988894254755748581")
+                })
+                it.skip("should swap feeder asset for main pool asset with 6 decimals", async () => {
+                    const { mAssetDetails, fAsset } = details
+                    await assertSwap(details, fAsset, mAssetDetails.bAssets[1], simpleToExactAmount(10), "9988894")
+                })
+            })
+            context("passing invalid arguments", async () => {
+                before(async () => {
+                    await runSetup()
+                })
+                it("should fail if identical assets", async () => {
+                    const { mAsset } = details
+                    await assertFailedSwap("Invalid pair", details.pool, mAsset, mAsset, 1)
+                })
+                it("should fail when 0 quantity", async () => {
+                    const { fAsset, mAsset } = details
+                    await assertFailedSwap("Qty==0", details.pool, mAsset, fAsset, 0)
+                })
+                it("should fail when zero output", async () => {
+                    const { fAsset, mAsset } = details
+                    await assertFailedSwap("Zero output quantity", details.pool, mAsset, fAsset, 2, 0, 0, true)
+                })
+                it("should fail if recipient is 0x0", async () => {
+                    const { fAsset, mAsset } = details
+                    await assertFailedSwap(
+                        "Invalid recipient",
+                        details.pool,
+                        mAsset,
+                        fAsset,
+                        simpleToExactAmount(1),
+                        0,
+                        "999150545856874530",
+                        true,
+                        sa.default.signer,
+                        ZERO_ADDRESS,
+                    )
+                })
+                it("should fail if sender doesn't have sufficient liquidity", async () => {
+                    const { fAsset, mAsset } = details
+                    await assertFailedSwap(
+                        "ERC20: transfer amount exceeds balance",
+                        details.pool,
+                        mAsset,
+                        fAsset,
+                        simpleToExactAmount(1),
+                        0,
+                        "999150545856874530",
+                        true,
+                        sa.dummy1.signer,
+                        sa.dummy1.address,
+                    )
+                })
+                it("should fail if sender doesn't give approval", async () => {
+                    const { bAssets, pool } = details
+                    const input = bAssets[0]
+                    const sender = sa.dummy2
+                    await input.transfer(sender.address, 10000)
+                    expect(await input.allowance(sender.address, pool.address)).eq(0)
+                    expect(await input.balanceOf(sender.address)).eq(10000)
+                    await assertFailedSwap(
+                        "ERC20: transfer amount exceeds balance",
+                        pool,
+                        input,
+                        bAssets[1],
+                        simpleToExactAmount(1),
+                        0,
+                        "999150545856874530",
+                        true,
+                        sender.signer,
+                        sender.address,
+                        false,
+                    )
+                })
+                it("should fail to swap mStable asset for main pool asset", async () => {
+                    await assertFailedSwap("Invalid pair", details.pool, details.mAsset, details.mAssetDetails.bAssets[0], 10)
+                })
+                it("should fail to swap main pool asset for mStable asset", async () => {
+                    await assertFailedSwap("Invalid pair", details.pool, details.mAssetDetails.bAssets[0], details.mAsset, 10)
+                })
+                it("should fail if *either* bAsset does not exist", async () => {
+                    const { bAssets, pool } = details
+                    const realBasset = bAssets[0]
+                    const fakeBasset = await feederMachine.mAssetMachine.loadBassetProxy("Mock", "MKK", 18, sa.default.address, 1000)
+                    await assertFailedSwap("Invalid pair", pool, fakeBasset, realBasset, 1)
+                    await assertFailedSwap("Invalid pair", pool, realBasset, fakeBasset, 1)
+                })
+                it("should fail if min qty < output qty", async () => {
+                    await assertFailedSwap(
+                        "Output qty < minimum qty",
+                        details.pool,
+                        details.mAsset,
+                        details.fAsset,
+                        simpleToExactAmount(1),
+                        simpleToExactAmount(1),
+                        "999150545856874530",
+                        true,
+                    )
+                })
+            })
+        })
+    })
+})

--- a/test/masset/admin.spec.ts
+++ b/test/masset/admin.spec.ts
@@ -501,12 +501,13 @@ describe("Masset Admin", () => {
         let transferringAsset: MockERC20
         before(async () => {
             await runSetup(true, false, false, true)
+            const lendingDetail = await mAssetMachine.loadATokens(details.bAssets)
             ;[, , , transferringAsset] = details.bAssets
             newMigration = await (await new MockPlatformIntegration__factory(sa.default.signer)).deploy(
                 DEAD_ADDRESS,
-                details.aavePlatformAddress,
+                lendingDetail.aavePlatformAddress,
                 details.bAssets.map((b) => b.address),
-                details.pTokens,
+                lendingDetail.aTokens.map((a) => a.aToken),
             )
             await newMigration.addWhitelist([details.mAsset.address])
         })

--- a/test/savings/savings-contract.spec.ts
+++ b/test/savings/savings-contract.spec.ts
@@ -3,7 +3,7 @@ import { expect } from "chai"
 import { simpleToExactAmount, BN } from "@utils/math"
 import { assertBNClose, assertBNClosePercent } from "@utils/assertions"
 import { StandardAccounts, MassetDetails, MassetMachine, Account } from "@utils/machines"
-import { fullScale, ZERO_ADDRESS, ZERO, MAX_UINT256, ONE_DAY, ONE_HOUR } from "@utils/constants"
+import { fullScale, ZERO_ADDRESS, ZERO, MAX_UINT256, ONE_DAY, ONE_HOUR, DEAD_ADDRESS } from "@utils/constants"
 import {
     SavingsContract,
     MockERC20__factory,
@@ -125,7 +125,7 @@ describe("SavingsContract", async () => {
 
     const createNewSavingsContract = async (): Promise<void> => {
         // Use a mock Nexus so we can dictate addresses
-        nexus = await (await new MockNexus__factory(sa.default.signer)).deploy(sa.governor.address, manager.address)
+        nexus = await (await new MockNexus__factory(sa.default.signer)).deploy(sa.governor.address, manager.address, DEAD_ADDRESS)
         // Use a mock mAsset so we can dictate the interest generated
         masset = await (await new MockMasset__factory(sa.default.signer)).deploy("MOCK", "MOCK", 18, sa.default.address, 1000000000)
 

--- a/test/savings/savings-vault.spec.ts
+++ b/test/savings/savings-vault.spec.ts
@@ -104,7 +104,7 @@ describe("SavingsVault", async () => {
     const lockedRewards = (total: BN): BN => total.div(5).mul(4)
 
     const redeployRewards = async (priceCoefficient = priceCoeff): Promise<BoostedSavingsVault> => {
-        nexus = await (await new MockNexus__factory(sa.default.signer)).deploy(sa.governor.address, DEAD_ADDRESS)
+        nexus = await (await new MockNexus__factory(sa.default.signer)).deploy(sa.governor.address, DEAD_ADDRESS, DEAD_ADDRESS)
         rewardToken = await (await new MockERC20__factory(sa.default.signer)).deploy(
             "Reward",
             "RWD",


### PR DESCRIPTION
- [x] Added FeederManager events to FeederPools so ethers will parse those events
- [x] Added KEY_INTEREST_VALIDATOR to nexus mock
- [x] Removed the requirement that some platform interest must be collected so many pools can have their interest collected - even if they have zero interest to collect.
- [x] Feeder pool tests added under `test/feeders`