### PR TITLE
Support transfers of platformToken in RewardsDistributor

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,16 @@
-# .prettierrc
-printWidth: 100
-parser: typescript
-tabWidth: 4
-trailingComma: all
-arrowParens: always
+{
+  "printWidth": 100,
+  "tabWidth": 4,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "overrides": [
+    {
+      "files": "*.sol",
+      "options": {
+        "printWidth": 100,
+        "bracketSpacing": true,
+        "explicitTypes": "always"
+      }
+    }
+  ]
+}

--- a/contracts/interfaces/IRewardsDistributionRecipient.sol
+++ b/contracts/interfaces/IRewardsDistributionRecipient.sol
@@ -5,5 +5,10 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 interface IRewardsDistributionRecipient {
     function notifyRewardAmount(uint256 reward) external;
     function getRewardToken() external view returns (IERC20);
+}
+
+interface IRewardsRecipientWithPlatformToken {
+    function notifyRewardAmount(uint256 reward) external;
+    function getRewardToken() external view returns (IERC20);
     function getPlatformToken() external view returns (IERC20);
 }

--- a/contracts/interfaces/IRewardsDistributionRecipient.sol
+++ b/contracts/interfaces/IRewardsDistributionRecipient.sol
@@ -5,4 +5,5 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 interface IRewardsDistributionRecipient {
     function notifyRewardAmount(uint256 reward) external;
     function getRewardToken() external view returns (IERC20);
+    function getPlatformToken() external view returns (IERC20);
 }

