### PR TITLE
RevenueBuyBack fixes and tests

### DIFF
--- a/contracts/emissions/BasicRewardsForwarder.sol
+++ b/contracts/emissions/BasicRewardsForwarder.sol
@@ -35,7 +35,8 @@ contract BasicRewardsForwarder is
      * @param _rewardsToken Token that is being distributed as a reward. eg MTA
      */
     constructor(address _nexus, address _rewardsToken)
-        InitializableRewardsDistributionRecipient(_nexus) {
+        InitializableRewardsDistributionRecipient(_nexus)
+    {
         require(_rewardsToken != address(0), "Rewards token is zero");
         REWARDS_TOKEN = IERC20(_rewardsToken);
     }

--- a/contracts/emissions/README.md
+++ b/contracts/emissions/README.md
@@ -72,11 +72,11 @@ The emissions controller will allow anyone to donate MTA rewards to a dial that 
 
 ### Polygon Integration
 
-Polygon’s [Proof of Stake (PoS) Bridge](https://docs.polygon.technology/docs/develop/ethereum-polygon/pos/getting-started) will be used by the Emissions Controller to send MTA to the existing [child MTA](https://polygonscan.com/token/0xF501dd45a1198C2E1b5aEF5314A68B9006D842E0) token on Polygon. This will be done indirectly using a dial recipient contract that interfaces with the PoS Bridge.
+Polygon’s [Proof of Stake (PoS) Bridge](https://docs.polygon.technology/docs/develop/ethereum-polygon/pos/getting-started) will be used by the Emissions Controller to send MTA to the existing [Polygon MTA](https://polygonscan.com/token/0xF501dd45a1198C2E1b5aEF5314A68B9006D842E0) token on Polygon. This will be done indirectly using a dial recipient contract that interfaces with the PoS Bridge.
 
-MTA rewards can be sent directly to the dial contract on Polygon. eg FRAX. Or MTA rewards can be sent via the Child Emissions Controller which will notify the recipient contract that the rewards have been transferred. eg the imUSD Vault on Polygon.
+MTA rewards can be sent directly to the dial contract on Polygon. eg FRAX. Or MTA rewards can be sent via the L2 Emissions Controller which will notify the recipient contract that the rewards have been transferred. eg the imUSD Vault on Polygon.
 
-Voting can not be done on Polygon. All voting of dials is done on Ehtereum mainnet.
+Voting can not be done on Polygon. All voting of dials is done on Ethereum mainnet.
 
 ### Weekly Distribution
 
@@ -135,7 +135,7 @@ It’s possible the MTA rewards can be calculated but not transferred. Each new 
 
 ## Polygon Integration
 
-Polygon's [Proof of Stake (PoS) Bridge](https://docs.polygon.technology/docs/develop/ethereum-polygon/pos/getting-started) will be used by the Emissions Controller to send MTA to the existing child MTA token on Polygon. This will be done indirectly using a dial recipient contract that interfaces with the PoS Bridge.
+Polygon's [Proof of Stake (PoS) Bridge](https://docs.polygon.technology/docs/develop/ethereum-polygon/pos/getting-started) will be used by the Emissions Controller to send MTA to the existing Polygon MTA token on Polygon. This will be done indirectly using a dial recipient contract that interfaces with the PoS Bridge.
 
 ### Contract dependencies
 
@@ -162,8 +162,8 @@ For sending to the Polygon imUSD Vault:
 
 The bridged MTA Token grants the Child Chain Manager the `DEPOSITOR` role so it can call the `deposit` function which mints bridged MTA for MTA that has been locked in the Root Chain Manager on Mainnet.
 
-**L2 Bridge Recipients** - Are contracts that receive bridged MTA tokens from the PoS Bridge. Separate contracts are used so the Child Emissions Controller knows the amounts to be distributed to the final reward recipient contracts.
+**L2 Bridge Recipients** - Are contracts that receive bridged MTA tokens from the PoS Bridge. Separate contracts are used so the L2 Emissions Controller knows the amounts to be distributed to the final reward recipient contracts.
 
-**Child Emission Controller** - is used transfer all bridged MTA Tokens from the L2 Bridge Recipients to the end contracts that implement the `IRewardsDistributionRecipient` interface. For example, the Polygon imUSD Vault. After the tokens are transferred, the `notifyRewardsAmount` is called on the recipient contract so it can process the rewards.
+**L2 Emission Controller** - is used transfer all bridged MTA Tokens from the L2 Bridge Recipients to the end contracts that implement the `IRewardsDistributionRecipient` interface. For example, the Polygon imUSD Vault. After the tokens are transferred, the `notifyRewardsAmount` is called on the recipient contract so it can process the rewards.
 
 The L2 Bridge Recipients need to have approved the L2 Emissions Controller to transfer the Bridged MTA tokens.

--- a/contracts/z_mocks/masset/MockMasset.sol
+++ b/contracts/z_mocks/masset/MockMasset.sol
@@ -56,13 +56,28 @@ contract MockMasset is MockERC20 {
         uint256 _inputQuantity,
         uint256 _minOutputQuantity,
         address _recipient
-    ) external returns (uint256) {
+    ) external returns (uint256 out_amt) {
         uint256 decimals = IBasicToken(_input).decimals();
-        uint256 out_amt = (_inputQuantity * (10**(18 - decimals)) * ratio) / 1e18;
+        out_amt = (_inputQuantity * (10**(18 - decimals)) * ratio) / 1e18;
         require(out_amt >= _minOutputQuantity, "MINT: Output amount not enough");
         IERC20(_input).transferFrom(msg.sender, address(this), _inputQuantity);
         _mint(_recipient, out_amt);
-        return out_amt;
+    }
+
+    function redeem(
+        address _output,
+        uint256 _mAssetQuantity,
+        uint256 _minOutputQuantity,
+        address _recipient
+    ) external returns (uint256 outputQuantity) {
+        _burn(msg.sender, _mAssetQuantity);
+
+        uint256 decimals = IBasicToken(_output).decimals();
+        outputQuantity = (_mAssetQuantity * ratio * (10**decimals)) / 1e36;
+        require(outputQuantity >= _minOutputQuantity, "bAsset qty < min qty");
+        require(outputQuantity > 0, "Output == 0");
+
+        IERC20(_output).transfer(_recipient, outputQuantity);
     }
 }
 

--- a/contracts/z_mocks/savings/MockStakingContract.sol
+++ b/contracts/z_mocks/savings/MockStakingContract.sol
@@ -7,11 +7,16 @@ pragma solidity 0.8.6;
 contract MockStakingContract {
     mapping(address => uint256) private _balances;
     mapping(address => uint256) private _votes;
+    uint256 public totalSupply;
 
     IGovernanceHook govHook;
 
     function setBalanceOf(address account, uint256 balance) public {
         _balances[account] = balance;
+    }
+
+    function setTotalSupply(uint256 _totalSupply) public {
+        totalSupply = _totalSupply;
     }
 
     function setVotes(address account, uint256 newVotes) public {

--- a/test/buy-and-make/revenue-buy-back.spec.ts
+++ b/test/buy-and-make/revenue-buy-back.spec.ts
@@ -1,0 +1,225 @@
+import { ethers } from "hardhat"
+import { expect } from "chai"
+
+import { simpleToExactAmount } from "@utils/math"
+import { MassetMachine, StandardAccounts } from "@utils/machines"
+
+import {
+    MockERC20,
+    MockNexus__factory,
+    MockNexus,
+    RevenueBuyBack__factory,
+    RevenueBuyBack,
+    MockUniswapV3,
+    MockUniswapV3__factory,
+    MockEmissionController__factory,
+    MockEmissionController,
+    MockStakingContract,
+    MockStakingContract__factory,
+    MockMasset__factory,
+    MockMasset,
+} from "types/generated"
+import { EncodedPaths, encodeUniswapPath } from "@utils/peripheral/uniswap"
+import { DEAD_ADDRESS } from "@utils/constants"
+
+describe("RevenueBuyBack", () => {
+    let sa: StandardAccounts
+    let mAssetMachine: MassetMachine
+    let nexus: MockNexus
+    let revenueBuyBack: RevenueBuyBack
+    let mUSD: MockMasset
+    let mBTC: MockMasset
+    let bAsset1: MockERC20
+    let bAsset2: MockERC20
+    let rewardsToken: MockERC20
+    let staking1: MockStakingContract
+    let staking2: MockStakingContract
+    let emissionController: MockEmissionController
+    let uniswap: MockUniswapV3
+    let uniswapMusdBasset1Paths: EncodedPaths
+    let uniswapMbtcBasset2Paths: EncodedPaths
+
+    /*
+        Test Data
+        mAssets: mUSD and mBTC with 18 decimals
+     */
+    const setupRevenueBuyBack = async (): Promise<void> => {
+        mUSD = await new MockMasset__factory(sa.default.signer).deploy(
+            "meta USD",
+            "mUSD",
+            18,
+            sa.default.address,
+            simpleToExactAmount(1000000),
+        )
+        bAsset1 = await mAssetMachine.loadBassetProxy("USD bAsset", "bUSD", 18)
+
+        mBTC = await new MockMasset__factory(sa.default.signer).deploy("meta BTC", "mBTC", 18, sa.default.address, simpleToExactAmount(100))
+        bAsset2 = await mAssetMachine.loadBassetProxy("USD bAsset", "bUSD", 6)
+
+        rewardsToken = await mAssetMachine.loadBassetProxy("Rewards Token", "RWD", 18)
+
+        // staking contracts
+        staking1 = await new MockStakingContract__factory(sa.default.signer).deploy()
+        staking2 = await new MockStakingContract__factory(sa.default.signer).deploy()
+        await staking1.setTotalSupply(simpleToExactAmount(3000000))
+        await staking2.setTotalSupply(simpleToExactAmount(1000000))
+
+        // Deploy mock Nexus
+        nexus = await new MockNexus__factory(sa.default.signer).deploy(
+            sa.governor.address,
+            sa.mockSavingsManager.address,
+            sa.mockInterestValidator.address,
+        )
+
+        // Mocked Uniswap V3
+        uniswap = await new MockUniswapV3__factory(sa.default.signer).deploy()
+        // Add rewards to Uniswap
+        await rewardsToken.transfer(uniswap.address, simpleToExactAmount(500000))
+        // Add bAsset to rewards exchange rates
+        await uniswap.setRate(bAsset1.address, rewardsToken.address, simpleToExactAmount(80, 16)) // 0.8 MTA/USD
+        await uniswap.setRate(bAsset2.address, rewardsToken.address, simpleToExactAmount(50, 33)) // 50,000 MTA/BTC
+        // Uniswap paths
+        uniswapMusdBasset1Paths = encodeUniswapPath([bAsset1.address, DEAD_ADDRESS, rewardsToken.address], [3000, 3000])
+        uniswapMbtcBasset2Paths = encodeUniswapPath([bAsset2.address, DEAD_ADDRESS, rewardsToken.address], [3000, 3000])
+
+        // Deploy Mock Emissions Controller
+        emissionController = await new MockEmissionController__factory(sa.default.signer).deploy()
+        await emissionController.addStakingContract(staking1.address)
+        await emissionController.addStakingContract(staking2.address)
+
+        // Deploy and initialize test RevenueBuyBack
+        revenueBuyBack = await new RevenueBuyBack__factory(sa.default.signer).deploy(
+            nexus.address,
+            rewardsToken.address,
+            uniswap.address,
+            emissionController.address,
+        )
+        await revenueBuyBack.initialize(sa.fundManager.address, [1, 2])
+
+        // Add config to buy rewards from mAssets
+        await revenueBuyBack
+            .connect(sa.governor.signer)
+            .setMassetConfig(
+                mUSD.address,
+                bAsset1.address,
+                simpleToExactAmount(98, 16),
+                simpleToExactAmount(79, 16),
+                uniswapMusdBasset1Paths.encoded,
+            )
+        await revenueBuyBack.connect(sa.governor.signer).setMassetConfig(
+            mBTC.address,
+            bAsset2.address,
+            simpleToExactAmount(98, 4),
+            // 49,000 BTC/USD * 1e12 as bAsset has 6 decimals and rewards has 18 decimals
+            simpleToExactAmount(49, 33),
+            uniswapMbtcBasset2Paths.encoded,
+        )
+    }
+
+    before(async () => {
+        const accounts = await ethers.getSigners()
+        mAssetMachine = await new MassetMachine().initAccounts(accounts)
+        sa = mAssetMachine.sa
+
+        await setupRevenueBuyBack()
+    })
+
+    describe("creating new instance", () => {
+        before(async () => {
+            await setupRevenueBuyBack()
+        })
+        it("should have immutable variables set", async () => {
+            expect(await revenueBuyBack.nexus(), "Nexus").eq(nexus.address)
+            expect(await revenueBuyBack.REWARDS_TOKEN(), "Rewards Token").eq(rewardsToken.address)
+            expect(await revenueBuyBack.UNISWAP_ROUTER(), "Uniswap Router").eq(uniswap.address)
+            expect(await revenueBuyBack.EMISSIONS_CONTROLLER(), "Emissions Controller").eq(emissionController.address)
+        })
+        it("should have storage variables set", async () => {
+            expect(await revenueBuyBack.keeper(), "Keeper").eq(sa.fundManager.address)
+            expect(await revenueBuyBack.stakingDialIds(0), "Staking Contract 1 dial id").eq(1)
+            expect(await revenueBuyBack.stakingDialIds(1), "Staking Contract 2 dial id").eq(2)
+        })
+    })
+    describe("notification of revenue", () => {
+        before(async () => {
+            await setupRevenueBuyBack()
+        })
+        it("should simply transfer from the sender", async () => {
+            const senderBalBefore = await mUSD.balanceOf(sa.default.address)
+            const revenueBuyBackBalBefore = await mUSD.balanceOf(revenueBuyBack.address)
+            const notificationAmount = simpleToExactAmount(100, 18)
+            expect(senderBalBefore.gte(notificationAmount), "sender rewards bal before").to.be.true
+
+            // approve
+            await mUSD.approve(revenueBuyBack.address, notificationAmount)
+            // call
+            const tx = revenueBuyBack.notifyRedistributionAmount(mUSD.address, notificationAmount)
+            await expect(tx).to.emit(revenueBuyBack, "RevenueReceived").withArgs(mUSD.address, notificationAmount)
+
+            // check output balances: mAsset sender/recipient
+            expect(await mUSD.balanceOf(sa.default.address), "mUSD sender bal after").eq(senderBalBefore.sub(notificationAmount))
+            expect(await mUSD.balanceOf(revenueBuyBack.address), "mUSD RevenueBuyBack bal after").eq(
+                revenueBuyBackBalBefore.add(notificationAmount),
+            )
+        })
+        describe("it should fail if", () => {
+            it("approval is not given from sender", async () => {
+                await expect(revenueBuyBack.notifyRedistributionAmount(mUSD.address, simpleToExactAmount(100, 18))).to.be.revertedWith(
+                    "ERC20: transfer amount exceeds allowance",
+                )
+            })
+            it("sender has insufficient balance", async () => {
+                await mUSD.transfer(sa.dummy1.address, simpleToExactAmount(1, 18))
+                await mUSD.connect(sa.dummy1.signer).approve(revenueBuyBack.address, simpleToExactAmount(100))
+                await expect(
+                    revenueBuyBack.connect(sa.dummy1.signer).notifyRedistributionAmount(mUSD.address, simpleToExactAmount(2, 18)),
+                ).to.be.revertedWith("ERC20: transfer amount exceeds balance")
+            })
+        })
+    })
+    describe("buy back MTA rewards", () => {
+        const musdRevenue = simpleToExactAmount(20000)
+        const mbtcRevenue = simpleToExactAmount(2)
+        beforeEach(async () => {
+            await setupRevenueBuyBack()
+
+            // Put some bAssets to the mAssets
+            await bAsset1.transfer(mUSD.address, musdRevenue)
+            await bAsset2.transfer(mBTC.address, mbtcRevenue.div(1e12))
+
+            // Distribute revenue to RevenueBuyBack
+            await mUSD.approve(revenueBuyBack.address, musdRevenue)
+            await mBTC.approve(revenueBuyBack.address, mbtcRevenue)
+            await revenueBuyBack.notifyRedistributionAmount(mUSD.address, musdRevenue)
+            await revenueBuyBack.notifyRedistributionAmount(mBTC.address, mbtcRevenue)
+        })
+        it("should sell mUSD for MTA", async () => {
+            expect(await mUSD.balanceOf(revenueBuyBack.address), "revenueBuyBack's mUSD Bal before").to.eq(musdRevenue)
+            expect(await bAsset1.balanceOf(mUSD.address), "mAsset's bAsset Bal before").to.eq(musdRevenue)
+
+            const tx = revenueBuyBack.connect(sa.fundManager.signer).buyBackRewards([mUSD.address])
+
+            const bAssetAmount = musdRevenue.mul(98).div(100)
+            // Exchange rate = 0.80 MTA/USD = 8 / 18
+            // Swap fee is 0.3% = 997 / 1000
+            const rewardsAmount = bAssetAmount.mul(8).div(10).mul(997).div(1000)
+            await expect(tx).to.emit(revenueBuyBack, "BuyBackRewards").withArgs(mUSD.address, musdRevenue, bAssetAmount, rewardsAmount)
+
+            expect(await mUSD.balanceOf(revenueBuyBack.address), "revenueBuyBack's mUSD Bal after").to.eq(0)
+        })
+        it("should sell mBTC for MTA", async () => {
+            expect(await mBTC.balanceOf(revenueBuyBack.address), "revenueBuyBack's mBTC Bal before").to.eq(mbtcRevenue)
+            expect(await bAsset2.balanceOf(mBTC.address), "mAsset's bAsset Bal before").to.eq(mbtcRevenue.div(1e12))
+
+            const tx = revenueBuyBack.connect(sa.fundManager.signer).buyBackRewards([mBTC.address])
+
+            const bAssetAmount = mbtcRevenue.mul(98).div(100).div(1e12)
+            // Exchange rate = 50,000 MTA/BTC
+            // Swap fee is 0.3% = 997 / 1000
+            const rewardsAmount = bAssetAmount.mul(50000).mul(997).div(1000).mul(1e12)
+            await expect(tx).to.emit(revenueBuyBack, "BuyBackRewards").withArgs(mBTC.address, mbtcRevenue, bAssetAmount, rewardsAmount)
+
+            expect(await mBTC.balanceOf(revenueBuyBack.address), "revenueBuyBack's mBTC Bal after").to.eq(0)
+        })
+    })
+})


### PR DESCRIPTION
`RevenueBuyBack` contract changes
* Added `BuyBackRewards` and `DonatedRewards` events
* Renamed `minBassetPercentage` to `minMasset2BassetPrice`
* Added approval of Uniswap to transfer bAssets from `RevenueBuyBack`

Other changes
* Minor README updates
* Added basic `RevenueBuyBack` unit tests
