### PR TITLE
wip: Fix intermittently failing CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,18 +68,6 @@ Tests are written with Hardhat, Ethers, Waffle & Typescript, using [Typechain](h
 $ yarn test
 ```
 
-#### Forking
-
-mStable-contracts test suite is built to support execution on a [mainnet fork](https://medium.com/ethereum-grid/forking-ethereum-mainnet-mint-your-own-dai-d8b62a82b3f7) of ganache. This allows tests to be ran using all mainnet dependencies (bAssets, lending protocols). To do this, certain mainnet accounts need to be unlocked to allows tx to be sent from that origin.
-
-_NB: The following commands assume you have a full Ethereum node running and exposed on local port 1234_
-
-```
-$ ganache-cli -f http://localhost:1234 -p 7545 -l 100000000 --allowUnlimitedContractSize --unlock "0x6cC5F688a315f3dC28A7781717a9A798a59fDA7b" --unlock "0x3f5CE5FBFe3E9af3971dD833D26bA9b5C936f0bE" --unlock "0x3dfd23a6c5e8bbcfc9581d2e864a68feb6a076d3"
-$ yarn compile
-$ truffle test ./test/xxx.spec.tx --network fork
-```
-
 #### Suite
 
 Key folders:

--- a/test/feeders/admin.spec.ts
+++ b/test/feeders/admin.spec.ts
@@ -1,3 +1,4 @@
+import { assertBNClose } from "@utils/assertions"
 import { ethers } from "hardhat"
 import { expect } from "chai"
 
@@ -305,7 +306,7 @@ describe("Feeder Admin", () => {
                     const incrementSeconds = startTime.add(testData.elapsedSeconds).sub(currentTime)
                     await increaseTime(incrementSeconds)
                     const config = await pool.getConfig()
-                    expect(config.a).to.eq(testData.expectedValaue)
+                    assertBNClose(config.a, BN.from(testData.expectedValaue), 4)
                 })
             }
         })

--- a/test/rewards/boosted-vault.spec.ts
+++ b/test/rewards/boosted-vault.spec.ts
@@ -1306,7 +1306,7 @@ describe("BoostedVault", async () => {
                 const r4 = data.userRewards[4]
                 const r5 = data.userRewards[5]
                 expect(r4.finish).to.be.eq(r5.start)
-                expect(r5.finish).to.be.eq(r5.start.add(1))
+                expect(r5.finish).to.be.lte(r5.start.add(2))
                 expect(r4.rate).to.be.eq(r5.rate)
                 assertBNClosePercent(r4.rate, lockedRewards(data.contractData.rewardRate), "0.001")
 


### PR DESCRIPTION
Tests relying on timestamps are failing intermittently as the timestamp increase cadence is not necessarily deterministic.

Trying to fix them all here. May need to run the CI a couple dozen times to catch the failing tests