### PR TITLE
feat: Add mock emission controller and hook into suite

### DIFF
--- a/test/governance/staked-token.spec.ts
+++ b/test/governance/staked-token.spec.ts
@@ -89,6 +89,7 @@ describe("Staked Token", () => {
         const emissionController = await new MockEmissionController__factory(sa.default.signer).deploy()
         await emissionController.addStakingContract(sToken.address)
         await emissionController.setPreferences(65793)
+        await sToken.connect(sa.governor.signer).setGovernanceHook(emissionController.address)
 
         return {
             stakedToken: sToken,


### PR DESCRIPTION
Before:
```
······························································|···························|·············|······························
|  Methods                                                                                                                            │
·····························|································|·············|·············|·············|···············|··············
|  Contract                  ·  Method                        ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
·····························|································|·············|·············|·············|···············|··············
|  IncentivisedVotingLockup  ·  createLock                    ·          -  ·          -  ·     242918  ·           10  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  IncentivisedVotingLockup  ·  exit                          ·     132094  ·     140942  ·     136527  ·            6  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  IncentivisedVotingLockup  ·  increaseLockAmount            ·          -  ·          -  ·     161621  ·            5  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  IncentivisedVotingLockup  ·  increaseLockLength            ·          -  ·          -  ·      28876  ·            1  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  MockERC20                 ·  approve                       ·      46251  ·      46275  ·      46271  ·          120  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  MockERC20                 ·  transfer                      ·      26909  ·      51609  ·      46879  ·           47  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  MockNexus                 ·  setRecollateraliser           ·          -  ·          -  ·      43940  ·           91  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  addQuest                      ·      68078  ·      85190  ·      72255  ·           82  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  addStakedToken                ·      79927  ·      79939  ·      79938  ·           91  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  completeQuests                ·     117501  ·     289453  ·     220785  ·           15  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  expireQuest                   ·          -  ·          -  ·      46358  ·            5  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  setQuestMaster                ·      35891  ·      41368  ·      38630  ·            4  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  setQuestSigner                ·          -  ·          -  ·      41155  ·            2  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  startNewQuestSeason           ·          -  ·          -  ·      72715  ·            2  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  blackListWrapper              ·          -  ·          -  ·      36054  ·            3  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  changeSlashingPercentage      ·          -  ·          -  ·      40833  ·           13  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  delegate                      ·      56932  ·     138415  ·     113005  ·           15  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  emergencyRecollateralisation  ·          -  ·          -  ·      77002  ·            8  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  endCooldown                   ·     129290  ·     129316  ·     129296  ·           18  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  reviewTimestamp               ·     127749  ·     127828  ·     127794  ·           14  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  stake                         ·     157940  ·     267113  ·     251215  ·          116  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  stake                         ·     237961  ·     242761  ·     241961  ·            6  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  stake                         ·          -  ·          -  ·     155696  ·            6  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  startCooldown                 ·     131731  ·     131817  ·     131797  ·           30  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  whitelistWrapper              ·      38015  ·      57915  ·      51282  ·            6  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  withdraw                      ·     140790  ·     152192  ·     145096  ·           18  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedTokenWrapper        ·  stake                         ·     167806  ·     250174  ·     222718  ·            3  ·          -  │
·····························|································|·············|·············|·············|···············|··············
```


After:
```
······························································|···························|·············|······························
|  Methods                                                                                                                            │
·····························|································|·············|·············|·············|···············|··············
|  Contract                  ·  Method                        ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
·····························|································|·············|·············|·············|···············|··············
|  IncentivisedVotingLockup  ·  createLock                    ·          -  ·          -  ·     278890  ·           10  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  IncentivisedVotingLockup  ·  exit                          ·     140942  ·     168087  ·     154510  ·            6  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  IncentivisedVotingLockup  ·  increaseLockAmount            ·          -  ·          -  ·     197593  ·            5  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  IncentivisedVotingLockup  ·  increaseLockLength            ·          -  ·          -  ·      28876  ·            1  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  MockEmissionController    ·  addStakingContract            ·     101303  ·     101315  ·     101314  ·           91  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  MockEmissionController    ·  setPreferences                ·          -  ·          -  ·     110381  ·           91  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  MockERC20                 ·  approve                       ·      46251  ·      46275  ·      46271  ·          120  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  MockERC20                 ·  transfer                      ·      26909  ·      51609  ·      46879  ·           47  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  MockNexus                 ·  setRecollateraliser           ·          -  ·          -  ·      43940  ·           91  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  addQuest                      ·      68078  ·      85190  ·      72255  ·           82  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  addStakedToken                ·      79927  ·      79939  ·      79938  ·           91  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  completeQuests                ·     117501  ·     325428  ·     249565  ·           15  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  expireQuest                   ·          -  ·          -  ·      46358  ·            5  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  setQuestMaster                ·      35891  ·      41368  ·      38630  ·            4  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  setQuestSigner                ·          -  ·          -  ·      41155  ·            2  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  QuestManager              ·  startNewQuestSeason           ·          -  ·          -  ·      72715  ·            2  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  blackListWrapper              ·          -  ·          -  ·      36054  ·            3  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  changeSlashingPercentage      ·          -  ·          -  ·      40833  ·           13  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  delegate                      ·      56932  ·     183424  ·     143365  ·           15  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  emergencyRecollateralisation  ·          -  ·          -  ·      77002  ·            8  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  endCooldown                   ·     165265  ·     165291  ·     165271  ·           18  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  reviewTimestamp               ·     163724  ·     163803  ·     163769  ·           14  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  setGovernanceHook             ·      57946  ·      57958  ·      57957  ·           91  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  stake                         ·     193912  ·     303085  ·     278416  ·          116  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  stake                         ·     273933  ·     278733  ·     277933  ·            6  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  stake                         ·          -  ·          -  ·     191668  ·            6  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  startCooldown                 ·     167698  ·     167784  ·     167764  ·           30  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  whitelistWrapper              ·      38015  ·      57915  ·      51282  ·            6  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedToken               ·  withdraw                      ·     140790  ·     188152  ·     163076  ·           18  ·          -  │
·····························|································|·············|·············|·············|···············|··············
|  StakedTokenWrapper        ·  stake                         ·     182580  ·     264948  ·     237492  ·            3  ·          -  │
·····························|································|·············|·············|·············|···············|··············
```