### PR TITLE
refactor: removes ts lint errors #143 (rebased)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,18 +20,27 @@ module.exports = {
         },
     },
     rules: {
-        "@typescript-eslint/no-use-before-define": 1,
         "import/no-extraneous-dependencies": "off",
         "no-console": "off",
         "import/prefer-default-export": "off",
         "no-nested-ternary": 1,
-        "@typescript-eslint/dot-notation": 1,
         "no-await-in-loop": 1,
         "no-restricted-syntax": 1,
+        "@typescript-eslint/dot-notation": 1,
+        "@typescript-eslint/no-use-before-define": 1,
         "@typescript-eslint/no-loop-func": 1,
         "@typescript-eslint/no-unused-expressions": 1,
         "lines-between-class-members": 0,
-        "prefer-destructuring": 1,
+        "prefer-destructuring": [
+            1,
+            {
+                array: false,
+                object: false,
+            },
+            {
+                enforceForRenamedProperties: false,
+            },
+        ],
     },
     overrides: [
         {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "scripts": {
         "lint": "yarn run lint-ts; yarn run lint-sol",
         "lint:fix": "yarn pretty-quick --pattern '**/*.*(sol|json)' --staged --verbose && yarn pretty-quick --staged --write tasks/**/*.ts test/**/*.ts types/*.ts",
-        "lint-ts": "yarn eslint ./test --ext .ts --fix --quiet",
+        "lint-ts": "yarn eslint tasks/ test/ types/ --ext .ts --quiet",
         "lint-sol": "solhint 'contracts/**/*.sol'",
         "compile-abis": "typechain --target=ethers-v5 --out-dir types/generated \"?(contracts|build)/!(build-info)/**/+([a-zA-Z0-9]).json\"",
         "compile-ts": "npx tsc",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "scripts": {
         "lint": "yarn run lint-ts; yarn run lint-sol",
         "lint:fix": "yarn pretty-quick --pattern '**/*.*(sol|json)' --staged --verbose && yarn pretty-quick --staged --write tasks/**/*.ts test/**/*.ts types/*.ts",
-        "lint-ts": "yarn eslint tasks/ test/ types/ --ext .ts --quiet",
+        "lint-ts": "yarn eslint tasks/ test/ types/ --ext .ts --fix",
         "lint-sol": "solhint 'contracts/**/*.sol'",
         "compile-abis": "typechain --target=ethers-v5 --out-dir types/generated \"?(contracts|build)/!(build-info)/**/+([a-zA-Z0-9]).json\"",
         "compile-ts": "npx tsc",

--- a/tasks/deployFeeders.ts
+++ b/tasks/deployFeeders.ts
@@ -95,7 +95,6 @@ task("deployVault", "Deploy Feeder Pool with boosted dual vault")
     .addOptionalParam("price", "Price coefficient is the value of the mAsset in USD. eg mUSD/USD = 1, mBTC/USD", 1, types.int)
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
     .setAction(async (taskArgs, hre) => {
-        const signer = await getSigner(hre, taskArgs.speed)
         const chain = getChain(hre)
 
         if (taskArgs.name?.length < 4) throw Error(`Invalid token name ${taskArgs.name}`)

--- a/tasks/deployIntegration.ts
+++ b/tasks/deployIntegration.ts
@@ -16,7 +16,7 @@ import { simpleToExactAmount } from "@utils/math"
 import { encodeUniswapPath } from "@utils/peripheral/uniswap"
 import { ZERO_ADDRESS } from "@utils/constants"
 import { deployContract, logTxDetails } from "./utils/deploy-utils"
-import { AAVE, ALCX, Chain, COMP, DAI, stkAAVE, tokens, USDC } from "./utils/tokens"
+import { AAVE, ALCX, Chain, COMP, DAI, stkAAVE, tokens } from "./utils/tokens"
 import { getChain, getChainAddress, resolveAddress } from "./utils/networkAddressFactory"
 import { getSigner } from "./utils/signerFactory"
 

--- a/tasks/deployMV3.ts
+++ b/tasks/deployMV3.ts
@@ -15,8 +15,7 @@ const defaultConfig = {
 
 task("deployMV3", "Deploys the mUSD V3 implementation").setAction(async (_, hre) => {
     const { ethers, network } = hre
-    const [deployer] = await ethers.getSigners()
-
+    
     const nexus = network.name === "mainnet" ? "0xafce80b19a8ce13dec0739a1aab7a028d6845eb3" : DEAD_ADDRESS
 
     const Logic = await ethers.getContractFactory("MassetLogic")

--- a/tasks/deployMbtc.ts
+++ b/tasks/deployMbtc.ts
@@ -36,6 +36,12 @@ interface CommonAddresses {
     renGatewayRegistry: string
 }
 
+interface BAssetRaw {
+    address: string
+    integrator: string
+    txFee: boolean
+}
+
 const COEFF = 45
 
 const deployBasset = async (sender: Signer, name: string, symbol: string, decimals = 18, initialMint = 500000): Promise<MockERC20> => {
@@ -353,7 +359,7 @@ task("reDeployMBTC", "Re-deploys the mBTC contracts given bAsset addresses").set
                   renGatewayRegistry: DEAD_ADDRESS,
               }
 
-    const bAssetsRaw: any[] = [
+    const bAssetsRaw: Array<BAssetRaw> = [
         {
             address: "0xd4Da7c3b1C985b8Baec8D2a5709409CCFE809096",
             integrator: ZERO_ADDRESS,
@@ -425,7 +431,7 @@ task("deployMBTC-mainnet", "Deploys the mBTC contracts to Mainnet").setAction(as
         poker: "0x0C2eF8a1b3Bc00Bf676053732F31a67ebbA5bD81",
         renGatewayRegistry: DEAD_ADDRESS,
     }
-    const bAssetsRaw: any[] = [
+    const bAssetsRaw: Array<BAssetRaw> = [
         {
             address: "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
             integrator: ZERO_ADDRESS,

--- a/tasks/deployPolygon.ts
+++ b/tasks/deployPolygon.ts
@@ -35,7 +35,6 @@ import {
     StakingRewardsWithPlatformToken__factory,
     StakingRewardsWithPlatformToken,
 } from "types/generated"
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address"
 import { DEAD_ADDRESS, KEY_LIQUIDATOR, KEY_PROXY_ADMIN, KEY_SAVINGS_MANAGER, ONE_DAY, ZERO_ADDRESS } from "@utils/constants"
 import { BN, simpleToExactAmount } from "@utils/math"
 import { formatUnits } from "@ethersproject/units"

--- a/tasks/deployRewards.ts
+++ b/tasks/deployRewards.ts
@@ -165,6 +165,7 @@ task("StakedToken.deploy", "Deploys a Staked Token behind a proxy")
         const stakedTokenLibraryAddresses = {
             "contracts/rewards/staking/PlatformTokenVendorFactory.sol:PlatformTokenVendorFactory": platformTokenVendorFactoryAddress,
         }
+         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let constructorArguments: any[]
         let stakedTokenImpl: Contract
         let data: string

--- a/tasks/feeder.ts
+++ b/tasks/feeder.ts
@@ -157,7 +157,7 @@ task("feeder-snap", "Gets feeder transactions over a period of time")
 
         const balances = await getBalances(feederPool, toBlock.blockNumber, fAsset, quantityFormatter)
 
-        const collectedInterestSummary = await getCollectedInterest(
+        await getCollectedInterest(
             fpAssets,
             feederPool,
             savingsManager,

--- a/tasks/mUSD.ts
+++ b/tasks/mUSD.ts
@@ -156,7 +156,7 @@ task("mUSD-snap", "Snaps mUSD")
 
         const balances = await getBalances(mAsset, accounts, usdFormatter, toBlock.blockNumber)
 
-        const collectedInterestSummary = await getCollectedInterest(
+        await getCollectedInterest(
             bAssets,
             mAsset,
             savingsManager,
@@ -221,6 +221,7 @@ task("mUSD-BassetAdded", "Lists the BassetAdded events from a mAsset")
         console.log(`${await mAsset.symbol()} ${mAsset.address}`)
         if (logs.length === 0)
             console.error(`Failed to find any BassetAdded events between blocks ${fromBlock.blockNumber} and ${toBlock.blockNumber}`)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         logs.forEach((log: any) => {
             console.log(`Basset added at block ${log.blockNumber} in tx ${log.blockHash}`)
         })

--- a/tasks/ops.ts
+++ b/tasks/ops.ts
@@ -126,6 +126,7 @@ task("proxy-upgrades", "Proxy implementation changes")
         const logs = await proxy.queryFilter(filter, fromBlock.blockNumber, toBlock.blockNumber)
 
         console.log(`${asset.symbol} proxy ${asset.address}`)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         logs.forEach((log: any) => {
             console.log(`Upgraded at block ${log.blockNumber} to ${log.args.implementation} in tx in ${log.blockHash}`)
         })

--- a/tasks/poker.ts
+++ b/tasks/poker.ts
@@ -110,12 +110,13 @@ task("over-boost", "Pokes accounts that are over boosted")
             accounts: string[]
         }[] = []
         // For each Boosted Vault
-        for (const vault of gqlData.boostedSavingsVaults) {
-            if (vault.id === mUSD.vault.toLocaleLowerCase()) continue
+        const vaults = gqlData.boostedSavingsVaults.filter((vault) => vault.id !== mUSD.vault.toLocaleLowerCase())
+        for (const vault of vaults) {
             const boostVault = BoostedVault__factory.connect(vault.id, signer)
             const priceCoeff = await boostVault.priceCoeff()
             const boostCoeff = await boostVault.boostCoeff()
 
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const overBoosted: any[] = []
             console.log(
                 `\nVault with id ${vault.id} for token ${vault.stakingToken.symbol}, ${vault.accounts.length} accounts, price coeff ${priceCoeff}, boost coeff ${boostCoeff}`,

--- a/tasks/utils/etherscan.ts
+++ b/tasks/utils/etherscan.ts
@@ -3,6 +3,7 @@ import { HardhatRuntimeEnvironment } from "hardhat/types"
 interface VerifyEtherscan {
     address: string
     contract?: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     constructorArguments?: any[]
     libraries?: {
         [libraryName: string]: string

--- a/tasks/utils/feederUtils.ts
+++ b/tasks/utils/feederUtils.ts
@@ -8,7 +8,6 @@ import {
     FeederPool,
     BoostedVault,
     MockERC20__factory,
-    FeederWrapper,
     MockInitializableToken__factory,
     AssetProxy__factory,
     MockERC20,
@@ -22,7 +21,7 @@ import {
     StakingRewardsWithPlatformToken__factory,
     StakingRewards__factory,
 } from "types/generated"
-import { deployContract, logTxDetails } from "./deploy-utils"
+import { deployContract } from "./deploy-utils"
 import { verifyEtherscan } from "./etherscan"
 import { getChain, getChainAddress } from "./networkAddressFactory"
 import { getSigner } from "./signerFactory"
@@ -132,6 +131,7 @@ export const deployFeederPool = async (signer: Signer, feederData: FeederData, c
 }
 
 export const deployVault = async (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     hre: any,
     vaultParams: VaultData,
 ): Promise<BoostedDualVault | BoostedVault | StakingRewardsWithPlatformToken | StakingRewards> => {
@@ -145,6 +145,7 @@ export const deployVault = async (
     const rewardsDistributorAddress = getChainAddress("RewardsDistributor", chain)
     const boostCoeff = 48
     let vault: BoostedDualVault | BoostedVault | StakingRewardsWithPlatformToken | StakingRewards
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let constructorArguments: any[]
     if (vaultData.boosted) {
         if (vaultData.dualRewardToken) {
@@ -265,26 +266,26 @@ export const deployVault = async (
 //     )
 // }
 
-const approveFeederWrapper = async (
-    sender: Signer,
-    feederWrapper: FeederWrapper,
-    feederPools: FeederPool[],
-    vaults: BoostedVault[],
-): Promise<void> => {
-    // Get tokens to approve
-    const len = feederPools.length
-    // eslint-disable-next-line
-    for (let i = 0; i < len; i++) {
-        const [[{ addr: massetAddr }, { addr: fassetAddr }]] = await feederPools[i].getBassets()
-        const masset = Masset__factory.connect(massetAddr, sender)
-        const [bassets] = await masset.getBassets()
-        const assets = [massetAddr, fassetAddr, ...bassets.map(({ addr }) => addr)]
+// const approveFeederWrapper = async (
+//     sender: Signer,
+//     feederWrapper: FeederWrapper,
+//     feederPools: FeederPool[],
+//     vaults: BoostedVault[],
+// ): Promise<void> => {
+//     // Get tokens to approve
+//     const len = feederPools.length
+//     // eslint-disable-next-line
+//     for (let i = 0; i < len; i++) {
+//         const [[{ addr: massetAddr }, { addr: fassetAddr }]] = await feederPools[i].getBassets()
+//         const masset = Masset__factory.connect(massetAddr, sender)
+//         const [bassets] = await masset.getBassets()
+//         const assets = [massetAddr, fassetAddr, ...bassets.map(({ addr }) => addr)]
 
-        // Make the approval in one tx
-        const approveTx = await feederWrapper["approve(address,address,address[])"](feederPools[i].address, vaults[i].address, assets)
-        await logTxDetails(approveTx, "Approved FeederWrapper tokens")
-    }
-}
+//         // Make the approval in one tx
+//         const approveTx = await feederWrapper["approve(address,address,address[])"](feederPools[i].address, vaults[i].address, assets)
+//         await logTxDetails(approveTx, "Approved FeederWrapper tokens")
+//     }
+// }
 
 // export const deployBoostedFeederPools = async (deployer: Signer, addresses: CommonAddresses, pairs: Pair[]): Promise<void> => {
 //     // 1.    Deploy boostDirector & Libraries

--- a/tasks/utils/networkAddressFactory.ts
+++ b/tasks/utils/networkAddressFactory.ts
@@ -50,6 +50,7 @@ export const contractNames = [
 export type ContractNames = typeof contractNames[number]
 
 export interface HardhatRuntime {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ethers?: any
     hardhatArguments?: {
         config?: string

--- a/tasks/utils/snap-utils.ts
+++ b/tasks/utils/snap-utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-restricted-syntax */
 import { Signer } from "ethers"
@@ -77,6 +78,7 @@ export function isMusdLegacy(asset: Masset | MusdEth | MusdLegacy | FeederPool):
     return (asset as MusdLegacy).getBasketManager !== undefined
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const getBlock = async (ethers, _blockNumber?: number): Promise<BlockInfo> => {
     const blockNumber = _blockNumber || (await ethers.provider.getBlockNumber())
     const toBlock = await ethers.provider.getBlock(blockNumber)
@@ -88,6 +90,7 @@ export const getBlock = async (ethers, _blockNumber?: number): Promise<BlockInfo
     }
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const getBlockRange = async (ethers, fromBlockNumber: number, _toBlockNumber?: number): Promise<BlockRange> => {
     const toBlockNumber = _toBlockNumber || (await ethers.provider.getBlockNumber())
     // const toBlock = await ethers.provider.getBlock(toBlockNumber)

--- a/test-fork/mUSD/mUSD-migrate.spec.ts.parked
+++ b/test-fork/mUSD/mUSD-migrate.spec.ts.parked
@@ -253,7 +253,7 @@ const validateBasset = (bAssets, i: number, expectToken: Token, expectVaultBalan
     }
     expect(bAssets.personal[i].addr, `${expectToken.symbol} address`).to.eq(expectToken.address)
     expect(bAssets.personal[i].integrator, `${expectToken.symbol} integrator`).to.eq(expectToken.integrator)
-    expect(bAssets.personal[i].hasTxFee, `${expectToken.symbol} hasTxFee`).to.be.false
+    expect(bAssets.personal[i].hasTxFee, `${expectToken.symbol} hasTxFee`).to.equal(false)
     expect(bAssets.personal[i].status, `${expectToken.symbol} status`).to.eq(BassetStatus.Normal)
     expect(bAssets.data[i].ratio, `${expectToken.symbol} ratio`).to.eq(simpleToExactAmount(1, 8 + (18 - expectToken.decimals)))
     expect(bAssets.data[i].vaultBalance, `${expectToken.symbol} vault`).to.eq(expectVaultBalances[i])
@@ -277,10 +277,10 @@ const validateNewMassetStorage = async (mUsd: MusdV2 | Masset, validator: string
 
     // Get basket state
     const basketState = await mUsd.basket()
-    expect(basketState.undergoingRecol, "undergoingRecol").to.be.true
-    expect(basketState[0], "basketState[0]").to.be.true
-    expect(basketState.failed, "undergoingRecol").to.be.false
-    expect(basketState[1], "basketState[1]").to.be.false
+    expect(basketState.undergoingRecol, "undergoingRecol").to.equal(true)
+    expect(basketState[0], "basketState[0]").to.equal(true)
+    expect(basketState.failed, "undergoingRecol").to.equal(false)
+    expect(basketState[1], "basketState[1]").to.equal(false)
 
     const invariantConfig = await mUsd.getConfig()
     expect(invariantConfig.a, "amplification coefficient (A)").to.eq(defaultConfig.a * 100)
@@ -749,10 +749,10 @@ describe("mUSD V2.0 to V3.0", () => {
                 await mUsdV2.proxy.connect(governor).negateIsolation(finalBassets[0].address)
                 // Get basket state
                 const basketState = await mUsdV2.proxy.basket()
-                expect(basketState.undergoingRecol, "undergoingRecol").to.be.false
-                expect(basketState[0], "basketState[0]").to.be.false
-                expect(basketState.failed, "undergoingRecol").to.be.false
-                expect(basketState[1], "basketState[1]").to.be.false
+                expect(basketState.undergoingRecol, "undergoingRecol").to.equal(false)
+                expect(basketState[0], "basketState[0]").to.equal(false)
+                expect(basketState.failed, "undergoingRecol").to.equal(false)
+                expect(basketState[1], "basketState[1]").to.equal(false)
             })
             // it("moves USDT to V2", async () => {
             //     await basketManager.migrateBassets([USDT.address], aaveV2.address)

--- a/test/feeders/admin.spec.ts
+++ b/test/feeders/admin.spec.ts
@@ -198,7 +198,7 @@ describe("Feeder Admin", () => {
             const { pool, mAsset } = details
             const asset = await pool.getBasset(mAsset.address)
             expect(asset.personal.addr, "personal.addr").to.eq(mAsset.address)
-            expect(asset.personal.hasTxFee, "personal.hasTxFee").to.false
+            expect(asset.personal.hasTxFee, "personal.hasTxFee").to.equal(false)
             expect(asset.personal.integrator, "personal.integrator").to.eq(ZERO_ADDRESS)
             expect(asset.personal.status, "personal.status").to.eq(BassetStatus.Normal)
             expect(asset.vaultData.ratio).to.eq(simpleToExactAmount(1, 8)) // 26 - 18
@@ -208,7 +208,7 @@ describe("Feeder Admin", () => {
             const { pool, fAsset } = details
             const asset = await pool.getBasset(fAsset.address)
             expect(asset.personal.addr, "personal.addr").to.eq(fAsset.address)
-            expect(asset.personal.hasTxFee, "personal.hasTxFee").to.false
+            expect(asset.personal.hasTxFee, "personal.hasTxFee").to.equal(false)
             expect(asset.personal.integrator, "personal.integrator").to.eq(ZERO_ADDRESS)
             expect(asset.personal.status, "personal.status").to.eq(BassetStatus.Normal)
             expect(asset.vaultData.ratio).to.eq(simpleToExactAmount(1, 8)) // 26 - 18
@@ -267,48 +267,48 @@ describe("Feeder Admin", () => {
                     // 60 * 60 * 24 * 10 / 2000 = 432
                     desc: "just under before increment",
                     elapsedSeconds: 61,
-                    expectedValaue: 30000,
+                    expectedValue: 30000,
                 },
                 {
                     desc: "just under after increment",
                     elapsedSeconds: 434,
-                    expectedValaue: 30005,
+                    expectedValue: 30005,
                 },
                 {
                     desc: "after 1 day",
                     elapsedSeconds: ONE_DAY.add(1),
-                    expectedValaue: 31000,
+                    expectedValue: 31000,
                 },
                 {
                     desc: "after 9 days",
                     elapsedSeconds: ONE_DAY.mul(9).add(1),
-                    expectedValaue: 39000,
+                    expectedValue: 39000,
                 },
                 {
                     desc: "just under 10 days",
                     elapsedSeconds: ONE_DAY.mul(10).sub(2),
-                    expectedValaue: 39999,
+                    expectedValue: 39999,
                 },
                 {
                     desc: "after 10 days",
                     elapsedSeconds: ONE_DAY.mul(10),
-                    expectedValaue: 40000,
+                    expectedValue: 40000,
                 },
                 {
                     desc: "after 11 days",
                     elapsedSeconds: ONE_DAY.mul(11),
-                    expectedValaue: 40000,
+                    expectedValue: 40000,
                 },
             ]
-            for (const testData of testsData) {
+            testsData.forEach((testData) => {
                 it(`should succeed getting A ${testData.desc}`, async () => {
                     const currentTime = await getTimestamp()
                     const incrementSeconds = startTime.add(testData.elapsedSeconds).sub(currentTime)
                     await increaseTime(incrementSeconds)
                     const config = await pool.getConfig()
-                    assertBNClose(config.a, BN.from(testData.expectedValaue), 20)
+                    assertBNClose(config.a, BN.from(testData.expectedValue), 20)
                 })
-            }
+            })
         })
         context("A target changes just in range", () => {
             let currentA: BN
@@ -370,48 +370,48 @@ describe("Feeder Admin", () => {
                     // 60 * 60 * 24 * 5 / 5000 = 86
                     desc: "just under before increment",
                     elapsedSeconds: 24,
-                    expectedValaue: 30000,
+                    expectedValue: 30000,
                 },
                 {
                     desc: "just under after increment",
                     elapsedSeconds: 88,
-                    expectedValaue: 29997,
+                    expectedValue: 29997,
                 },
                 {
                     desc: "after 1 day",
                     elapsedSeconds: ONE_DAY.add(1),
-                    expectedValaue: 27000,
+                    expectedValue: 27000,
                 },
                 {
                     desc: "after 4 days",
                     elapsedSeconds: ONE_DAY.mul(4).add(1),
-                    expectedValaue: 18000,
+                    expectedValue: 18000,
                 },
                 {
                     desc: "just under 5 days",
                     elapsedSeconds: ONE_DAY.mul(5).sub(2),
-                    expectedValaue: 15001,
+                    expectedValue: 15001,
                 },
                 {
                     desc: "after 5 days",
                     elapsedSeconds: ONE_DAY.mul(5),
-                    expectedValaue: 15000,
+                    expectedValue: 15000,
                 },
                 {
                     desc: "after 6 days",
                     elapsedSeconds: ONE_DAY.mul(6),
-                    expectedValaue: 15000,
+                    expectedValue: 15000,
                 },
             ]
-            for (const testData of testsData) {
+            testsData.forEach((testData) => {
                 it(`should succeed getting A ${testData.desc}`, async () => {
                     const currentTime = await getTimestamp()
                     const incrementSeconds = startTime.add(testData.elapsedSeconds).sub(currentTime)
                     await increaseTime(incrementSeconds)
                     const config = await pool.getConfig()
-                    assertBNClose(config.a, BN.from(testData.expectedValaue), 10)
+                    assertBNClose(config.a, BN.from(testData.expectedValue), 10)
                 })
-            }
+            })
         })
         describe("should fail to start ramp A", () => {
             before(async () => {

--- a/test/feeders/from-data/cross.spec.ts
+++ b/test/feeders/from-data/cross.spec.ts
@@ -35,6 +35,7 @@ const mAssetFees = { swap: simpleToExactAmount(6, 14), redeem: simpleToExactAmou
 const ratio = simpleToExactAmount(1, 8)
 const tolerance = BN.from(20)
 const cv = (n: number | string): BN => BN.from(BigInt(n).toString())
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getMPReserves = (data: any) =>
     [0, 1, 2, 3, 4, 5]
         .filter((i) => data[`mpAssetReserve${i}`])
@@ -42,6 +43,7 @@ const getMPReserves = (data: any) =>
             ratio,
             vaultBalance: cv(data[`mpAssetReserve${i}`]),
         }))
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getFPReserves = (data: any) =>
     [data.feederPoolMAssetReserve, data.feederPoolFAssetReserve].map((r) => ({
         ratio,
@@ -154,7 +156,7 @@ describe("Cross swap - One basket many tests", () => {
         let dataBefore: Data
         let count = 0
 
-        for (const testData of integrationData.actions.slice(0, runLongTests ? integrationData.actions.length : maxAction)) {
+        integrationData.actions.slice(0, runLongTests ? integrationData.actions.length : maxAction).forEach((testData) => {
             describe(`Action ${(count += 1)}`, () => {
                 before(async () => {
                     dataBefore = await getData(feederPool, mAsset)
@@ -285,7 +287,7 @@ describe("Cross swap - One basket many tests", () => {
                                     feederPool.getRedeemOutput(mpAssetAddresses[testData.outputIndex], testData.inputQty),
                                 ).to.be.revertedWith("Exceeds weight limits")
                             })
-                        } else if (testData["insufficientLiquidityError"]) {
+                        } else if (testData.insufficientLiquidityError) {
                             it(`throws insufficient liquidity error when redeeming ${testData.inputQty} mAssets for bAsset ${testData.outputIndex}`, async () => {
                                 await expect(
                                     feederPool.redeem(mpAssetAddresses[testData.outputIndex], testData.inputQty, 0, recipient),
@@ -335,6 +337,6 @@ describe("Cross swap - One basket many tests", () => {
                     }
                 })
             })
-        }
+        })
     })
 })

--- a/test/feeders/from-data/integration.spec.ts
+++ b/test/feeders/from-data/integration.spec.ts
@@ -22,6 +22,7 @@ const maxAction = 100
 const feederFees = { swap: simpleToExactAmount(8, 14), redeem: simpleToExactAmount(6, 14), gov: simpleToExactAmount(1, 17) }
 
 const cv = (n: number | string): BN => BN.from(BigInt(n).toString())
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getReserves = (data: any) =>
     [0, 1, 2, 3, 4, 5]
         .filter((i) => data[`reserve${i}`])

--- a/test/feeders/from-data/single.spec.ts
+++ b/test/feeders/from-data/single.spec.ts
@@ -32,6 +32,7 @@ const ratio = simpleToExactAmount(1, 8)
 const tolerance = 1
 
 const cv = (n: number | string): BN => BN.from(BigInt(n).toString())
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getReserves = (data: any) =>
     [0, 1, 2, 3, 4]
         .filter((i) => data[`reserve${i}`])
@@ -59,11 +60,11 @@ describe("Feeder Validator - One basket one test", () => {
     describe("Compute Mint", () => {
         let count = 0
         const testMintData = runLongTests ? mintData : mintData.slice(0, 2)
-        for (const testData of testMintData) {
+        testMintData.forEach((testData) => {
             const reserves = getReserves(testData)
             const localConfig = { ...config, supply: testData.LPTokenSupply }
             describe(`reserves: ${testData.reserve0}, ${testData.reserve1}`, () => {
-                for (const testMint of testData.mints) {
+                testData.mints.forEach((testMint) => {
                     if (testMint.hardLimitError) {
                         it(`${(count += 1)} throws Max Weight error when minting ${testMint.bAssetQty.toString()} bAssets with index ${
                             testMint.bAssetIndex
@@ -85,35 +86,35 @@ describe("Feeder Validator - One basket one test", () => {
                             expect(mAssetQty).eq(cv(testMint.expectedQty))
                         })
                     }
-                }
+                })
             })
-        }
+        })
     })
     describe("Compute Multi Mint", () => {
         let count = 0
         const testMultiMintData = runLongTests ? mintMultiData : mintMultiData.slice(0, 2)
-        for (const testData of testMultiMintData) {
+        testMultiMintData.forEach((testData) => {
             const reserves = getReserves(testData)
             const localConfig = { ...config, supply: testData.LPTokenSupply }
             describe(`reserves: ${testData.reserve0}, ${testData.reserve1}`, () => {
-                for (const testMint of testData.mints) {
+                testData.mints.forEach((testMint) => {
                     const qtys = testMint.bAssetQtys.map((b) => cv(b))
                     it(`${(count += 1)} deposit ${qtys} bAssets`, async () => {
                         const mAssetQty = await exposedFeeder.computeMintMulti(reserves, [0, 1], qtys, localConfig)
                         expect(mAssetQty).eq(cv(testMint.expectedQty))
                     })
-                }
+                })
             })
-        }
+        })
     })
     describe("Compute Swap", () => {
         let count = 0
         const testSwapData = runLongTests ? swapData : swapData.slice(0, 2)
-        for (const testData of testSwapData) {
+        testSwapData.forEach((testData) => {
             const reserves = getReserves(testData)
             const localConfig = { ...config, supply: testData.LPTokenSupply }
             describe(`reserves: ${testData.reserve0}, ${testData.reserve1}`, () => {
-                for (const testSwap of testData.swaps) {
+                testData.swaps.forEach((testSwap) => {
                     if (testSwap.hardLimitError) {
                         it(`${(count += 1)} throws Max Weight error when swapping ${testSwap.inputQty.toString()} ${
                             testSwap.inputIndex
@@ -144,18 +145,18 @@ describe("Feeder Validator - One basket one test", () => {
                             assertBNClose(result.bAssetOutputQuantity, cv(testSwap.outputQty), tolerance)
                         })
                     }
-                }
+                })
             })
-        }
+        })
     })
     describe("Compute Redeem", () => {
         let count = 0
         const testRedeemData = runLongTests ? redeemData : redeemData.slice(0, 2)
-        for (const testData of testRedeemData) {
+        testRedeemData.forEach((testData) => {
             const reserves = getReserves(testData)
             const localConfig = { ...config, supply: testData.LPTokenSupply }
             describe(`reserves: ${testData.reserve0}, ${testData.reserve1}`, () => {
-                for (const testRedeem of testData.redeems) {
+                testData.redeems.forEach((testRedeem) => {
                     // Deduct swap fee before performing redemption
                     const netInput = cv(testRedeem.mAssetQty).mul(fullScale.sub(redemptionFeeRate)).div(fullScale)
 
@@ -173,18 +174,18 @@ describe("Feeder Validator - One basket one test", () => {
                             assertBNClose(bAssetQty, cv(testRedeem.outputQty), 2)
                         })
                     }
-                }
+                })
             })
-        }
+        })
     })
     describe("Compute Exact Redeem", () => {
         let count = 0
         const testRedeemExactData = runLongTests ? redeemExactData : redeemExactData.slice(0, 2)
-        for (const testData of testRedeemExactData) {
+        testRedeemExactData.forEach((testData) => {
             const reserves = getReserves(testData)
             const localConfig = { ...config, supply: testData.LPTokenSupply }
             describe(`reserves: ${testData.reserve0}, ${testData.reserve1}`, () => {
-                for (const testRedeem of testData.redeems) {
+                testData.redeems.forEach((testRedeem) => {
                     // Deduct swap fee after performing redemption
                     const applyFee = (m: BN): BN => m.mul(fullScale).div(fullScale.sub(redemptionFeeRate))
                     const qtys = testRedeem.bAssetQtys.map((b) => cv(b))
@@ -207,15 +208,15 @@ describe("Feeder Validator - One basket one test", () => {
                             assertBNClose(applyFee(mAssetQty), cv(testRedeem.mAssetQty), tolerance)
                         })
                     }
-                }
+                })
             })
-        }
+        })
     })
 
     describe("Compute Redeem Masset", () => {
         let count = 0
         const testRedeemData = runLongTests ? redeemProportionalData : redeemProportionalData.slice(0, 2)
-        for (const testData of testRedeemData) {
+        testRedeemData.forEach((testData) => {
             const reserves = getReserves(testData)
             describe(`reserves: ${testData.reserve0}, ${testData.reserve1}`, () => {
                 let feederPool: FeederPool
@@ -285,9 +286,9 @@ describe("Feeder Validator - One basket one test", () => {
                     )
                 })
 
-                for (const testRedeem of testData.redeems) {
+                testData.redeems.forEach((testRedeem) => {
                     const qtys = testRedeem.bAssetQtys.map((b) => cv(b))
-                    if (testRedeem["insufficientLiquidityError"]) {
+                    if ("insufficientLiquidityError" in testRedeem) {
                         it(`${(count += 1)} throws throw insufficient liquidity error when redeeming ${
                             testRedeem.mAssetQty
                         } mAsset`, async () => {
@@ -295,7 +296,7 @@ describe("Feeder Validator - One basket one test", () => {
                                 "VM Exception",
                             )
                         })
-                    } else if (testRedeem["hardLimitError"]) {
+                    } else if ("hardLimitError" in testRedeem) {
                         it(`${(count += 1)} throws Max Weight error when redeeming ${qtys} bAssets`, async () => {
                             await expect(feederPool.redeemProportionately(cv(testRedeem.mAssetQty), qtys, recipient)).to.be.revertedWith(
                                 "Exceeds weight limits",
@@ -307,8 +308,8 @@ describe("Feeder Validator - One basket one test", () => {
                             await feederPool.redeemProportionately(cv(testRedeem.mAssetQty), qtys, recipient)
                         })
                     }
-                }
+                })
             })
-        }
+        })
     })
 })

--- a/test/feeders/mint.spec.ts
+++ b/test/feeders/mint.spec.ts
@@ -368,15 +368,15 @@ describe("Feeder - Mint", () => {
                 context("when feeder pool is paused", () => {
                     before(async () => {
                         const { pool } = details
-                        expect(await pool.paused(), "before pause").to.be.false
+                        expect(await pool.paused(), "before pause").to.equal(false)
                         await pool.connect(sa.governor.signer).pause()
-                        expect(await pool.paused(), "after pause").to.be.true
+                        expect(await pool.paused(), "after pause").to.equal(true)
                     })
                     after(async () => {
                         const { pool } = details
-                        expect(await pool.paused(), "before unpause").to.be.true
+                        expect(await pool.paused(), "before unpause").to.equal(true)
                         await pool.connect(sa.governor.signer).unpause()
-                        expect(await pool.paused(), "after unpause").to.be.false
+                        expect(await pool.paused(), "after unpause").to.equal(false)
                     })
                     it("should fail to mint feeder asset", async () => {
                         await assertFailedMint("Unhealthy", details.pool, details.fAsset, simpleToExactAmount(1), "999991742447046384")
@@ -631,15 +631,15 @@ describe("Feeder - Mint", () => {
                 context("when feeder pool is paused", () => {
                     before(async () => {
                         const { pool } = details
-                        expect(await pool.paused(), "before pause").to.be.false
+                        expect(await pool.paused(), "before pause").to.equal(false)
                         await pool.connect(sa.governor.signer).pause()
-                        expect(await pool.paused(), "after pause").to.be.true
+                        expect(await pool.paused(), "after pause").to.equal(true)
                     })
                     after(async () => {
                         const { pool } = details
-                        expect(await pool.paused(), "before unpause").to.be.true
+                        expect(await pool.paused(), "before unpause").to.equal(true)
                         await pool.connect(sa.governor.signer).unpause()
-                        expect(await pool.paused(), "after unpause").to.be.false
+                        expect(await pool.paused(), "after unpause").to.equal(false)
                     })
                     it("should fail to multi mint feeder asset", async () => {
                         await assertFailedMintMulti(

--- a/test/feeders/redeem.spec.ts
+++ b/test/feeders/redeem.spec.ts
@@ -182,7 +182,7 @@ describe("Feeder - Redeem", () => {
         await expect(tx, "Redeem event").to.emit(pool, "Redeemed")
         // TODO replace when Waffle supports withNamedArgs
         const redeemEvent = receipt.events.find((event) => event.event === "Redeemed" && event.address === pool.address)
-        expect(redeemEvent).to.exist
+        expect(redeemEvent).to.not.equal(undefined)
         expect(redeemEvent.args.redeemer, "redeemer in Redeemer event").to.eq(sender.address)
         expect(redeemEvent.args.recipient, "recipient in Redeemer event").to.eq(recipient)
         expect(redeemEvent.args.mAssetQuantity, "mAssetQuantity in Redeemer event").to.eq(fpTokenQuantityExact)
@@ -272,7 +272,7 @@ describe("Feeder - Redeem", () => {
         await expect(tx).to.emit(pool, "RedeemedMulti")
         // TODO replace when Waffle supports withNamedArgs
         const redeemEvent = receipt.events.find((event) => event.event === "RedeemedMulti" && event.address === pool.address)
-        expect(redeemEvent).to.exist
+        expect(redeemEvent).to.not.equal(undefined)
         expect(redeemEvent.args.redeemer, "redeemer in RedeemedMulti event").to.eq(sender.address)
         expect(redeemEvent.args.recipient, "recipient in RedeemedMulti event").to.eq(recipient)
         expect(redeemEvent.args.mAssetQuantity, "mAssetQuantity in RedeemedMulti event").to.eq(inputQuantityExpectedExact)
@@ -334,7 +334,7 @@ describe("Feeder - Redeem", () => {
         await expect(tx).to.emit(pool, "RedeemedMulti")
         // TODO replace when Waffle supports withNamedArgs
         const redeemEvent = receipt.events.find((event) => event.event === "RedeemedMulti" && event.address === pool.address)
-        expect(redeemEvent).to.exist
+        expect(redeemEvent).to.not.equal(undefined)
         expect(redeemEvent.args.redeemer, "redeemer in RedeemedMulti event").to.eq(sender.address)
         expect(redeemEvent.args.recipient, "recipient in RedeemedMulti event").to.eq(recipient)
         expect(redeemEvent.args.mAssetQuantity, "mAssetQuantity in RedeemedMulti event").to.eq(fpTokenQuantityExact)
@@ -465,15 +465,15 @@ describe("Feeder - Redeem", () => {
                 context("when feeder pool is paused", () => {
                     before(async () => {
                         const { pool } = details
-                        expect(await pool.paused(), "before pause").to.be.false
+                        expect(await pool.paused(), "before pause").to.equal(false)
                         await pool.connect(sa.governor.signer).pause()
-                        expect(await pool.paused(), "after pause").to.be.true
+                        expect(await pool.paused(), "after pause").to.equal(true)
                     })
                     after(async () => {
                         const { pool } = details
-                        expect(await pool.paused(), "before unpause").to.be.true
+                        expect(await pool.paused(), "before unpause").to.equal(true)
                         await pool.connect(sa.governor.signer).unpause()
-                        expect(await pool.paused(), "after unpause").to.be.false
+                        expect(await pool.paused(), "after unpause").to.equal(false)
                     })
                     it("should fail to redeem feeder asset", async () => {
                         const { fAsset, pool } = details
@@ -714,15 +714,15 @@ describe("Feeder - Redeem", () => {
                 context("when feeder pool is paused", () => {
                     before(async () => {
                         const { pool } = details
-                        expect(await pool.paused(), "before pause").to.be.false
+                        expect(await pool.paused(), "before pause").to.equal(false)
                         await pool.connect(sa.governor.signer).pause()
-                        expect(await pool.paused(), "after pause").to.be.true
+                        expect(await pool.paused(), "after pause").to.equal(true)
                     })
                     after(async () => {
                         const { pool } = details
-                        expect(await pool.paused(), "before unpause").to.be.true
+                        expect(await pool.paused(), "before unpause").to.equal(true)
                         await pool.connect(sa.governor.signer).unpause()
-                        expect(await pool.paused(), "after unpause").to.be.false
+                        expect(await pool.paused(), "after unpause").to.equal(false)
                     })
                     it("should fail to redeem exact feeder asset", async () => {
                         const { fAsset, pool } = details
@@ -856,15 +856,15 @@ describe("Feeder - Redeem", () => {
                 context("when feeder pool is paused", () => {
                     before(async () => {
                         const { pool } = details
-                        expect(await pool.paused(), "before pause").to.be.false
+                        expect(await pool.paused(), "before pause").to.equal(false)
                         await pool.connect(sa.governor.signer).pause()
-                        expect(await pool.paused(), "after pause").to.be.true
+                        expect(await pool.paused(), "after pause").to.equal(true)
                     })
                     after(async () => {
                         const { pool } = details
-                        expect(await pool.paused(), "before unpause").to.be.true
+                        expect(await pool.paused(), "before unpause").to.equal(true)
                         await pool.connect(sa.governor.signer).unpause()
-                        expect(await pool.paused(), "after unpause").to.be.false
+                        expect(await pool.paused(), "after unpause").to.equal(false)
                     })
                     it("should fail to redeem proportionately", async () => {
                         const { pool } = details

--- a/test/governance/ClaimableGovernor.behaviour.ts
+++ b/test/governance/ClaimableGovernor.behaviour.ts
@@ -13,7 +13,7 @@ export interface IClaimableGovernableBehaviourContext {
 export function shouldBehaveLikeClaimable(ctx: IClaimableGovernableBehaviourContext): void {
     it("should have a governor", async () => {
         const governor = await ctx.claimable.governor()
-        expect(governor !== ZERO_ADDRESS).to.be.true
+        expect(governor !== ZERO_ADDRESS).to.equal(true)
     })
 
     it("changes pendingGovernor after transfer", async () => {
@@ -21,7 +21,7 @@ export function shouldBehaveLikeClaimable(ctx: IClaimableGovernableBehaviourCont
         await ctx.claimable.connect(ctx.governor.signer).requestGovernorChange(newGovernor.address)
         const proposedGovernor = await ctx.claimable.proposedGovernor()
 
-        expect(proposedGovernor === newGovernor.address).to.be.true
+        expect(proposedGovernor === newGovernor.address).to.equal(true)
     })
 
     it("should prevent cancelGovernor from non-governor", async () => {
@@ -29,12 +29,12 @@ export function shouldBehaveLikeClaimable(ctx: IClaimableGovernableBehaviourCont
         const newGovernor = ctx.other
         await ctx.claimable.connect(ctx.governor.signer).requestGovernorChange(newGovernor.address)
         const proposedGovernor = await ctx.claimable.proposedGovernor()
-        expect(proposedGovernor === newGovernor.address).to.be.true
+        expect(proposedGovernor === newGovernor.address).to.equal(true)
 
         // Try to Cancel governor
         await expect(ctx.claimable.connect(ctx.default.signer).cancelGovernorChange()).to.be.revertedWith("GOV: caller is not the Governor")
         const newProposedGovernor = await ctx.claimable.proposedGovernor()
-        expect(proposedGovernor === newProposedGovernor).to.be.true
+        expect(proposedGovernor === newProposedGovernor).to.equal(true)
     })
 
     it("should prevent cancelGovernor from pending-governor", async () => {
@@ -42,12 +42,12 @@ export function shouldBehaveLikeClaimable(ctx: IClaimableGovernableBehaviourCont
         const newGovernor = ctx.other
         await ctx.claimable.connect(ctx.governor.signer).requestGovernorChange(newGovernor.address)
         const proposedGovernor = await ctx.claimable.proposedGovernor()
-        expect(proposedGovernor === newGovernor.address).to.be.true
+        expect(proposedGovernor === newGovernor.address).to.equal(true)
 
         // Try to Cancel governor
         await expect(ctx.claimable.connect(ctx.other.signer).cancelGovernorChange()).to.be.revertedWith("GOV: caller is not the Governor")
         const newProposedGovernor = await ctx.claimable.proposedGovernor()
-        expect(proposedGovernor === newProposedGovernor).to.be.true
+        expect(proposedGovernor === newProposedGovernor).to.equal(true)
     })
 
     it("should allow cancelGovernor from Governor", async () => {
@@ -56,16 +56,16 @@ export function shouldBehaveLikeClaimable(ctx: IClaimableGovernableBehaviourCont
         const currentGovernor = await ctx.claimable.governor()
         await ctx.claimable.connect(ctx.governor.signer).requestGovernorChange(newGovernor.address)
         const proposedGovernor = await ctx.claimable.proposedGovernor()
-        expect(proposedGovernor === newGovernor.address).to.be.true
+        expect(proposedGovernor === newGovernor.address).to.equal(true)
 
         // Try to Cancel governor
         await ctx.claimable.connect(ctx.governor.signer).cancelGovernorChange()
         const newProposedGovernor = await ctx.claimable.proposedGovernor()
         const governor = await ctx.claimable.governor()
 
-        expect(proposedGovernor !== ZERO_ADDRESS).to.be.true
-        expect(newProposedGovernor === ZERO_ADDRESS).to.be.true
-        expect(governor === currentGovernor).to.be.true
+        expect(proposedGovernor !== ZERO_ADDRESS).to.equal(true)
+        expect(newProposedGovernor === ZERO_ADDRESS).to.equal(true)
+        expect(governor === currentGovernor).to.equal(true)
     })
 
     it("should prevent Others to call claimOwnership when there is no pendingGovernor", async () => {
@@ -79,7 +79,7 @@ export function shouldBehaveLikeClaimable(ctx: IClaimableGovernableBehaviourCont
     it("should prevent non-governors from transfering", async () => {
         const governor = await ctx.claimable.governor()
 
-        expect(governor !== ctx.other.address).to.be.true
+        expect(governor !== ctx.other.address).to.equal(true)
         await expect(ctx.claimable.connect(ctx.other.signer).requestGovernorChange(ctx.other.address)).to.be.revertedWith(
             "GOV: caller is not the Governor",
         )

--- a/test/governance/claimable-governor.spec.ts
+++ b/test/governance/claimable-governor.spec.ts
@@ -33,7 +33,7 @@ describe("ClaimableGovernable", () => {
             await ctx.claimable.connect(newOwner.signer).claimGovernorChange()
             const owner = await ctx.claimable.governor()
 
-            expect(owner === newOwner.address).to.be.true
+            expect(owner === newOwner.address).to.equal(true)
         })
     })
 })

--- a/test/governance/incentivised-voting-lockup-gov.spec.ts
+++ b/test/governance/incentivised-voting-lockup-gov.spec.ts
@@ -376,7 +376,7 @@ describe("IncentivisedVotingLockup", () => {
 
                 expect(after.epoch).eq(before.epoch.add(1))
                 expect(after.totalStaticWeight).eq(before.totalStaticWeight)
-                expect(after.lastPoint.bias).lt(before.lastPoint.bias as any)
+                expect(after.lastPoint.bias).lt(before.lastPoint.bias)
                 expect(after.lastPoint.slope).eq(before.lastPoint.slope)
                 expect(after.lastPoint.blk).eq(BN.from((await latestBlock()).number))
             })

--- a/test/governance/incentivised-voting-lockup-rewards.spec.ts
+++ b/test/governance/incentivised-voting-lockup-rewards.spec.ts
@@ -54,7 +54,7 @@ const expectWithdrawEvent = async (
     const currentTime = await getTimestamp()
     await expect(tx).to.emit(votingLockup, EVENTS.WITHDRAW)
     const withdrawEvent = findContractEvent(receipt, votingLockup.address, EVENTS.WITHDRAW)
-    expect(withdrawEvent).to.exist
+    expect(withdrawEvent).to.not.equal(undefined)
     expect(withdrawEvent.args.provider, "provider in Withdraw event").to.eq(args.provider)
     expect(withdrawEvent.args.value, "value in Withdraw event").to.eq(args.value)
     assertBNClose(withdrawEvent.args.ts, currentTime.add(1), BN.from(10), "ts in Withdraw event")
@@ -204,17 +204,13 @@ describe("IncentivisedVotingLockupRewards", () => {
         shouldResetRewards = false,
     ): Promise<void> => {
         const timeAfter = await getTimestamp()
-        const periodIsFinished = BN.from(timeAfter).gt(beforeData.periodFinishTime)
-
+        const periodIsFinished = timeAfter.gt(beforeData.periodFinishTime)
+        const lastUpdateTokenTime =
+            beforeData.rewardPerTokenStored.eq(0) && beforeData.totalStaticWeight.eq(0) ? beforeData.lastUpdateTime : timeAfter
         //    LastUpdateTime
-        expect(
-            periodIsFinished
-                ? beforeData.periodFinishTime
-                : beforeData.rewardPerTokenStored.eq(0) && beforeData.totalStaticWeight.eq(0)
-                ? beforeData.lastUpdateTime
-                : timeAfter,
-        ).eq(afterData.lastUpdateTime)
-        //    RewardRate doesnt change
+        expect(periodIsFinished ? beforeData.periodFinishTime : lastUpdateTokenTime).eq(afterData.lastUpdateTime)
+
+        //    RewardRate does not change
         expect(beforeData.rewardRate).eq(afterData.rewardRate)
         //    RewardPerTokenStored goes up
         expect(afterData.rewardPerTokenStored).gte(beforeData.rewardPerTokenStored)
@@ -292,7 +288,7 @@ describe("IncentivisedVotingLockupRewards", () => {
         const receipt = await (await tx).wait()
         await expect(tx).to.emit(votingLockup, EVENTS.DEPOSIT)
         const depositEvent = findContractEvent(receipt, votingLockup.address, EVENTS.DEPOSIT)
-        expect(depositEvent).to.exist
+        expect(depositEvent).to.not.equal(undefined)
         expect(depositEvent.args.provider, "provider in Deposit event").to.eq(sender.address)
         expect(depositEvent.args.value, "value in Deposit event").to.eq(expectedAmount)
         expect(depositEvent.args.locktime, "locktime in Deposit event").to.eq(expectedLocktime)

--- a/test/governance/staking/staked-token-bpt.spec.ts
+++ b/test/governance/staking/staked-token-bpt.spec.ts
@@ -17,37 +17,39 @@ import {
     QuestManager,
     MockEmissionController__factory,
 } from "types"
-import { assertBNClose, DEAD_ADDRESS } from "index"
-import { ONE_DAY, ONE_WEEK, ZERO_ADDRESS } from "@utils/constants"
-import { BN, simpleToExactAmount } from "@utils/math"
+import { DEAD_ADDRESS } from "index"
+import { ONE_DAY, ONE_WEEK } from "@utils/constants"
+import { simpleToExactAmount } from "@utils/math"
 import { expect } from "chai"
-import { getTimestamp, increaseTime } from "@utils/time"
-import { arrayify, formatBytes32String, solidityKeccak256 } from "ethers/lib/utils"
-import { BigNumberish, Signer } from "ethers"
-import { QuestStatus, QuestType, UserStakingData } from "types/stakedToken"
+// import { getTimestamp } from "@utils/time"
+import { formatBytes32String } from "ethers/lib/utils"
 
-const signUserQuests = async (user: string, questIds: BigNumberish[], questSigner: Signer): Promise<string> => {
-    const messageHash = solidityKeccak256(["address", "uint256[]"], [user, questIds])
-    const signature = await questSigner.signMessage(arrayify(messageHash))
-    return signature
-}
+// import { arrayify, formatBytes32String, solidityKeccak256 } from "ethers/lib/utils"
+// import { BigNumberish, Signer } from "ethers"
+import { UserStakingData } from "types/stakedToken"
 
-const signQuestUsers = async (questId: BigNumberish, users: string[], questSigner: Signer): Promise<string> => {
-    const messageHash = solidityKeccak256(["uint256", "address[]"], [questId, users])
-    const signature = await questSigner.signMessage(arrayify(messageHash))
-    return signature
-}
+// const signUserQuests = async (user: string, questIds: BigNumberish[], questSigner: Signer): Promise<string> => {
+//     const messageHash = solidityKeccak256(["address", "uint256[]"], [user, questIds])
+//     const signature = await questSigner.signMessage(arrayify(messageHash))
+//     return signature
+// }
+
+// const signQuestUsers = async (questId: BigNumberish, users: string[], questSigner: Signer): Promise<string> => {
+//     const messageHash = solidityKeccak256(["uint256", "address[]"], [questId, users])
+//     const signature = await questSigner.signMessage(arrayify(messageHash))
+//     return signature
+// }
 
 describe("Staked Token BPT", () => {
     let sa: StandardAccounts
-    let deployTime: BN
+    // let deployTime: BN
 
     let nexus: MockNexus
     let rewardToken: MockERC20
     let stakedToken: MockStakedTokenWithPrice
     let questManager: QuestManager
 
-    const startingMintAmount = simpleToExactAmount(10000000)
+    // const startingMintAmount = simpleToExactAmount(10000000)
 
     console.log(`Staked contract size ${MockStakedTokenWithPrice__factory.bytecode.length / 2} bytes`)
 
@@ -57,7 +59,7 @@ describe("Staked Token BPT", () => {
     }
 
     const redeployStakedToken = async (): Promise<Deployment> => {
-        deployTime = await getTimestamp()
+        // deployTime = await getTimestamp()
         nexus = await new MockNexus__factory(sa.default.signer).deploy(sa.governor.address, DEAD_ADDRESS, DEAD_ADDRESS)
         await nexus.setRecollateraliser(sa.mockRecollateraliser.address)
         rewardToken = await new MockERC20__factory(sa.default.signer).deploy("Reward", "RWD", 18, sa.default.address, 10000000)

--- a/test/governance/staking/staked-token-mta.spec.ts
+++ b/test/governance/staking/staked-token-mta.spec.ts
@@ -35,17 +35,17 @@ export interface SnapData {
 
 describe("Staked Token MTA rewards", () => {
     let sa: StandardAccounts
-    let deployTime: BN
+    // let deployTime: BN
     let nexus: MockNexus
     let rewardToken: MockERC20
     let stakedToken: StakedToken
     let rewardsVendorAddress: string
-    const startingMintAmount = simpleToExactAmount(10000000)
+    // const startingMintAmount = simpleToExactAmount(10000000)
 
     console.log(`Staked Token MTA contract size ${StakedTokenMTA__factory.bytecode.length / 2} bytes`)
 
     const redeployStakedToken = async (): Promise<void> => {
-        deployTime = await getTimestamp()
+        // deployTime = await getTimestamp()
         nexus = await new MockNexus__factory(sa.default.signer).deploy(sa.governor.address, DEAD_ADDRESS, DEAD_ADDRESS)
         await nexus.setRecollateraliser(sa.mockRecollateraliser.address)
         rewardToken = await new MockERC20__factory(sa.default.signer).deploy(
@@ -284,7 +284,6 @@ describe("Staked Token MTA rewards", () => {
                 await increaseTime(ONE_DAY)
                 await rewardToken.connect(sa.mockRewardsDistributor.signer).transfer(stakedToken.address, distAmount)
                 await stakedToken.connect(sa.mockRewardsDistributor.signer).notifyRewardAmount(distAmount)
-                const firstDistTimestamp = await getTimestamp()
                 // distribute 2nd rewards
                 await increaseTime(ONE_DAY.mul(8))
                 const secondDistAmount = simpleToExactAmount(15000)
@@ -310,7 +309,7 @@ describe("Staked Token MTA rewards", () => {
                 // expect(user1DataAfter.rewardPerTokenStored, "rewardPerTokenStored user 1 after").to.eq(0)
                 expect(user1DataAfter.rewardPerTokenPaid, "rewardPerTokenPaid user 1 after").to.eq(0)
                 expect(user1DataAfter.rewards, "rewards user 1 after").to.eq(0)
-                const secondsPassed = secondDistTimestamp.sub(firstDistTimestamp)
+                // const secondsPassed = secondDistTimestamp.sub(firstDistTimestamp)
                 // user 1 earned 10000 * 1000 / (1000 + 2000) * 6 / 7 = 10000 * 6 / 21 = 2,857.1428571429
                 const user1EarnedExpected = distAmount.div(3)
                 assertBNClose(user1DataAfter.earned, user1EarnedExpected, 1000000)

--- a/test/governance/staking/staked-token.spec.ts
+++ b/test/governance/staking/staked-token.spec.ts
@@ -476,7 +476,7 @@ describe("Staked Token", () => {
 
                     await expect(tx).to.emit(stakedToken, "CooldownExited").withArgs(sa.default.address)
 
-                    const endCooldownTimestamp = await getTimestamp()
+                    // const endCooldownTimestamp = await getTimestamp()
                     const stakerDataAfter = await snapshotUserStakingData(sa.default.address)
                     expect(stakerDataAfter.userBalances.cooldownTimestamp, "cooldown timestamp after").to.eq(0)
                     expect(stakerDataAfter.userBalances.cooldownUnits, "cooldown units after").to.eq(0)
@@ -495,7 +495,7 @@ describe("Staked Token", () => {
 
                     await expect(tx).to.emit(stakedToken, "CooldownExited").withArgs(sa.default.address)
 
-                    const endCooldownTimestamp = await getTimestamp()
+                    // const endCooldownTimestamp = await getTimestamp()
                     const stakerDataAfter = await snapshotUserStakingData(sa.default.address)
                     expect(stakerDataAfter.userBalances.cooldownTimestamp, "cooldown timestamp after").to.eq(0)
                     expect(stakerDataAfter.userBalances.cooldownUnits, "cooldown units after").to.eq(0)
@@ -514,7 +514,7 @@ describe("Staked Token", () => {
 
                     await expect(tx).to.emit(stakedToken, "CooldownExited").withArgs(sa.default.address)
 
-                    const endCooldownTimestamp = await getTimestamp()
+                    // const endCooldownTimestamp = await getTimestamp()
                     const stakerDataAfter = await snapshotUserStakingData(sa.default.address)
                     expect(stakerDataAfter.userBalances.cooldownTimestamp, "cooldown timestamp after").to.eq(0)
                     expect(stakerDataAfter.userBalances.cooldownUnits, "cooldown units after").to.eq(0)
@@ -533,7 +533,7 @@ describe("Staked Token", () => {
 
                     await expect(tx).to.emit(stakedToken, "CooldownExited").withArgs(sa.default.address)
 
-                    const endCooldownTimestamp = await getTimestamp()
+                    // const endCooldownTimestamp = await getTimestamp()
                     const stakerDataAfter = await snapshotUserStakingData(sa.default.address)
                     expect(stakerDataAfter.userBalances.cooldownTimestamp, "cooldown timestamp after").to.eq(0)
                     expect(stakerDataAfter.userBalances.cooldownUnits, "cooldown units after").to.eq(0)
@@ -559,7 +559,7 @@ describe("Staked Token", () => {
 
                     await expect(tx).to.emit(stakedToken, "CooldownExited").withArgs(sa.default.address)
 
-                    const endCooldownTimestamp = await getTimestamp()
+                    // const endCooldownTimestamp = await getTimestamp()
                     const stakerDataAfter = await snapshotUserStakingData(sa.default.address)
                     expect(stakerDataAfter.userBalances.cooldownTimestamp, "cooldown timestamp after").to.eq(0)
                     expect(stakerDataAfter.userBalances.cooldownUnits, "cooldown units after").to.eq(0)
@@ -578,7 +578,7 @@ describe("Staked Token", () => {
 
                     await expect(tx).to.emit(stakedToken, "CooldownExited").withArgs(sa.default.address)
 
-                    const endCooldownTimestamp = await getTimestamp()
+                    // const endCooldownTimestamp = await getTimestamp()
                     const stakerDataAfter = await snapshotUserStakingData(sa.default.address)
                     expect(stakerDataAfter.userBalances.cooldownTimestamp, "cooldown timestamp after").to.eq(0)
                     expect(stakerDataAfter.userBalances.cooldownUnits, "cooldown units after").to.eq(0)
@@ -597,7 +597,7 @@ describe("Staked Token", () => {
 
                     await expect(tx).to.emit(stakedToken, "CooldownExited").withArgs(sa.default.address)
 
-                    const endCooldownTimestamp = await getTimestamp()
+                    // const endCooldownTimestamp = await getTimestamp()
                     const stakerDataAfter = await snapshotUserStakingData(sa.default.address)
                     expect(stakerDataAfter.userBalances.cooldownTimestamp, "cooldown timestamp after").to.eq(0)
                     expect(stakerDataAfter.userBalances.cooldownUnits, "cooldown units after").to.eq(0)
@@ -640,7 +640,7 @@ describe("Staked Token", () => {
                 // Stake 3000 on top of 7000 and end cooldown
                 const secondStakeAmount = simpleToExactAmount(3000)
                 const tx = await stakedToken["stake(uint256,bool)"](secondStakeAmount, true)
-                const secondStakedTimestamp = await getTimestamp()
+                // const secondStakedTimestamp = await getTimestamp()
 
                 await expect(tx).to.emit(stakedToken, "Staked").withArgs(sa.default.address, secondStakeAmount, ZERO_ADDRESS)
                 await expect(tx).to.emit(stakedToken, "DelegateChanged").not
@@ -681,7 +681,7 @@ describe("Staked Token", () => {
                 const secondStakeAmount = simpleToExactAmount(3000)
                 await stakedToken["stake(uint256,address)"](secondStakeAmount, sa.default.address)
 
-                const secondStakeTimestamp = await getTimestamp()
+                // const secondStakeTimestamp = await getTimestamp()
 
                 const stakerDataAfter = await snapshotUserStakingData(sa.default.address)
                 expect(stakerDataAfter.userBalances.cooldownTimestamp, "staker cooldown timestamp after 2nd stake").to.eq(
@@ -1089,7 +1089,7 @@ describe("Staked Token", () => {
                 .to.emit(rewardToken, "Transfer")
                 .withArgs(stakedToken.address, sa.default.address, stakedAmount.sub(redemptionFee))
 
-            const withdrawTimestamp = await getTimestamp()
+            // const withdrawTimestamp = await getTimestamp()
             const afterData = await snapshotUserStakingData(sa.default.address)
             expect(afterData.stakedBalance, "staker stkRWD after").to.eq(0)
             expect(afterData.votes, "staker votes after").to.eq(0)
@@ -1111,10 +1111,10 @@ describe("Staked Token", () => {
             await rewardToken.transfer(stakedTokenWrapper.address, stakedAmount.mul(3))
         })
         it("should allow governor to whitelist a contract", async () => {
-            expect(await stakedToken.whitelistedWrappers(stakedTokenWrapper.address), "wrapper not whitelisted before").to.be.false
+            expect(await stakedToken.whitelistedWrappers(stakedTokenWrapper.address), "wrapper not whitelisted before").to.equal(false)
             const tx = await stakedToken.connect(sa.governor.signer).whitelistWrapper(stakedTokenWrapper.address)
             await expect(tx).to.emit(stakedToken, "WrapperWhitelisted").withArgs(stakedTokenWrapper.address)
-            expect(await stakedToken.whitelistedWrappers(stakedTokenWrapper.address), "wrapper whitelisted after").to.be.true
+            expect(await stakedToken.whitelistedWrappers(stakedTokenWrapper.address), "wrapper whitelisted after").to.equal(true)
 
             const tx2 = await stakedTokenWrapper["stake(uint256)"](stakedAmount)
             await expect(tx2).to.emit(stakedToken, "Staked").withArgs(stakedTokenWrapper.address, stakedAmount, ZERO_ADDRESS)
@@ -1122,11 +1122,11 @@ describe("Staked Token", () => {
         it("should allow governor to blacklist a contract", async () => {
             const tx = await stakedToken.connect(sa.governor.signer).whitelistWrapper(stakedTokenWrapper.address)
             await expect(tx).to.emit(stakedToken, "WrapperWhitelisted").withArgs(stakedTokenWrapper.address)
-            expect(await stakedToken.whitelistedWrappers(stakedTokenWrapper.address), "wrapper whitelisted").to.be.true
+            expect(await stakedToken.whitelistedWrappers(stakedTokenWrapper.address), "wrapper whitelisted").to.equal(true)
 
             const tx2 = await stakedToken.connect(sa.governor.signer).blackListWrapper(stakedTokenWrapper.address)
             await expect(tx2).to.emit(stakedToken, "WrapperBlacklisted").withArgs(stakedTokenWrapper.address)
-            expect(await stakedToken.whitelistedWrappers(stakedTokenWrapper.address), "wrapper not whitelisted").to.be.false
+            expect(await stakedToken.whitelistedWrappers(stakedTokenWrapper.address), "wrapper not whitelisted").to.equal(false)
 
             await expect(stakedTokenWrapper["stake(uint256)"](stakedAmount)).to.revertedWith("Not a whitelisted contract")
         })
@@ -1436,7 +1436,7 @@ describe("Staked Token", () => {
             })
             it("should allow quest signer to complete a user's seasonal quest", async () => {
                 const userAddress = sa.default.address
-                expect(await questManager.hasCompleted(userAddress, seasonQuestId), "quest completed before").to.be.false
+                expect(await questManager.hasCompleted(userAddress, seasonQuestId), "quest completed before").to.equal(false)
 
                 // Complete User Season Quest
                 const signature = await signUserQuests(userAddress, [seasonQuestId], sa.questSigner.signer)
@@ -1446,7 +1446,7 @@ describe("Staked Token", () => {
                 await expect(tx).to.emit(questManager, "QuestCompleteQuests").withArgs(userAddress, [seasonQuestId])
 
                 // Check data
-                expect(await questManager.hasCompleted(userAddress, seasonQuestId), "quest completed after").to.be.true
+                expect(await questManager.hasCompleted(userAddress, seasonQuestId), "quest completed after").to.equal(true)
                 const userDataAfter = await snapshotUserStakingData(userAddress)
                 expect(userDataAfter.userBalances.cooldownTimestamp, "cooldown timestamp after").to.eq(0)
                 expect(userDataAfter.userBalances.cooldownUnits, "cooldown units after").to.eq(0)
@@ -1462,7 +1462,7 @@ describe("Staked Token", () => {
             })
             it("should allow quest signer to complete a user's permanent quest", async () => {
                 const userAddress = sa.default.address
-                expect(await questManager.hasCompleted(userAddress, permanentQuestId), "quest completed before").to.be.false
+                expect(await questManager.hasCompleted(userAddress, permanentQuestId), "quest completed before").to.equal(false)
 
                 // Complete User Permanent Quest
                 const signature = await signUserQuests(userAddress, [permanentQuestId], sa.questSigner.signer)
@@ -1471,7 +1471,7 @@ describe("Staked Token", () => {
                 // Check events
                 await expect(tx).to.emit(questManager, "QuestCompleteQuests").withArgs(userAddress, [permanentQuestId])
                 // Check data
-                expect(await questManager.hasCompleted(userAddress, permanentQuestId), "quest completed after").to.be.true
+                expect(await questManager.hasCompleted(userAddress, permanentQuestId), "quest completed after").to.equal(true)
                 const userDataAfter = await snapshotUserStakingData(userAddress)
                 expect(userDataAfter.userBalances.cooldownTimestamp, "cooldown timestamp after").to.eq(0)
                 expect(userDataAfter.userBalances.cooldownUnits, "cooldown units after").to.eq(0)
@@ -1487,7 +1487,7 @@ describe("Staked Token", () => {
             })
             it("should complete user quest before a user stakes", async () => {
                 const userAddress = sa.dummy1.address
-                expect(await questManager.hasCompleted(userAddress, permanentQuestId), "quest completed before").to.be.false
+                expect(await questManager.hasCompleted(userAddress, permanentQuestId), "quest completed before").to.equal(false)
 
                 // Complete User Permanent and Seasonal Quests
                 const signature = await signUserQuests(userAddress, [permanentQuestId, seasonQuestId], sa.questSigner.signer)
@@ -1501,7 +1501,7 @@ describe("Staked Token", () => {
                 await expect(tx).to.emit(questManager, "QuestCompleteQuests").withArgs(userAddress, [permanentQuestId, seasonQuestId])
 
                 // Check data
-                expect(await questManager.hasCompleted(userAddress, permanentQuestId), "quest completed after").to.be.true
+                expect(await questManager.hasCompleted(userAddress, permanentQuestId), "quest completed after").to.equal(true)
                 const userDataAfter = await snapshotUserStakingData(userAddress)
                 expect(userDataAfter.userBalances.raw, "staked raw balance after").to.eq(0)
                 expect(userDataAfter.userBalances.weightedTimestamp, "weighted timestamp after").to.eq(0)
@@ -1517,10 +1517,10 @@ describe("Staked Token", () => {
                 const user2Address = sa.dummy2.address
                 const user3Address = sa.dummy3.address
                 const user4Address = sa.dummy4.address
-                expect(await questManager.hasCompleted(user1Address, permanentQuestId), "user 1 quest completed before").to.be.false
-                expect(await questManager.hasCompleted(user2Address, permanentQuestId), "user 2 quest completed before").to.be.false
-                expect(await questManager.hasCompleted(user3Address, permanentQuestId), "user 3 quest completed before").to.be.false
-                expect(await questManager.hasCompleted(user4Address, permanentQuestId), "user 4 quest completed before").to.be.false
+                expect(await questManager.hasCompleted(user1Address, permanentQuestId), "user 1 quest completed before").to.equal(false)
+                expect(await questManager.hasCompleted(user2Address, permanentQuestId), "user 2 quest completed before").to.equal(false)
+                expect(await questManager.hasCompleted(user3Address, permanentQuestId), "user 3 quest completed before").to.equal(false)
+                expect(await questManager.hasCompleted(user4Address, permanentQuestId), "user 4 quest completed before").to.equal(false)
 
                 // Complete User Permanent and Seasonal Quests
                 const signature = await signQuestUsers(
@@ -1540,8 +1540,8 @@ describe("Staked Token", () => {
                     .withArgs(permanentQuestId, [user1Address, user2Address, user3Address, user4Address])
 
                 // Check data
-                expect(await questManager.hasCompleted(user1Address, permanentQuestId), "user 1 quest completed after").to.be.true
-                expect(await questManager.hasCompleted(user2Address, permanentQuestId), "user 2 quest completed after").to.be.true
+                expect(await questManager.hasCompleted(user1Address, permanentQuestId), "user 1 quest completed after").to.equal(true)
+                expect(await questManager.hasCompleted(user2Address, permanentQuestId), "user 2 quest completed after").to.equal(true)
                 const user1DataAfter = await snapshotUserStakingData(user1Address)
                 expect(user1DataAfter.questBalance.lastAction, "user 1 last action after").to.eq(completeQuestTimestamp)
                 expect(user1DataAfter.questBalance.permMultiplier, "user 1 perm multiplier after").to.eq(permanentMultiplier)

--- a/test/masset/admin.spec.ts
+++ b/test/masset/admin.spec.ts
@@ -1,7 +1,7 @@
 import { ethers } from "hardhat"
 import { expect } from "chai"
 
-import { simpleToExactAmount, BN, applyRatio } from "@utils/math"
+import { simpleToExactAmount, BN } from "@utils/math"
 import { MassetDetails, MassetMachine, StandardAccounts } from "@utils/machines"
 
 import { DEAD_ADDRESS, MAX_UINT256, ONE_DAY, ONE_HOUR, ONE_WEEK, TEN_MINS, ZERO_ADDRESS } from "@utils/constants"
@@ -181,36 +181,36 @@ describe("Masset Admin", () => {
             })
             it("when no integration balance", async () => {
                 const { personal } = await details.mAsset.getBasset(details.bAssets[3].address)
-                expect(personal.hasTxFee).to.be.false
+                expect(personal.hasTxFee).to.equal(false)
 
                 const tx = details.mAsset.connect(sa.governor.signer).setTransferFeesFlag(personal.addr, true)
                 await expect(tx).to.emit(details.wrappedManagerLib, "TransferFeeEnabled").withArgs(personal.addr, true)
                 const { personal: after } = await details.mAsset.getBasset(details.bAssets[3].address)
-                expect(after.hasTxFee).to.be.true
+                expect(after.hasTxFee).to.equal(true)
 
                 // restore the flag back to false
                 const tx2 = details.mAsset.connect(sa.governor.signer).setTransferFeesFlag(personal.addr, false)
                 await expect(tx2).to.emit(details.wrappedManagerLib, "TransferFeeEnabled").withArgs(personal.addr, false)
                 await tx2
                 const { personal: end } = await details.mAsset.getBasset(details.bAssets[3].address)
-                expect(end.hasTxFee).to.be.false
+                expect(end.hasTxFee).to.equal(false)
             })
             it("when an integration balance", async () => {
                 const { personal } = await details.mAsset.getBasset(details.bAssets[2].address)
-                expect(personal.hasTxFee).to.be.false
+                expect(personal.hasTxFee).to.equal(false)
 
                 const tx = details.mAsset.connect(sa.governor.signer).setTransferFeesFlag(personal.addr, true)
                 await expect(tx).to.emit(details.wrappedManagerLib, "TransferFeeEnabled").withArgs(personal.addr, true)
 
                 const { personal: after } = await details.mAsset.getBasset(details.bAssets[2].address)
-                expect(after.hasTxFee).to.be.true
+                expect(after.hasTxFee).to.equal(true)
 
                 // restore the flag back to false
                 const tx2 = details.mAsset.connect(sa.governor.signer).setTransferFeesFlag(personal.addr, false)
                 await expect(tx2).to.emit(details.wrappedManagerLib, "TransferFeeEnabled").withArgs(personal.addr, false)
 
                 const { personal: end } = await details.mAsset.getBasset(details.bAssets[2].address)
-                expect(end.hasTxFee).to.be.false
+                expect(end.hasTxFee).to.equal(false)
             })
         })
     })
@@ -230,7 +230,7 @@ describe("Masset Admin", () => {
             const { mAsset, bAssets } = details
             const bAsset = await mAsset.getBasset(bAssets[0].address)
             expect(bAsset.personal.addr).to.eq(bAsset[0].addr)
-            expect(bAsset.personal.hasTxFee).to.false
+            expect(bAsset.personal.hasTxFee).to.equal(false)
             expect(bAsset.personal.integrator).to.eq(bAsset[0].integrator)
             expect(bAsset.personal.status).to.eq(BassetStatus.Normal)
         })
@@ -316,7 +316,7 @@ describe("Masset Admin", () => {
             // 2.0 Get all balances and data before
             const mAssetBalBefore = await details.mAsset.balanceOf(sa.mockSavingsManager.address)
             const bassetsBefore = await mAssetMachine.getBassetsInMasset(details)
-            const sumOfVaultsBefore = bassetsBefore.reduce((p, c) => p.add(applyRatio(c.vaultBalance, c.ratio)), BN.from(0))
+            // const sumOfVaultsBefore = bassetsBefore.reduce((p, c) => p.add(applyRatio(c.vaultBalance, c.ratio)), BN.from(0))
             const totalSupplyBefore = await details.mAsset.totalSupply()
 
             // 3.0 Check the SavingsManager in the mock Nexus contract
@@ -541,11 +541,11 @@ describe("Masset Admin", () => {
         it("should skip when Normal (by governor)", async () => {
             const { bAssets, mAsset, wrappedManagerLib } = details
             const basketBefore = await mAsset.getBasket()
-            expect(basketBefore[0]).to.false
+            expect(basketBefore[0]).to.equal(false)
             const tx = mAsset.connect(sa.governor.signer).negateIsolation(bAssets[0].address)
             await expect(tx).to.emit(wrappedManagerLib, "BassetStatusChanged").withArgs(bAssets[0].address, BassetStatus.Normal)
             const afterBefore = await mAsset.getBasket()
-            expect(afterBefore[0]).to.false
+            expect(afterBefore[0]).to.equal(false)
         })
         it("should fail when called by default", async () => {
             const { bAssets, mAsset } = details
@@ -564,14 +564,14 @@ describe("Masset Admin", () => {
             const bAsset = bAssets[1]
 
             const basketBefore = await mAsset.getBasket()
-            expect(basketBefore[0], "before undergoingRecol").to.false
+            expect(basketBefore[0], "before undergoingRecol").to.equal(false)
             const bAssetStateBefore = await mAsset.getBasset(bAsset.address)
             expect(bAssetStateBefore.personal.status).to.eq(BassetStatus.Normal)
 
             await mAsset.connect(sa.governor.signer).handlePegLoss(bAsset.address, false)
 
             const basketAfterPegLoss = await mAsset.getBasket()
-            expect(basketAfterPegLoss[0], "after handlePegLoss undergoingRecol").to.true
+            expect(basketAfterPegLoss[0], "after handlePegLoss undergoingRecol").to.equal(true)
             const bAssetStateAfterPegLoss = await mAsset.getBasset(bAsset.address)
             expect(bAssetStateAfterPegLoss.personal.status, "after handlePegLoss personal.status").to.eq(BassetStatus.BrokenAbovePeg)
 
@@ -580,7 +580,7 @@ describe("Masset Admin", () => {
             await expect(tx).to.emit(wrappedManagerLib, "BassetStatusChanged").withArgs(bAsset.address, BassetStatus.Normal)
             await tx
             const basketAfterNegateIsolation = await mAsset.getBasket()
-            expect(basketAfterNegateIsolation[0], "after negateIsolation undergoingRecol").to.false
+            expect(basketAfterNegateIsolation[0], "after negateIsolation undergoingRecol").to.equal(false)
             const bAssetStateAfterNegateIsolation = await mAsset.getBasset(bAsset.address)
             expect(bAssetStateAfterNegateIsolation.personal.status, "after negateIsolation personal.status").to.eq(BassetStatus.Normal)
         })
@@ -588,13 +588,13 @@ describe("Masset Admin", () => {
             const { bAssets, mAsset, wrappedManagerLib } = details
 
             const basketBefore = await mAsset.getBasket()
-            expect(basketBefore[0], "before undergoingRecol").to.false
+            expect(basketBefore[0], "before undergoingRecol").to.equal(false)
 
             await mAsset.connect(sa.governor.signer).handlePegLoss(bAssets[2].address, true)
             await mAsset.connect(sa.governor.signer).handlePegLoss(bAssets[3].address, true)
 
             const basketAfterPegLoss = await mAsset.getBasket()
-            expect(basketAfterPegLoss[0], "after handlePegLoss undergoingRecol").to.true
+            expect(basketAfterPegLoss[0], "after handlePegLoss undergoingRecol").to.equal(true)
             const bAsset2StateAfterPegLoss = await mAsset.getBasset(bAssets[2].address)
             expect(bAsset2StateAfterPegLoss.personal.status, "after handlePegLoss personal.status 2").to.eq(BassetStatus.BrokenBelowPeg)
             const bAsset3StateAfterPegLoss = await mAsset.getBasset(bAssets[3].address)
@@ -605,7 +605,7 @@ describe("Masset Admin", () => {
             await expect(tx).to.emit(wrappedManagerLib, "BassetStatusChanged").withArgs(bAssets[3].address, BassetStatus.Normal)
             await tx
             const basketAfterNegateIsolation = await mAsset.getBasket()
-            expect(basketAfterNegateIsolation[0], "after negateIsolation undergoingRecol").to.true
+            expect(basketAfterNegateIsolation[0], "after negateIsolation undergoingRecol").to.equal(true)
             const bAsset2AfterNegateIsolation = await mAsset.getBasset(bAssets[2].address)
             expect(bAsset2AfterNegateIsolation.personal.status, "after negateIsolation personal.status 2").to.eq(
                 BassetStatus.BrokenBelowPeg,
@@ -659,47 +659,47 @@ describe("Masset Admin", () => {
                     // 60 * 60 * 24 * 10 / 2000 = 432
                     desc: "just under before increment",
                     elapsedSeconds: 431,
-                    expectedValaue: 10000,
+                    expectedValue: 10000,
                 },
                 {
                     desc: "just under after increment",
                     elapsedSeconds: 434,
-                    expectedValaue: 10001,
+                    expectedValue: 10001,
                 },
                 {
                     desc: "after 1 day",
                     elapsedSeconds: ONE_DAY.add(1),
-                    expectedValaue: 10200,
+                    expectedValue: 10200,
                 },
                 {
                     desc: "after 9 days",
                     elapsedSeconds: ONE_DAY.mul(9).add(1),
-                    expectedValaue: 11800,
+                    expectedValue: 11800,
                 },
                 {
                     desc: "just under 10 days",
                     elapsedSeconds: ONE_DAY.mul(10).sub(2),
-                    expectedValaue: 11999,
+                    expectedValue: 11999,
                 },
                 {
                     desc: "after 10 days",
                     elapsedSeconds: ONE_DAY.mul(10),
-                    expectedValaue: 12000,
+                    expectedValue: 12000,
                 },
                 {
                     desc: "after 11 days",
                     elapsedSeconds: ONE_DAY.mul(11),
-                    expectedValaue: 12000,
+                    expectedValue: 12000,
                 },
             ]
-            for (const testData of testsData) {
+            testsData.forEach((testData) =>
                 it(`should succeed getting A ${testData.desc}`, async () => {
                     const currentTime = await getTimestamp()
                     const incrementSeconds = startTime.add(testData.elapsedSeconds).sub(currentTime)
                     await increaseTime(incrementSeconds)
-                    assertBNClose(await mAsset.getA(), BN.from(testData.expectedValaue), 5)
-                })
-            }
+                    assertBNClose(await mAsset.getA(), BN.from(testData.expectedValue), 5)
+                }),
+            )
         })
         context("A target changes just in range", () => {
             let currentA: BN
@@ -749,47 +749,47 @@ describe("Masset Admin", () => {
                     // 60 * 60 * 24 * 5 / 5000 = 86
                     desc: "just under before increment",
                     elapsedSeconds: 84,
-                    expectedValaue: 10000,
+                    expectedValue: 10000,
                 },
                 {
                     desc: "just under after increment",
                     elapsedSeconds: 88,
-                    expectedValaue: 9999,
+                    expectedValue: 9999,
                 },
                 {
                     desc: "after 1 day",
                     elapsedSeconds: ONE_DAY.add(1),
-                    expectedValaue: 9000,
+                    expectedValue: 9000,
                 },
                 {
                     desc: "after 4 days",
                     elapsedSeconds: ONE_DAY.mul(4).add(1),
-                    expectedValaue: 6000,
+                    expectedValue: 6000,
                 },
                 {
                     desc: "just under 5 days",
                     elapsedSeconds: ONE_DAY.mul(5).sub(2),
-                    expectedValaue: 5001,
+                    expectedValue: 5001,
                 },
                 {
                     desc: "after 5 days",
                     elapsedSeconds: ONE_DAY.mul(5),
-                    expectedValaue: 5000,
+                    expectedValue: 5000,
                 },
                 {
                     desc: "after 6 days",
                     elapsedSeconds: ONE_DAY.mul(6),
-                    expectedValaue: 5000,
+                    expectedValue: 5000,
                 },
             ]
-            for (const testData of testsData) {
+            testsData.forEach((testData) =>
                 it(`should succeed getting A ${testData.desc}`, async () => {
                     const currentTime = await getTimestamp()
                     const incrementSeconds = startTime.add(testData.elapsedSeconds).sub(currentTime)
                     await increaseTime(incrementSeconds)
-                    expect(await mAsset.getA()).to.eq(testData.expectedValaue)
+                    expect(await mAsset.getA()).to.eq(testData.expectedValue)
                 })
-            }
+            )
         })
         describe("should fail to start ramp A", () => {
             before(async () => {

--- a/test/masset/from-data/integration.spec.ts
+++ b/test/masset/from-data/integration.spec.ts
@@ -23,6 +23,7 @@ const ratio = simpleToExactAmount(1, 8)
 const tolerance = BN.from(10)
 
 const cv = (n: number | string): BN => BN.from(BigInt(n).toString())
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getReserves = (data: any) =>
     [0, 1, 2, 3, 4, 5]
         .filter((i) => data[`reserve${i}`])

--- a/test/masset/from-data/single.spec.ts
+++ b/test/masset/from-data/single.spec.ts
@@ -1,8 +1,9 @@
+/* eslint-disable @typescript-eslint/dot-notation */
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable @typescript-eslint/no-loop-func */
 
 import { assertBNClose } from "@utils/assertions"
-import { DEAD_ADDRESS, fullScale, MAX_UINT256, ZERO_ADDRESS } from "@utils/constants"
+import { DEAD_ADDRESS, MAX_UINT256, ZERO_ADDRESS } from "@utils/constants"
 import { MassetMachine, StandardAccounts } from "@utils/machines"
 import { BN, simpleToExactAmount } from "@utils/math"
 import { mAssetData } from "@utils/validator-data"
@@ -28,6 +29,7 @@ const swapFeeRate = simpleToExactAmount(6, 14)
 const tolerance = 1
 
 const cv = (n: number | string): BN => BN.from(BigInt(n).toString())
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getReserves = (data: any) =>
     [0, 1, 2, 3, 4]
         .filter((i) => data[`reserve${i}`])
@@ -164,7 +166,7 @@ describe("Feeder Logic - One basket one test", () => {
             describe(`reserves: ${testData.reserve0}, ${testData.reserve1}, ${testData.reserve2}`, () => {
                 for (const testRedeem of testData.redeems) {
                     // Deduct swap fee before performing redemption
-                    if (testRedeem.hardLimitError) {
+                    if (testRedeem["hardLimitError"]) {
                         it(`${(count += 1)} throws Max Weight error when redeeming ${testRedeem.mAssetQty} mAssets for bAsset ${
                             testRedeem.bAssetIndex
                         }`, async () => {
@@ -202,13 +204,13 @@ describe("Feeder Logic - One basket one test", () => {
                     // Deduct swap fee after performing redemption
                     const qtys = testRedeem.bAssetQtys.map((b) => cv(b))
 
-                    if (testRedeem.insufficientLiquidityError) {
+                    if (testRedeem["insufficientLiquidityError"]) {
                         it(`${(count += 1)} throws throw insufficient liquidity error when redeeming ${qtys} bAssets`, async () => {
                             await expect(validator.computeRedeemExact(reserves, [0, 1, 2], qtys, config, swapFeeRate)).to.be.revertedWith(
                                 "VM Exception",
                             )
                         })
-                    } else if (testRedeem.hardLimitError) {
+                    } else if (testRedeem["hardLimitError"]) {
                         it(`${(count += 1)} throws Max Weight error when redeeming ${qtys} bAssets`, async () => {
                             await expect(validator.computeRedeemExact(reserves, [0, 1, 2], qtys, config, swapFeeRate)).to.be.revertedWith(
                                 "Exceeds weight limits",
@@ -239,7 +241,6 @@ describe("Feeder Logic - One basket one test", () => {
                 let bAssetAddresses: string[]
                 let bAssets: MockERC20[]
                 let massetFactory: Masset__factory
-                let forgeValAddr: string
                 before(async () => {
                     const accounts = await ethers.getSigners()
                     const mAssetMachine = await new MassetMachine().initAccounts(accounts)

--- a/test/masset/peripheral/aavev2.spec.ts
+++ b/test/masset/peripheral/aavev2.spec.ts
@@ -299,7 +299,7 @@ describe("AaveIntegration", async () => {
             const bal2 = await bAsset.balanceOf(aaveIntegration.address)
             const receivedAmount = bal2.sub(bal1)
             // Ensure fee is being deducted
-            expect(receivedAmount).lt(amount as any)
+            expect(receivedAmount).lt(amount)
             // fee = initialAmount - receivedAmount
             const fee = amount.sub(receivedAmount)
             // feeRate = fee/amount (base 1e18)
@@ -308,7 +308,7 @@ describe("AaveIntegration", async () => {
             const expectedDeposit = receivedAmount.sub(receivedAmount.mul(feeRate).div(simpleToExactAmount(1)))
 
             // Step 2. call deposit
-            const tx = await aaveIntegration.connect(mAsset.signer).deposit(bAsset.address, receivedAmount.toString(), true)
+            await aaveIntegration.connect(mAsset.signer).deposit(bAsset.address, receivedAmount.toString(), true)
 
             // Step 3. Check for things:
             const aaveIntegrationBalAfter = await aToken.balanceOf(aaveIntegration.address)
@@ -344,7 +344,7 @@ describe("AaveIntegration", async () => {
             // Step 0. Choose tokens
             const bAsset = await new MockERC20__factory(sa.default.signer).attach(integrationDetails.aTokens[0].bAsset)
             const amount = BN.from(10).pow(BN.from(12))
-            const aToken = await new MockATokenV2__factory(sa.default.signer).attach(integrationDetails.aTokens[0].aToken)
+            await new MockATokenV2__factory(sa.default.signer).attach(integrationDetails.aTokens[0].aToken)
 
             // Step 2. call deposit
             await expect(aaveIntegration.connect(mAsset.signer).deposit(bAsset.address, amount.toString(), false)).to.be.revertedWith(
@@ -357,11 +357,11 @@ describe("AaveIntegration", async () => {
             const bAssetDecimals = await bAsset.decimals()
             const amount = BN.from(10).mul(BN.from(10).pow(bAssetDecimals))
             const amountHigh = BN.from(11).mul(BN.from(10).pow(bAssetDecimals))
-            const aToken = await new MockATokenV2__factory(sa.default.signer).attach(integrationDetails.aTokens[1].aToken)
+            await new MockATokenV2__factory(sa.default.signer).attach(integrationDetails.aTokens[1].aToken)
 
             // Step 1. xfer low tokens to integration
             await bAsset.transfer(aaveIntegration.address, amount.toString())
-            expect(await bAsset.balanceOf(aaveIntegration.address)).lte(amount as any)
+            expect(await bAsset.balanceOf(aaveIntegration.address)).lte(amount)
             // Step 2. call deposit with high tokens
             await expect(aaveIntegration.connect(mAsset.signer).deposit(bAsset.address, amountHigh.toString(), false)).to.be.revertedWith(
                 "ERC20: transfer amount exceeds balance",
@@ -395,7 +395,7 @@ describe("AaveIntegration", async () => {
                 "Must deposit something",
             )
             // Succeeds with Incorrect bool (defaults to false)
-            const tx = await aaveIntegration.connect(mAsset.signer).deposit(bAsset.address, amount.toString(), undefined)
+            await aaveIntegration.connect(mAsset.signer).deposit(bAsset.address, amount.toString(), undefined)
 
             // Step 3. Check for things:
             // 3.1 Check that lending pool has bAssets
@@ -439,7 +439,7 @@ describe("AaveIntegration", async () => {
             const aaveIntegrationBalBefore = await aToken.balanceOf(aaveIntegration.address)
 
             // Step 1. call withdraw
-            const tx = await aaveIntegration["withdraw(address,address,uint256,bool)"](
+            await aaveIntegration["withdraw(address,address,uint256,bool)"](
                 bAssetRecipient,
                 bAsset.address,
                 amount.toString(),
@@ -482,7 +482,7 @@ describe("AaveIntegration", async () => {
             const aaveIntegrationBalBefore = await aToken.balanceOf(aaveIntegration.address)
 
             // Step 1. call withdraw
-            const tx = await aaveIntegration["withdraw(address,address,uint256,bool)"](
+            await aaveIntegration["withdraw(address,address,uint256,bool)"](
                 bAssetRecipient,
                 bAsset.address,
                 amount.toString(),
@@ -496,9 +496,9 @@ describe("AaveIntegration", async () => {
             const amountScaled = amount.mul(scale)
             const expectedAmount = amountScaled.div(simpleToExactAmount(1))
             // Step 2. Validate recipient
-            expect(bAssetRecipientBalAfter).gte(bAssetRecipientBalBefore.add(expectedAmount) as any)
-            expect(bAssetRecipientBalAfter).lte(bAssetRecipientBalBefore.add(amount) as any)
-            expect(aaveIntegrationBalAfter).eq(aaveIntegrationBalBefore.sub(amount) as any)
+            expect(bAssetRecipientBalAfter).gte(bAssetRecipientBalBefore.add(expectedAmount))
+            expect(bAssetRecipientBalAfter).lte(bAssetRecipientBalBefore.add(amount))
+            expect(aaveIntegrationBalAfter).eq(aaveIntegrationBalBefore.sub(amount))
             const expectedBalance = aaveIntegrationBalBefore.sub(amount)
             assertBNSlightlyGT(aaveIntegrationBalAfter, expectedBalance, BN.from("100"))
             // Cross that match with the `checkBalance` call
@@ -555,7 +555,7 @@ describe("AaveIntegration", async () => {
                 aaveIntegration["withdraw(address,address,uint256,bool)"](sa.dummy1.address, bAsset.address, "0", false),
             ).to.be.revertedWith("Must withdraw something")
             // Succeeds with Incorrect bool (defaults to false)
-            const tx = await aaveIntegration["withdraw(address,address,uint256,bool)"](
+            await aaveIntegration["withdraw(address,address,uint256,bool)"](
                 sa.dummy1.address,
                 bAsset.address,
                 amount.toString(),
@@ -597,7 +597,7 @@ describe("AaveIntegration", async () => {
                 const bAssetDecimals = await bAsset.decimals()
                 const amount = simpleToExactAmount(5, bAssetDecimals)
                 const totalAmount = amount.mul(2)
-                const aToken = await new MockATokenV2__factory(sa.default.signer).attach(integrationDetails.aTokens[0].aToken)
+                await new MockATokenV2__factory(sa.default.signer).attach(integrationDetails.aTokens[0].aToken)
                 // 0.1 Get balance before
                 const bAssetRecipient = sa.dummy1.address
                 const bAssetRecipientBalBefore = await bAsset.balanceOf(bAssetRecipient)
@@ -611,7 +611,7 @@ describe("AaveIntegration", async () => {
                         ["withdraw(address,address,uint256,uint256,bool)"](bAssetRecipient, bAsset.address, amount, totalAmount, false),
                 ).to.be.revertedWith("Only the LP can execute")
                 // send the amount
-                const tx = await aaveIntegration["withdraw(address,address,uint256,uint256,bool)"](
+                await aaveIntegration["withdraw(address,address,uint256,uint256,bool)"](
                     bAssetRecipient,
                     bAsset.address,
                     amount,
@@ -677,7 +677,7 @@ describe("AaveIntegration", async () => {
             const aaveIntegrationBalBefore = await bAsset.balanceOf(aaveIntegration.address)
             const aaveBalanceBefore = await aaveIntegration.callStatic.checkBalance(bAsset.address)
 
-            const tx = await aaveIntegration.connect(mAsset.signer).withdrawRaw(bAssetRecipient, bAsset.address, amount)
+            await aaveIntegration.connect(mAsset.signer).withdrawRaw(bAssetRecipient, bAsset.address, amount)
 
             const bAssetRecipientBalAfter = await bAsset.balanceOf(bAssetRecipient)
             const aaveIntegrationBalAfter = await bAsset.balanceOf(aaveIntegration.address)

--- a/test/masset/peripheral/compound.spec.ts
+++ b/test/masset/peripheral/compound.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable consistent-return */
 
 import { StandardAccounts, MassetMachine } from "@utils/machines"
-import { ZERO_ADDRESS, DEAD_ADDRESS, fullScale, ONE_WEEK, MAX_UINT256 } from "@utils/constants"
+import { ZERO_ADDRESS, DEAD_ADDRESS, fullScale, MAX_UINT256 } from "@utils/constants"
 import { BN, simpleToExactAmount } from "@utils/math"
 import { MockCToken, MockCToken__factory, MockERC20, MockERC20__factory, MockNexus, MockNexus__factory } from "types/generated"
 import { ethers } from "hardhat"

--- a/test/masset/redeem.spec.ts
+++ b/test/masset/redeem.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "chai"
 import { ethers } from "hardhat"
 import { Signer } from "ethers"
 
-import { simpleToExactAmount, BN, applyRatio } from "@utils/math"
+import { simpleToExactAmount, BN } from "@utils/math"
 import { MassetDetails, MassetMachine, StandardAccounts } from "@utils/machines"
 import { MockERC20, Masset } from "types/generated"
 import { fullScale, ZERO_ADDRESS } from "@utils/constants"
@@ -183,9 +183,9 @@ describe("Masset - Redeem", () => {
 
         // Execute the redemption
         const tx = mAsset.redeem(bAsset.address, mAssetQuantityExact, minBassetOutputExact, recipient)
-        const integratorBalBefore = await bAssetBefore.contract.balanceOf(
-            bAssetBefore.integrator ? bAssetBefore.integratorAddr : mAsset.address,
-        )
+        // const integratorBalBefore = await bAssetBefore.contract.balanceOf(
+        //     bAssetBefore.integrator ? bAssetBefore.integratorAddr : mAsset.address,
+        // )
 
         // Check the emitted events
         await expect(tx)
@@ -210,9 +210,9 @@ describe("Masset - Redeem", () => {
         await tx
 
         // VaultBalance should line up
-        const integratorBalAfter = await bAssetBefore.contract.balanceOf(
-            bAssetBefore.integrator ? bAssetBefore.integratorAddr : mAsset.address,
-        )
+        // const integratorBalAfter = await bAssetBefore.contract.balanceOf(
+        //     bAssetBefore.integrator ? bAssetBefore.integratorAddr : mAsset.address,
+        // )
         // Calculate after balance
         // expect(integratorBalAfter, "integratorBalAfter").eq(integratorBalBefore.sub(bAssetQuantityExact))
         // Sender should have less mAsset
@@ -730,8 +730,6 @@ describe("Masset - Redeem", () => {
                     const recipient = sa.dummy3
                     // 1.0 Assert bAsset has fee
                     const bAsset = bAssets[3]
-                    const bAssetDecimals = await bAsset.decimals()
-                    const oneBasset = simpleToExactAmount(1, bAssetDecimals)
                     const bAssetBefore = await mAsset.getBasset(bAsset.address)
                     expect(bAssetBefore.personal.hasTxFee).to.eq(true)
 

--- a/test/masset/validator-etc.spec.ts
+++ b/test/masset/validator-etc.spec.ts
@@ -2,7 +2,6 @@ import { ethers } from "hardhat"
 import { expect } from "chai"
 
 import { simpleToExactAmount, BN } from "@utils/math"
-import { MassetMachine, StandardAccounts } from "@utils/machines"
 import { ExposedMassetLogic } from "types/generated"
 
 const config = {
@@ -33,14 +32,6 @@ const getReserves = (simpleUnits: number[], decimals: number[] = simpleUnits.map
 
 describe("Invariant Validator", () => {
     let validator: ExposedMassetLogic
-    let sa: StandardAccounts
-
-    before(async () => {
-        const accounts = await ethers.getSigners()
-        const mAssetMachine = await new MassetMachine().initAccounts(accounts)
-        sa = mAssetMachine.sa
-        await redeployValidator()
-    })
 
     const redeployValidator = async () => {
         const LogicFactory = await ethers.getContractFactory("MassetLogic")
@@ -53,7 +44,9 @@ describe("Invariant Validator", () => {
         const massetFactory = await ethers.getContractFactory("ExposedMassetLogic", linkedAddress)
         validator = (await massetFactory.deploy()) as ExposedMassetLogic
     }
-
+    before(async () => {
+        await redeployValidator()
+    })
     describe("Validating bAssets with different ratios", () => {
         const x1 = getReserves([10, 10, 10, 10], [10, 18, 6, 18])
         const x2 = getReserves([10, 10, 10, 10], [18, 18, 6, 18])

--- a/test/polygon/pliquidator.spec.ts
+++ b/test/polygon/pliquidator.spec.ts
@@ -150,7 +150,7 @@ describe("Liquidator", () => {
         await redeployLiquidator()
 
         ctx.sa = sa
-        ctx.module = liquidator as any as ImmutableModule
+        ctx.module = liquidator as ImmutableModule
     })
 
     describe("verifying initialization", async () => {
@@ -200,7 +200,7 @@ describe("Liquidator", () => {
                 await paaveIntegration.claimRewards()
                 await liquidator.triggerLiquidation(paaveIntegration.address)
                 const after = await snapshotData()
-                expect(after.savingsManagerBal).gt(before.savingsManagerBal as any)
+                expect(after.savingsManagerBal).gt(before.savingsManagerBal)
             })
         })
     })

--- a/test/rewards/boost-director.spec.ts
+++ b/test/rewards/boost-director.spec.ts
@@ -2,7 +2,6 @@
 
 import { ethers } from "hardhat"
 import { expect } from "chai"
-import { BN } from "@utils/math"
 import { StandardAccounts, MassetMachine } from "@utils/machines"
 import { DEAD_ADDRESS } from "@utils/constants"
 import {
@@ -16,46 +15,6 @@ import {
     MockBoostedVault__factory,
 } from "types/generated"
 import { Account } from "types"
-
-interface StakingBalance {
-    raw: BN
-    balance: BN
-    totalSupply: BN
-}
-
-interface TokenBalance {
-    sender: BN
-    contract: BN
-}
-
-interface UserData {
-    rewardPerTokenPaid: BN
-    rewards: BN
-    lastAction: BN
-    rewardCount: number
-    userClaim: BN
-}
-interface ContractData {
-    rewardPerTokenStored: BN
-    rewardRate: BN
-    lastUpdateTime: BN
-    lastTimeRewardApplicable: BN
-    periodFinishTime: BN
-}
-interface Reward {
-    start: BN
-    finish: BN
-    rate: BN
-}
-
-interface StakingData {
-    boostBalance: StakingBalance
-    tokenBalance: TokenBalance
-    vMTABalance: BN
-    userData: UserData
-    userRewards: Reward[]
-    contractData: ContractData
-}
 
 describe("BoostDirectorV2", async () => {
     let sa: StandardAccounts

--- a/test/rewards/staking-rewards.spec.ts
+++ b/test/rewards/staking-rewards.spec.ts
@@ -126,15 +126,12 @@ describe("StakingRewards", async () => {
     ): Promise<void> => {
         const timeAfter = await getTimestamp()
         const periodIsFinished = timeAfter.gt(beforeData.periodFinishTime)
+        const beforeDataLastUpdateTime =
+            beforeData.rewardPerTokenStored.eq(0) && beforeData.totalSupply.eq(0) ? beforeData.lastUpdateTime : timeAfter
 
         //    LastUpdateTime
-        expect(
-            periodIsFinished
-                ? beforeData.periodFinishTime
-                : beforeData.rewardPerTokenStored.eq(0) && beforeData.totalSupply.eq(0)
-                ? beforeData.lastUpdateTime
-                : timeAfter,
-        ).eq(afterData.lastUpdateTime)
+        expect(periodIsFinished ? beforeData.periodFinishTime : beforeDataLastUpdateTime).eq(afterData.lastUpdateTime)
+
         //    RewardRate doesnt change
         expect(beforeData.rewardRate).eq(afterData.rewardRate)
         //    RewardPerTokenStored goes up

--- a/test/savings/savings-contract.spec.ts
+++ b/test/savings/savings-contract.spec.ts
@@ -89,9 +89,10 @@ const getExpectedPoke = (data: Data, withdrawCredits: BN = BN.from(0)): Expected
     const connectorDerived = balances.contract.gt(totalCollat) ? BN.from(0) : totalCollat.sub(balances.contract)
     const max = totalCollat.mul(connector.fraction.add(simpleToExactAmount(2, 17))).div(fullScale)
     const ideal = totalCollat.mul(connector.fraction).div(fullScale)
+    const pokeType = connector.balance.gt(ideal) ? "withdraw" : "deposit"
     return {
         aboveMax: connectorDerived.gt(max),
-        type: connector.balance.eq(ideal) ? "none" : connector.balance.gt(ideal) ? "withdraw" : "deposit",
+        type: connector.balance.eq(ideal) ? "none" : pokeType,
         amount: connector.balance.gte(ideal) ? connector.balance.sub(ideal) : ideal.sub(connector.balance),
         ideal,
     }

--- a/test/savings/savings-manager.spec.ts
+++ b/test/savings/savings-manager.spec.ts
@@ -440,7 +440,7 @@ describe("SavingsManager", async () => {
                 const s15 = await snapshotData()
                 assertBNClosePercent(s15.savingsManagerBal, s7.savingsManagerBal.sub(expectedInterest), "0.01")
 
-                expect(s15.liqStream.end).lt(s15.lastCollection as any)
+                expect(s15.liqStream.end).lt(s15.lastCollection)
                 expect(s15.liqStream.rate).eq(s7.liqStream.rate)
                 assertBNClose(s15.savingsManagerBal, BN.from(0), simpleToExactAmount(1, 6))
 
@@ -622,7 +622,7 @@ describe("SavingsManager", async () => {
                 assertBNClosePercent(s16.savingsManagerBal, s115.savingsManagerBal.sub(expectedInterest), "0.01")
                 assertBNClosePercent(s16.savingsContractBal, s115.savingsContractBal.add(expectedInterest), "0.01")
                 // all mUSD should be drained now
-                expect(s16.savingsManagerBal).lt(simpleToExactAmount(1, 16) as any)
+                expect(s16.savingsManagerBal).lt(simpleToExactAmount(1, 16))
                 await increaseTime(ONE_DAY.div(2))
                 // @16.5
                 const ts17 = await getTimestamp()
@@ -735,7 +735,7 @@ describe("SavingsManager", async () => {
                 const passingInterest = simpleToExactAmount(9999, 18)
                 await mUSD.setAmountForCollectInterest(passingInterest)
 
-                const tx = await savingsManager.collectAndDistributeInterest(mUSD.address)
+                await savingsManager.collectAndDistributeInterest(mUSD.address)
 
                 const endTime = await getTimestamp()
                 const lastCollectionEnd = await savingsManager.lastCollection(mUSD.address)
@@ -956,7 +956,7 @@ describe("SavingsManager", async () => {
 
             it("should allow interest collection before 30 mins", async () => {
                 await savingsManager.collectAndDistributeInterest(mUSD.address)
-                const tx = await savingsManager.collectAndDistributeInterest(mUSD.address)
+                await savingsManager.collectAndDistributeInterest(mUSD.address)
             })
 
             it("should allow interest collection again after 30 mins", async () => {


### PR DESCRIPTION
refactor: removes ts lint errors
closes #143

0. rebase masterV-2 to master in this branch 
1. updates  rues on .eslintrc.js 
2. general refactor to avoid lint warnings 
3. updates command `lint-ts` on package.json