### PR TITLE
Feature: added rewards task

### DIFF
--- a/tasks/mUSD.ts
+++ b/tasks/mUSD.ts
@@ -194,4 +194,18 @@ task("mUSD-rates", "mUSD rate comparison to Curve")
         await snapConfig(mAsset, block.blockNumber)
     })
 
+task("rewards", "Get Compound and Aave platform reward tokens")
+    .addOptionalParam("block", "Block number to compare rates at. (default: current block)", 0, types.int)
+    .setAction(async (taskArgs, hre) => {
+        const { ethers } = hre
+        const [signer] = await ethers.getSigners()
+
+        const block = await getBlock(ethers, taskArgs.block)
+
+        console.log(`\nGetting platform tokens at block ${block.blockNumber}, ${block.blockTime.toUTCString()}`)
+
+        await getCompTokens(signer, block)
+        await getAaveTokens(signer, block)
+    })
+
 module.exports = {}


### PR DESCRIPTION
- [x] Add new `rewards` task that reports the amount of accrued COMP and stkAAVE

To run for the current block
```
yarn run task --network mainnet rewards
```

To run for a past block
```
yarn run task --network mainnet rewards --block 12680538
```

Example output
```
Getting platform tokens at block 12682476, Tue, 22 Jun 2021 06:40:23 GMT

COMP accrued
USDC                 38.79
Integration           0.00
Liquidator          494.76
Total               533.56     121,892.52 USDC (228 COMP/USDC)

stkAAVE accrued
sUSD                68.72
USDT               168.30
DAI                168.30
GUSD                22.90
BUSD                 0.00
WBTC                19.39
Liquidator           0.00 unlock Sun, 11 Jan 1970 00:00:00 GMT
Total              447.61      91,308.23 USDC (203 AAVE/USDC)
```