--- a/contracts/rewards/RewardsDistributionRecipient.sol
+++ b/contracts/rewards/RewardsDistributionRecipient.sol
@@ -16,7 +16,6 @@ contract RewardsDistributionRecipient is IRewardsDistributionRecipient, Module {
     // @abstract
     function notifyRewardAmount(uint256 reward) external;
     function getRewardToken() external view returns (IERC20);
-    function getPlatformToken() external view returns (IERC20);
 
     // This address has the ability to distribute the rewards
     address public rewardsDistributor;

--- a/contracts/rewards/RewardsDistributionRecipient.sol
+++ b/contracts/rewards/RewardsDistributionRecipient.sol
@@ -16,6 +16,7 @@ contract RewardsDistributionRecipient is IRewardsDistributionRecipient, Module {
     // @abstract
     function notifyRewardAmount(uint256 reward) external;
     function getRewardToken() external view returns (IERC20);
+    function getPlatformToken() external view returns (IERC20);
 
     // This address has the ability to distribute the rewards
     address public rewardsDistributor;

--- a/contracts/rewards/RewardsDistributor.sol
+++ b/contracts/rewards/RewardsDistributor.sol
@@ -1,8 +1,9 @@
 pragma solidity 0.5.16;
 
 import { IRewardsDistributionRecipient } from "../interfaces/IRewardsDistributionRecipient.sol";
-
-import { InitializableGovernableWhitelist } from "../governance/InitializableGovernableWhitelist.sol";
+import {
+    InitializableGovernableWhitelist
+} from "../governance/InitializableGovernableWhitelist.sol";
 import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
 /**
@@ -12,19 +13,20 @@ import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/SafeERC20
  * to specified Reward Recipients.
  */
 contract RewardsDistributor is InitializableGovernableWhitelist {
-
     using SafeERC20 for IERC20;
 
     event RemovedFundManager(address indexed _address);
-    event DistributedReward(address funder, address recipient, address rewardToken, uint256 amount, address platformToken, uint256 platformAmount);
+    event DistributedReward(
+        address funder,
+        address recipient,
+        address rewardToken,
+        uint256 amount,
+        address platformToken,
+        uint256 platformAmount
+    );
 
     /** @dev Recipient is a module, governed by mStable governance */
-    constructor(
-        address _nexus,
-        address[] memory _fundManagers
-    )
-        public
-    {
+    constructor(address _nexus, address[] memory _fundManagers) public {
         InitializableGovernableWhitelist._initialize(_nexus, _fundManagers);
     }
 
@@ -32,10 +34,7 @@ contract RewardsDistributor is InitializableGovernableWhitelist {
      * @dev Allows the mStable governance to add a new FundManager
      * @param _address  FundManager to add
      */
-    function addFundManager(address _address)
-        external
-        onlyGovernor
-    {
+    function addFundManager(address _address) external onlyGovernor {
         _addWhitelist(_address);
     }
 
@@ -43,10 +42,7 @@ contract RewardsDistributor is InitializableGovernableWhitelist {
      * @dev Allows the mStable governance to remove inactive FundManagers
      * @param _address  FundManager to remove
      */
-    function removeFundManager(address _address)
-        external
-        onlyGovernor
-    {
+    function removeFundManager(address _address) external onlyGovernor {
         require(_address != address(0), "Address is zero");
         require(whitelist[_address], "Address is not whitelisted");
 
@@ -66,16 +62,13 @@ contract RewardsDistributor is InitializableGovernableWhitelist {
         IRewardsDistributionRecipient[] calldata _recipients,
         uint256[] calldata _amounts,
         uint256[] calldata _platformAmounts
-    )
-        external
-        onlyWhitelisted
-    {
+    ) external onlyWhitelisted {
         uint256 len = _recipients.length;
         require(len > 0, "Must choose recipients");
         require(len == _amounts.length, "Mismatching inputs");
         require(len == _platformAmounts.length, "Mismatching inputs");
 
-        for(uint i = 0; i < len; i++){
+        for (uint256 i = 0; i < len; i++) {
             uint256 amount = _amounts[i];
             uint256 platformAmount = _platformAmounts[i];
             IRewardsDistributionRecipient recipient = _recipients[i];
@@ -88,8 +81,14 @@ contract RewardsDistributor is InitializableGovernableWhitelist {
             // Only after successful tx - notify the contract of the new funds
             recipient.notifyRewardAmount(amount);
 
-            emit DistributedReward(msg.sender, address(recipient), address(rewardToken), amount, address(platformToken), platformAmount);
+            emit DistributedReward(
+                msg.sender,
+                address(recipient),
+                address(rewardToken),
+                amount,
+                address(platformToken),
+                platformAmount
+            );
         }
     }
-    
 }

--- a/contracts/rewards/RewardsDistributor.sol
+++ b/contracts/rewards/RewardsDistributor.sol
@@ -70,14 +70,16 @@ contract RewardsDistributor is InitializableGovernableWhitelist {
 
         for (uint256 i = 0; i < len; i++) {
             uint256 amount = _amounts[i];
-            uint256 platformAmount = _platformAmounts[i];
             IRewardsDistributionRecipient recipient = _recipients[i];
             // Send the RewardToken to recipient
             IERC20 rewardToken = recipient.getRewardToken();
             rewardToken.safeTransferFrom(msg.sender, address(recipient), amount);
             // Send the PlatformToken to recipient
-            IERC20 platformToken = recipient.getPlatformToken();
-            platformToken.safeTransferFrom(msg.sender, address(recipient), platformAmount);
+            uint256 platformAmount = _platformAmounts[i];
+            if(platformAmount > 0) {
+                IERC20 platformToken = recipient.getPlatformToken();
+                platformToken.safeTransferFrom(msg.sender, address(recipient), platformAmount);
+            }
             // Only after successful tx - notify the contract of the new funds
             recipient.notifyRewardAmount(amount);
 

--- a/contracts/rewards/staking/StakingRewardsWithPlatformToken.sol
+++ b/contracts/rewards/staking/StakingRewardsWithPlatformToken.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.5.16;
 
 // Internal
+import { IRewardsRecipientWithPlatformToken } from "../../interfaces/IRewardsDistributionRecipient.sol";
 import { RewardsDistributionRecipient } from "../RewardsDistributionRecipient.sol";
 import { StakingTokenWrapper } from "./StakingTokenWrapper.sol";
 import { PlatformTokenVendor } from "./PlatformTokenVendor.sol";
@@ -19,7 +20,7 @@ import { StableMath } from "../../shared/StableMath.sol";
  * additionally, distributes the Platform token airdropped by the platform
  * @dev    Derives from ./StakingRewards.sol and implements a secondary token into the core logic
  */
-contract StakingRewardsWithPlatformToken is StakingTokenWrapper, RewardsDistributionRecipient {
+contract StakingRewardsWithPlatformToken is StakingTokenWrapper, IRewardsRecipientWithPlatformToken, RewardsDistributionRecipient {
 
     using StableMath for uint256;
 

--- a/contracts/rewards/staking/StakingRewardsWithPlatformToken.sol
+++ b/contracts/rewards/staking/StakingRewardsWithPlatformToken.sol
@@ -215,6 +215,17 @@ contract StakingRewardsWithPlatformToken is StakingTokenWrapper, RewardsDistribu
     {
         return rewardsToken;
     }
+    
+    /**
+     * @dev Gets the PlatformToken
+     */
+    function getPlatformToken()
+        external
+        view
+        returns (IERC20)
+    {
+        return platformToken;
+    }
 
     /**
      * @dev Gets the last applicable timestamp for this reward period

--- a/contracts/z_mocks/rewards/MockRewardsDistributionRecipient.sol
+++ b/contracts/z_mocks/rewards/MockRewardsDistributionRecipient.sol
@@ -6,9 +6,11 @@ import { IRewardsDistributionRecipient } from "../../interfaces/IRewardsDistribu
 contract MockRewardsDistributionRecipient is IRewardsDistributionRecipient {
 
     IERC20 public rewardToken;
+    IERC20 public platformToken;
 
-    constructor(IERC20 _rewardToken) public {
+    constructor(IERC20 _rewardToken, IERC20 _platformToken) public {
         rewardToken = _rewardToken;
+        platformToken = _platformToken;
     }
 
     function notifyRewardAmount(uint256 reward)
@@ -19,5 +21,9 @@ contract MockRewardsDistributionRecipient is IRewardsDistributionRecipient {
 
     function getRewardToken() external view returns (IERC20) {
         return rewardToken;
+    }
+    
+    function getPlatformToken() external view returns (IERC20) {
+        return platformToken;
     }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "mocha": "^7.0.1",
     "parse-duration": "^0.1.2",
     "prettier": "^1.18.2",
+    "prettier-plugin-solidity": "^1.0.0-beta.13",
     "solc": "0.5.16",
     "truffle": "5.1.22",
     "truffle-plugin-verify": "^0.3.10",

--- a/test/rewards/TestRewardsDistributor.spec.ts
+++ b/test/rewards/TestRewardsDistributor.spec.ts
@@ -265,6 +265,41 @@ contract("RewardsDistributor", async (accounts) => {
                         platformAmount: new BN(0),
                     });
                 });
+                it("should succeed if rewardToken gt 0 & platformToken eq 0", async () => {
+                    const oneToken = simpleToExactAmount(1, 18);
+                    const twoToken = simpleToExactAmount(2, 18);
+                    await rewardToken1.approve(rewardsDistributor.address, twoToken, {
+                        from: sa.fundManager,
+                    });
+                    // erc balance before
+                    const funderBalBefore = await rewardToken1.balanceOf(sa.fundManager);
+                    const recipient1BalBefore = await rewardToken1.balanceOf(
+                        rewardRecipient1.address,
+                    );
+                    // distribute
+                    const tx = await rewardsDistributor.distributeRewards(
+                        [rewardRecipient1.address],
+                        [oneToken],
+                        [0],
+                        { from: sa.fundManager },
+                    );
+                    expectEvent(tx.receipt, "DistributedReward", {
+                        funder: sa.fundManager,
+                        recipient: rewardRecipient1.address,
+                        rewardToken: rewardToken1.address,
+                        amount: oneToken,
+                        platformToken: platformToken1.address,
+                        platformAmount: new BN(0),
+                    });
+                    // erc balance after
+                    const funderBalAfter = await rewardToken1.balanceOf(sa.fundManager);
+                    const recipient1BalAfter = await rewardToken1.balanceOf(
+                        rewardRecipient1.address,
+                    );
+                    // verify balance change
+                    expect(funderBalAfter).bignumber.eq(funderBalBefore.sub(oneToken));
+                    expect(recipient1BalAfter).bignumber.eq(recipient1BalBefore.add(oneToken));
+                });
                 it("should transfer the rewardToken & platformToken to all recipients", async () => {
                     const oneToken = simpleToExactAmount(1, 18);
                     const twoToken = simpleToExactAmount(2, 18);

--- a/test/rewards/TestRewardsDistributor.spec.ts
+++ b/test/rewards/TestRewardsDistributor.spec.ts
@@ -261,7 +261,7 @@ contract("RewardsDistributor", async (accounts) => {
                         recipient: rewardRecipient1.address,
                         rewardToken: rewardToken1.address,
                         amount: new BN(0),
-                        platformToken: platformToken1.address,
+                        platformToken: ZERO_ADDRESS,
                         platformAmount: new BN(0),
                     });
                 });
@@ -288,7 +288,7 @@ contract("RewardsDistributor", async (accounts) => {
                         recipient: rewardRecipient1.address,
                         rewardToken: rewardToken1.address,
                         amount: oneToken,
-                        platformToken: platformToken1.address,
+                        platformToken: ZERO_ADDRESS,
                         platformAmount: new BN(0),
                     });
                     // erc balance after

--- a/yarn.lock
+++ b/yarn.lock
@@ -515,6 +515,13 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
+"@solidity-parser/parser@^0.13.2":
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.13.2.tgz#b6c71d8ca0b382d90a7bbed241f9bc110af65cbe"
+  integrity sha512-RwHnpRnfrnD2MSPveYoPh8nhofEvX7fgjHk1Oq+NNvCcLx4r1js91CO9o+F/F3fBzOCyvm8kKRTriFICX/odWw==
+  dependencies:
+    antlr4ts "^0.5.0-alpha.4"
+
 "@solidity-parser/parser@^0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.7.1.tgz#660210130e4237476cb55e2882064809f80f861e"
@@ -1158,6 +1165,11 @@ antlr4ts@^0.5.0-alpha.3:
   version "0.5.0-alpha.3"
   resolved "https://registry.yarnpkg.com/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz#fa6d39d88d6b96341a8afef45867af9abcb38766"
   integrity sha512-La89tKkGcHFIVuruv4Bm1esc3zLmES2NOTEwwNS1pudz+zx/0FNqQeUu9p48i9/QHKPVqjN87LB+q3buTg7oDQ==
+
+antlr4ts@^0.5.0-alpha.4:
+  version "0.5.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz#71702865a87478ed0b40c0709f422cf14d51652a"
+  integrity sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==
 
 any-promise@1.3.0, any-promise@^1.3.0:
   version "1.3.0"
@@ -2805,6 +2817,11 @@ emoji-regex@^9.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.0.tgz#a26da8e832b16a9753309f25e35e3c0efb9a066a"
   integrity sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==
 
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -2965,6 +2982,11 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escodegen@1.8.x:
   version "1.8.1"
@@ -5818,6 +5840,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 lru-queue@0.1:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
@@ -6938,6 +6967,18 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
+prettier-plugin-solidity@^1.0.0-beta.13:
+  version "1.0.0-beta.13"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.13.tgz#2e31c5a5e2df3239e5e93704f9bcafe09a5f8190"
+  integrity sha512-AWMDRSabpNQMX7EqdDKgx/UVtQY6e3/Iu4gSPYDGvgiWl+OY8kYhAMll2NZHK/X+F0YYpPHYpebkDh7MGxbB1g==
+  dependencies:
+    "@solidity-parser/parser" "^0.13.2"
+    emoji-regex "^9.2.2"
+    escape-string-regexp "^4.0.0"
+    semver "^7.3.5"
+    solidity-comments-extractor "^0.0.7"
+    string-width "^4.2.2"
+
 prettier@^1.18.2:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
@@ -7592,6 +7633,13 @@ semver@^7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@~5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
@@ -7845,6 +7893,11 @@ solc@0.7.3:
     semver "^5.5.0"
     tmp "0.0.33"
 
+solidity-comments-extractor@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz#99d8f1361438f84019795d928b931f4e5c39ca19"
+  integrity sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==
+
 solidity-coverage@^0.7.12:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.7.12.tgz#0c6ca866cc6e15bfebecd71725666b3bc121f263"
@@ -8054,6 +8107,15 @@ string-width@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
+string-width@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
@@ -9754,6 +9816,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@13.1.2, yargs-parser@^13.1.0, yargs-parser@^13.1.2:
   version "13.1.2"


### PR DESCRIPTION
## Changelog:
- Adds `getPlatformToken()` to `StakingRewardsWithPlatformToken.sol`
- Adds argument of `platformAmounts` to `distributeRewards()` in `RewardsDistributor.sol`
- Updates `DistributedReward` event to include `platformAmounts` and `platformToken`
- Updates tests fo `RewardsDistributor.sol`