### PR TITLE
Generalise cap function and improve readability

### DIFF
--- a/contracts/emissions/EmissionsController.sol
+++ b/contracts/emissions/EmissionsController.sol
@@ -438,10 +438,10 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
                 VOTING-EXTERNAL
     ****************************************/
 
-    function pokeSources() external {
-        uint256 votesCast = voterPreferences[msg.sender].votesCast;
-        _moveVotingPower(msg.sender, getVotes(msg.sender) - votesCast, _add);
-        voterPreferences[msg.sender].lastSourcePoke = SafeCast.toUint32(block.timestamp);
+    function pokeSources(address _voter) external {
+        uint256 votesCast = voterPreferences[_voter].votesCast;
+        _moveVotingPower(_voter, getVotes(_voter) - votesCast, _add);
+        voterPreferences[_voter].lastSourcePoke = SafeCast.toUint32(block.timestamp);
     }
 
     /**
@@ -498,7 +498,7 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
             require(addTime > 0, "Caller must be staking contract");
 
             // If burning (withdraw) or transferring delegated votes from a staker
-            if (from != address(0)) {
+            if (from != address(0) && voterPreferences[from].lastSourcePoke > 0) {
                 require(
                     voterPreferences[from].lastSourcePoke > addTime,
                     "Must init new contract bal"
@@ -506,7 +506,7 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
                 _moveVotingPower(from, amount, _subtract);
             }
             // If minting (staking) or transferring delegated votes to a staker
-            if (to != address(0)) {
+            if (to != address(0) && voterPreferences[to].lastSourcePoke > 0) {
                 require(
                     voterPreferences[to].lastSourcePoke > addTime,
                     "Must init new contract bal"

--- a/test-utils/time.ts
+++ b/test-utils/time.ts
@@ -25,7 +25,7 @@ export const increaseTimeTo = async (target: BN | number): Promise<void> => {
 export const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
 export const startWeek = (epochSeconds: BigNumberish): BN => BN.from(epochSeconds).div(ONE_WEEK).mul(ONE_WEEK)
-export const startCurrentWeek = (): BN => startWeek(Math.floor(Date.now() / 1000))
+export const startCurrentWeek = async (): Promise<BN> => startWeek(await getTimestamp())
 
 export const weekEpoch = (epochSeconds: BigNumberish): BN => BN.from(epochSeconds).div(ONE_WEEK)
-export const currentWeekEpoch = (): BN => weekEpoch(Math.floor(Date.now() / 1000))
+export const currentWeekEpoch = async (): Promise<BN> => weekEpoch(await getTimestamp())

--- a/test/emissions/emission-controller-polygon.spec.ts
+++ b/test/emissions/emission-controller-polygon.spec.ts
@@ -73,7 +73,7 @@ describe("EmissionsController Polygon Integration", async () => {
         emissionsController = new EmissionsController__factory(sa.default.signer).attach(proxy.address)
 
         await rewardToken.approve(emissionsController.address, totalRewards)
-        await emissionsController.initialize([], [], [staking1.address, staking2.address], simpleToExactAmount(29400963))
+        await emissionsController.initialize([], [], [], [staking1.address, staking2.address], simpleToExactAmount(29400963))
 
         await staking1.setGovernanceHook(emissionsController.address)
         await staking2.setGovernanceHook(emissionsController.address)
@@ -165,8 +165,8 @@ describe("EmissionsController Polygon Integration", async () => {
                 emissionsController.address,
             )
 
-            await emissionsController.connect(sa.governor.signer).addDial(rootRecipient1.address, true)
-            await emissionsController.connect(sa.governor.signer).addDial(rootRecipient2.address, true)
+            await emissionsController.connect(sa.governor.signer).addDial(rootRecipient1.address, 0, true)
+            await emissionsController.connect(sa.governor.signer).addDial(rootRecipient2.address, 0, true)
             await increaseTime(ONE_WEEK.mul(2))
         })
         it("to first polygon recipient", async () => {

--- a/test/emissions/emission-controller.spec.ts
+++ b/test/emissions/emission-controller.spec.ts
@@ -22,7 +22,7 @@ import {
     MockStakingContract__factory,
 } from "types/generated"
 import { deployContract } from "tasks/utils/deploy-utils"
-import { currentWeekEpoch, increaseTime, increaseTimeTo, startCurrentWeek } from "@utils/time"
+import { currentWeekEpoch, increaseTime, getTimestamp, increaseTimeTo, startWeek } from "@utils/time"
 
 const defaultConfig = {
     A: -166000,
@@ -112,7 +112,8 @@ describe("EmissionsController", async () => {
         console.log(`User 3 ${sa.dummy3.address}`)
 
         // Set the time to Thursday, 01:00am UTC time which is just after the start of the distribution period
-        const startCurrentPeriod = startCurrentWeek()
+        const currentTime = await getTimestamp()
+        const startCurrentPeriod = startWeek(currentTime)
         const earlyNextPeriod = startCurrentPeriod.add(ONE_WEEK).add(ONE_HOUR)
         await increaseTimeTo(earlyNextPeriod)
         console.log(`Time at start ${new Date(earlyNextPeriod.toNumber() * 1000).toUTCString()}, epoch ${earlyNextPeriod}`)
@@ -137,8 +138,9 @@ describe("EmissionsController", async () => {
         })
         it("epoch set on initialization", async () => {
             const [startEpoch, lastEpoch] = await emissionsController.epochs()
-            expect(startEpoch, "start epoch").to.eq(currentWeekEpoch().add(2))
-            expect(lastEpoch, "last epoch").to.eq(currentWeekEpoch().add(2))
+            const e = await currentWeekEpoch()
+            expect(startEpoch, "start epoch").to.eq(e.add(1))
+            expect(lastEpoch, "last epoch").to.eq(e.add(1))
         })
         it("transfer MTA on initialization", async () => {
             expect(await rewardToken.balanceOf(emissionsController.address), "ec rewards bal").to.eq(totalRewards)


### PR DESCRIPTION
### Dial cap

**What**
   - Intermediary step in distribution with only capped && non disabled. If over cap, takes cap% for them, and reduces from total votes and top level emission accordingly
   - Generalised `cap` variable set at dial creation time
 
**Why**
   - Previous impl assumes that the staking contracts always received >10% of the votes which may not be true
   - Previous impl assumes staking contracts are the only ones with caps
   - Previous impl did not factor in the reduction of stakingContract votes on overall vote count

### Historic vote logging in `calculateRewards`

**What**
   - Removed while loop in favour of 2 step if statement
  
**Why**
   - When looping through the historic rewards, the count we are looking for is either at:
      - the end of array (requires reading + new entry) or
      - at the second last entry (requires reading) or
      - it doesn't exist, if the dial is new

### Cached votes cast

**What**
   - Supports the addition of new staking contracts by adding a timestamp for when it was added, and disallowing hook calls from staking contracts that have not been initialised

**Why**
   - Without this, it would be impossible to add new staking contract sources. The blocker is a necessary evil to avoid accounting issues

### Other

   - Setting startEpoch in constructor doesn't optimise gas: we still need lastEpoch in storage and it's 1 SLOAD together. Also removes ability to upgrade contract since this would be overridden at impl deploy time
   - Aligned comments and readability of storage props
   - Generally tried to reduce line count and comment complexity to help auditors