### PR TITLE
Set staking rewards duration on deployment

### DIFF
--- a/contracts/rewards/staking/StakingRewards.sol
+++ b/contracts/rewards/staking/StakingRewards.sol
@@ -30,18 +30,21 @@ contract StakingRewards is Initializable, StakingTokenWrapper, InitializableRewa
     using SafeERC20 for IERC20;
     using StableMath for uint256;
 
+    /// @notice token the rewards are distributed in. eg MTA
     IERC20 public immutable rewardsToken;
 
-    uint256 public constant DURATION = 7 days;
+    /// @notice length of each staking period in seconds. 7 days = 604,800; 3 months = 7,862,400
+    uint256 public immutable DURATION;
 
-    // Timestamp for current period finish
+    /// @notice Timestamp for current period finish
     uint256 public periodFinish = 0;
-    // RewardRate for the rest of the PERIOD
+    /// @notice RewardRate for the rest of the period
     uint256 public rewardRate = 0;
-    // Last time any user took action
+    /// @notice Last time any user took action
     uint256 public lastUpdateTime = 0;
-    // Ever increasing rewardPerToken rate, based on % of total supply
+    /// @notice Ever increasing rewardPerToken rate, based on % of total supply
     uint256 public rewardPerTokenStored = 0;
+
     mapping(address => uint256) public userRewardPerTokenPaid;
     mapping(address => uint256) public rewards;
 
@@ -54,30 +57,36 @@ contract StakingRewards is Initializable, StakingTokenWrapper, InitializableRewa
      * @param _nexus mStable system Nexus address
      * @param _stakingToken token that is beinf rewarded for being staked. eg MTA, imUSD or fPmUSD/GUSD
      * @param _rewardsToken first token that is being distributed as a reward. eg MTA
+     * @param _duration length of each staking period in seconds. 7 days = 604,800; 3 months = 7,862,400
      */
     constructor(
         address _nexus,
         address _stakingToken,
-        address _rewardsToken
+        address _rewardsToken,
+        uint256 _duration
     )
         public
         StakingTokenWrapper(_stakingToken)
         InitializableRewardsDistributionRecipient(_nexus)
     {
         rewardsToken = IERC20(_rewardsToken);
+        DURATION = _duration;
     }
 
     /**
-     * @param _rewardsDistributor mStable Reward Distributor contract address
+     * @dev Initialization function for upgradable proxy contract.
+     *      This function should be called via Proxy just after contract deployment.
+     *      To avoid variable shadowing appended `Arg` after arguments name.
+     * @param _rewardsDistributorArg mStable Reward Distributor contract address
      * @param _nameArg token name. eg imUSD Vault or GUSD Feeder Pool Vault
      * @param _symbolArg token symbol. eg v-imUSD or v-fPmUSD/GUSD
      */
     function initialize(
-        address _rewardsDistributor,
+        address _rewardsDistributorArg,
         string calldata _nameArg,
         string calldata _symbolArg
     ) external initializer {
-        InitializableRewardsDistributionRecipient._initialize(_rewardsDistributor);
+        InitializableRewardsDistributionRecipient._initialize(_rewardsDistributorArg);
         StakingTokenWrapper._initialize(_nameArg, _symbolArg);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mstable/protocol",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "description": "mStable Contracts",
     "author": "mStable <info@mstable.org>",
     "license": "AGPL-3.0-or-later",
@@ -23,7 +23,7 @@
         "lint:fix": "yarn pretty-quick --pattern '**/*.*(sol|json)' --staged --verbose",
         "lint-ts": "yarn eslint ./test --ext .ts --fix --quiet",
         "lint-sol": "solhint 'contracts/**/*.sol'",
-        "compile-abis": "typechain --target=ethers-v5 --out-dir types/generated \"?(contracts|build)/!(build-info)/**/+([a-zA-Z0-9]).json\"",
+        "compile-abis": "typechain --target=ethers-v5 --out-dir types/generated --out-dir dist/types/generated \"?(contracts|build)/!(build-info)/**/+([a-zA-Z0-9]).json\"",
         "compile-ts": "npx tsc",
         "compile": "yarn hardhat compile --force && yarn run compile-abis",
         "flatten": "npx sol-merger \"./contracts/**/*.sol\" ./_flat",

--- a/tasks/utils/networkAddressFactory.ts
+++ b/tasks/utils/networkAddressFactory.ts
@@ -126,5 +126,7 @@ export const getNetworkAddress = (contractName: ContractNames, networkName = "ma
         }
     }
 
-    throw Error(`Failed to find contract address for contract name ${contractName} on the ${networkName} network`)
+    throw Error(
+        `Failed to find contract address for contract name ${contractName} on the ${networkName} network and config Hardhat ${hardhatConfig}`,
+    )
 }

--- a/test/rewards/staking-rewards-with-platform-token.spec.ts
+++ b/test/rewards/staking-rewards-with-platform-token.spec.ts
@@ -49,6 +49,7 @@ describe("StakingRewardsWithPlatformToken", async () => {
             stakingToken.address,
             rewardToken.address,
             platformToken.address,
+            ONE_DAY.mul(7),
         )
         const initializeData = stakingRewardsImpl.interface.encodeFunctionData("initialize", [
             rewardsDistributor.address,

--- a/test/rewards/staking-rewards.spec.ts
+++ b/test/rewards/staking-rewards.spec.ts
@@ -33,6 +33,7 @@ describe("StakingRewards", async () => {
             nexusAddress,
             stakingToken.address,
             rewardToken.address,
+            ONE_DAY.mul(7),
         )
         const initializeData = stakingRewardsImpl.interface.encodeFunctionData("initialize", [
             rewardsDistributor.address,


### PR DESCRIPTION
- [x] In the `StakingReward` and `StakingRewardsWithPlatformToken` contracts, change the duration from a 7 days constant to an immutable.
- [x] Set the duration on contract deployment. eg 91 days for 3 months
- [x] Update unit tests
- [x] Update hardhat deployment task to pass the duration on deployment
- [x] Create a new hardhat task to deploy new impl with 3 month duration and upgrade the staking rewards proxy