### PR TITLE
Correct the misleading comment

### DIFF
--- a/contracts/shared/StableMath.sol
+++ b/contracts/shared/StableMath.sol
@@ -80,7 +80,7 @@ library StableMath {
     ) internal pure returns (uint256) {
         // e.g. assume scale = fullScale
         // z = 10e18 * 9e17 = 9e36
-        // return 9e38 / 1e18 = 9e18
+        // return 9e36 / 1e18 = 9e18
         return (x * y) / scale;
     }
 


### PR DESCRIPTION
The result of "9e38 / 1e18" should be "9e20" instead of "9e18".
I guess, what the comment intends to explain is "9e36 / 1e18 = 9e18", based on the context.