### PR TITLE
RevenueBuyBack tests and Deployment tasks

### DIFF
--- a/contracts/buy-and-make/RevenueBuyBack.sol
+++ b/contracts/buy-and-make/RevenueBuyBack.sol
@@ -102,7 +102,7 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
         keeper = _keeper;
 
         for (uint256 i = 0; i < _stakingDialIds.length; i++) {
-            stakingDialIds.push(_stakingDialIds[i]);
+            _addStakingContract(_stakingDialIds[i]);
         }
     }
 
@@ -262,7 +262,16 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
      * @param _stakingDialId dial identifier from the Emissions Controller of the staking contract.
      */
     function addStakingContract(uint16 _stakingDialId) external onlyGovernor {
-        require(_stakingDialId != 0, "Staking dial id is zero");
+        _addStakingContract(_stakingDialId);
+    }
+
+    function _addStakingContract(uint16 _stakingDialId) internal {
+        for (uint256 i = 0; i < stakingDialIds.length; i++) {
+            require(stakingDialIds[i] != _stakingDialId, "Staking dial id already exists");
+        }
+        // Make sure the dial id of the staking contract is valid
+        require(EMISSIONS_CONTROLLER.getDialRecipient(_stakingDialId) != address(0), "Missing staking dial");
+
         stakingDialIds.push(_stakingDialId);
 
         emit AddedStakingContract(_stakingDialId);

--- a/contracts/buy-and-make/RevenueBuyBack.sol
+++ b/contracts/buy-and-make/RevenueBuyBack.sol
@@ -102,7 +102,6 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
         keeper = _keeper;
 
         for (uint256 i = 0; i < _stakingDialIds.length; i++) {
-            require(_stakingDialIds[i] != 0, "Staking dial id is zero");
             stakingDialIds.push(_stakingDialIds[i]);
         }
     }
@@ -176,8 +175,9 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
         uint256 totalVotingPower;
         // Get the voting power of each staking contract
         for (uint256 i = 0; i < numberStakingContracts; i++) {
-            DialData memory dialData = EMISSIONS_CONTROLLER.dials(stakingDialIds[i]);
-            address staingContractAddress = dialData.recipient;
+            address staingContractAddress = EMISSIONS_CONTROLLER.getDialRecipient(
+                stakingDialIds[i]
+            );
             require(staingContractAddress != address(0), "invalid dial id");
 
             votingPower[i] = IERC20(staingContractAddress).totalSupply();
@@ -187,6 +187,7 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
 
         // STEP 2 - Get rewards that need to be distributed
         uint256 rewardsBal = REWARDS_TOKEN.balanceOf(address(this));
+        require(rewardsBal > 0, "No rewards to donate");
 
         // STEP 3 - Calculate rewards for each staking contract
         uint256[] memory rewardDonationAmounts = new uint256[](numberStakingContracts);

--- a/contracts/emissions/BridgeForwarder.sol
+++ b/contracts/emissions/BridgeForwarder.sol
@@ -27,7 +27,7 @@ contract BridgeForwarder is
     /// @notice Mainnet Proof of Stake (PoS) bridge contract to Polygon
     IRootChainManager public immutable ROOT_CHAIN_MANAGER;
     /// @notice Polygon contract that will receive the bridged rewards on the Polygon chain
-    address public immutable CHILD_RECIPIENT;
+    address public immutable BRIDGE_RECIPIENT;
 
     event Forwarded(uint256 amount);
 
@@ -35,21 +35,21 @@ contract BridgeForwarder is
      * @param _nexus            mStable system Nexus address
      * @param _rewardsToken     First token that is being distributed as a reward. eg MTA
      * @param _rootChainManager Mainnet Proof of Stake (PoS) bridge contract to Polygon
-     * @param _childRecipient   Polygon contract that will receive the bridged rewards on the Polygon chain
+     * @param _bridgeRecipient  Polygon contract that will receive the bridged rewards on the Polygon chain
      */
     constructor(
         address _nexus,
         address _rewardsToken,
         address _rootChainManager,
-        address _childRecipient
+        address _bridgeRecipient
     ) InitializableRewardsDistributionRecipient(_nexus) {
         require(_rewardsToken != address(0), "Rewards token is zero");
         require(_rootChainManager != address(0), "RootChainManager is zero");
-        require(_childRecipient != address(0), "ChildRecipient is zero");
+        require(_bridgeRecipient != address(0), "Bridge recipient is zero");
 
         REWARDS_TOKEN = IERC20(_rewardsToken);
         ROOT_CHAIN_MANAGER = IRootChainManager(_rootChainManager);
-        CHILD_RECIPIENT = _childRecipient;
+        BRIDGE_RECIPIENT = _bridgeRecipient;
     }
 
     /**
@@ -75,7 +75,7 @@ contract BridgeForwarder is
         onlyRewardsDistributor
     {
         ROOT_CHAIN_MANAGER.depositFor(
-            CHILD_RECIPIENT,
+            BRIDGE_RECIPIENT,
             address(REWARDS_TOKEN),
             abi.encode(_rewards)
         );

--- a/contracts/emissions/EmissionsController.sol
+++ b/contracts/emissions/EmissionsController.sol
@@ -149,17 +149,15 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
      * @dev Initialisation function to configure the first dials. All recipient contracts with _notifies = true need to
      *      implement the `IRewardsDistributionRecipient` interface.
      * @param _recipients       List of dial contract addresses that can receive rewards
-     * @param _caps             Limit on the percentage of the weekly top line emission the corresponding dial can receive (where 10% = 10)
+     * @param _caps             Limit on the percentage of the weekly top line emission the corresponding dial can receive (where 10% = 10 and uncapped = 0)
      * @param _notifies         If true, `notifyRewardAmount` is called in the `distributeRewards` function
      * @param _stakingContracts Initial staking contracts used for voting power lookup
-     * @param _totalRewards     Total reward units that will be distributed during the emission lifetime
      */
     function initialize(
         address[] memory _recipients,
         uint8[] memory _caps,
         bool[] memory _notifies,
-        address[] memory _stakingContracts,
-        uint128 _totalRewards
+        address[] memory _stakingContracts
     ) external initializer {
         uint256 len = _recipients.length;
         require(_notifies.length == len && _caps.length == len, "Initialize args mistmatch");
@@ -173,8 +171,6 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
         //       Set the weekly epoch this contract starts distributions which will be 1 - 2 week after deployment.
         uint32 startEpoch = SafeCast.toUint32((block.timestamp + 1 weeks) / DISTRIBUTION_PERIOD);
         epochs = EpochHistory({ startEpoch: startEpoch, lastEpoch: startEpoch });
-
-        REWARD_TOKEN.safeTransferFrom(msg.sender, address(this), _totalRewards);
 
         // 3.0 - Initialize the staking contracts
         for (uint256 i = 0; i < _stakingContracts.length; i++) {

--- a/contracts/emissions/EmissionsController.sol
+++ b/contracts/emissions/EmissionsController.sol
@@ -222,6 +222,15 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
             1e6; // e.g. SUM = 1,6542492e17 * 1e6 = 165424e18
     }
 
+    /**
+     * @notice Gets a dial's recipient address
+     * @param dialId dial identifier
+     * @return recipient address of the recipient account associated with
+     */
+    function getDialRecipient(uint256 dialId) public view returns (address recipient) {
+        recipient = dials[dialId].recipient;
+    }
+
     /***************************************
                     ADMIN
     ****************************************/

--- a/contracts/emissions/L2BridgeRecipient.sol
+++ b/contracts/emissions/L2BridgeRecipient.sol
@@ -21,13 +21,13 @@ contract L2BridgeRecipient {
 
     /**
      * @param _childRewardsToken Bridged rewards token on the Polygon chain.
-     * @param _childEmissionsController Polygon contract that will distribute bridged rewards on the Polygon chain.
+     * @param _l2EmissionsController Polygon contract that will distribute bridged rewards on the Polygon chain.
      */
-    constructor(address _childRewardsToken, address _childEmissionsController) {
+    constructor(address _childRewardsToken, address _l2EmissionsController) {
         REWARDS_TOKEN = IERC20(_childRewardsToken);
-        L2_EMISSIONS_CONTROLLER = _childEmissionsController;
+        L2_EMISSIONS_CONTROLLER = _l2EmissionsController;
 
         // Approve the Polygon PoS Bridge to transfer reward tokens from this contract
-        IERC20(_childRewardsToken).safeApprove(_childEmissionsController, type(uint256).max);
+        IERC20(_childRewardsToken).safeApprove(_l2EmissionsController, type(uint256).max);
     }
 }

--- a/contracts/interfaces/IEmissionsController.sol
+++ b/contracts/interfaces/IEmissionsController.sol
@@ -9,7 +9,7 @@ import { DialData } from "../emissions/EmissionsController.sol";
  * @dev Emissions Controller interface used for by RevenueBuyBack
  */
 interface IEmissionsController {
-    function dials(uint256 dialId) external returns (DialData memory);
+    function getDialRecipient(uint256 dialId) external returns (address recipient);
 
     function donate(uint256[] memory _dialIds, uint256[] memory _amounts) external;
 

--- a/hardhat-fork-polygon.config.ts
+++ b/hardhat-fork-polygon.config.ts
@@ -7,7 +7,6 @@ export default {
         hardhat: {
             allowUnlimitedContractSize: false,
             blockGasLimit: 20000000, // 20 million
-            gasPrice: 5000000000, // 5 Gwei
             forking: {
                 url: process.env.NODE_URL || "https://matic-mainnet-archive-rpc.bwarelabs.com",
             },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "lint-sol": "solhint 'contracts/**/*.sol'",
         "compile-abis": "typechain --target=ethers-v5 --out-dir types/generated \"?(contracts|build)/!(build-info)/**/+([a-zA-Z0-9]).json\"",
         "compile-ts": "npx tsc",
-        "compile": "yarn hardhat compile --force && yarn run compile-abis",
+        "compile": "yarn hardhat compile && yarn run compile-abis",
         "flatten": "npx sol-merger \"./contracts/**/*.sol\" ./_flat",
         "coverage": "yarn hardhat compile --force && node --max_old_space_size=6144 node_modules/.bin/hardhat coverage --temp 'build/contracts' --testfiles 'test/**/*.spec.ts' --show-stack-traces",
         "convertTestFiles": "cd test-utils/validator-data; ts-node ./convertCsvTestFiles.ts",

--- a/tasks-fork-polygon.config.ts
+++ b/tasks-fork-polygon.config.ts
@@ -1,5 +1,6 @@
 import config from "./hardhat-fork-polygon.config"
 
+import "./tasks/deployEmissionsController"
 import "./tasks/deployIntegration"
 import "./tasks/deployFeeders"
 import "./tasks/deployPolygon"

--- a/tasks-fork.config.ts
+++ b/tasks-fork.config.ts
@@ -1,5 +1,6 @@
 import config from "./hardhat-fork.config"
 
+import "./tasks/deployEmissionsController"
 import "./tasks/deployIntegration"
 import "./tasks/deployRewards"
 import "./tasks/deployMbtc"

--- a/tasks.config.ts
+++ b/tasks.config.ts
@@ -1,5 +1,6 @@
 import config from "./hardhat.config"
 
+import "./tasks/deployEmissionsController"
 import "./tasks/deployIntegration"
 import "./tasks/deployRewards"
 import "./tasks/deployMbtc"

--- a/tasks/deployEmissionsController.ts
+++ b/tasks/deployEmissionsController.ts
@@ -1,0 +1,44 @@
+import "ts-node/register"
+import "tsconfig-paths/register"
+
+import { task, types } from "hardhat/config"
+import { getSigner } from "./utils/signerFactory"
+import {
+    deployBridgeForwarder,
+    deployEmissionsController,
+    deployL2BridgeRecipients,
+    deployL2EmissionsController,
+} from "./utils/emissions-utils"
+import { resolveAddress } from "./utils/networkAddressFactory"
+import { Chain } from "./utils/tokens"
+
+task("deploy-emissions-polly", "Deploys L2EmissionsController and L2 Bridge Recipients for Polygon mUSD Vault and FRAX Farm")
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const signer = await getSigner(hre, taskArgs.speed)
+
+        const l2EmissionsController = await deployL2EmissionsController(signer, hre)
+
+        await deployL2BridgeRecipients(signer, hre, l2EmissionsController.address)
+    })
+
+task("deploy-emissions")
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const signer = await getSigner(hre, taskArgs.speed)
+        await deployEmissionsController(signer, hre)
+    })
+
+task("deploy-bridge-forwarders", "Deploys Polygon mUSD Vault and FRAX BridgeForwarders on mainnet")
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const signer = await getSigner(hre, taskArgs.speed)
+
+        const mUSDBridgeRecipientAddress = resolveAddress("PmUSD", Chain.polygon, "bridgeRecipient")
+        await deployBridgeForwarder(signer, hre, mUSDBridgeRecipientAddress)
+
+        const fraxBridgeRecipientAddress = resolveAddress("PFRAX", Chain.polygon, "bridgeRecipient")
+        await deployBridgeForwarder(signer, hre, fraxBridgeRecipientAddress)
+    })
+
+module.exports = {}

--- a/tasks/deployEmissionsController.ts
+++ b/tasks/deployEmissionsController.ts
@@ -2,14 +2,17 @@ import "ts-node/register"
 import "tsconfig-paths/register"
 
 import { task, types } from "hardhat/config"
+import { MockRootChainManager__factory } from "types/generated"
 import { getSigner } from "./utils/signerFactory"
 import {
     deployBridgeForwarder,
     deployEmissionsController,
     deployL2BridgeRecipients,
     deployL2EmissionsController,
+    deployRevenueBuyBack,
 } from "./utils/emissions-utils"
-import { resolveAddress } from "./utils/networkAddressFactory"
+import { getChain, resolveAddress } from "./utils/networkAddressFactory"
+import { deployContract } from "./utils/deploy-utils"
 import { Chain } from "./utils/tokens"
 
 task("deploy-emissions-polly", "Deploys L2EmissionsController and L2 Bridge Recipients for Polygon mUSD Vault and FRAX Farm")
@@ -20,25 +23,51 @@ task("deploy-emissions-polly", "Deploys L2EmissionsController and L2 Bridge Reci
         const l2EmissionsController = await deployL2EmissionsController(signer, hre)
 
         await deployL2BridgeRecipients(signer, hre, l2EmissionsController.address)
+
+        console.log(`Set L2EmissionsController contract name in networkAddressFactory to ${l2EmissionsController.address}`)
     })
 
 task("deploy-emissions")
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
     .setAction(async (taskArgs, hre) => {
         const signer = await getSigner(hre, taskArgs.speed)
-        await deployEmissionsController(signer, hre)
+        const emissionsController = await deployEmissionsController(signer, hre)
+
+        console.log(`Set RewardsDistributor in the networkAddressFactory to ${emissionsController.address}`)
     })
 
 task("deploy-bridge-forwarders", "Deploys Polygon mUSD Vault and FRAX BridgeForwarders on mainnet")
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
     .setAction(async (taskArgs, hre) => {
+        const chain = getChain(hre)
         const signer = await getSigner(hre, taskArgs.speed)
 
-        const mUSDBridgeRecipientAddress = resolveAddress("PmUSD", Chain.polygon, "bridgeRecipient")
+        const l2Chain = chain === Chain.mainnet ? Chain.polygon : Chain.mumbai
+        const mUSDBridgeRecipientAddress = resolveAddress("mUSD", l2Chain, "bridgeRecipient")
         await deployBridgeForwarder(signer, hre, mUSDBridgeRecipientAddress)
 
-        const fraxBridgeRecipientAddress = resolveAddress("PFRAX", Chain.polygon, "bridgeRecipient")
-        await deployBridgeForwarder(signer, hre, fraxBridgeRecipientAddress)
+        if (chain === Chain.mainnet) {
+            const fraxBridgeRecipientAddress = resolveAddress("FRAX", l2Chain, "bridgeRecipient")
+            await deployBridgeForwarder(signer, hre, fraxBridgeRecipientAddress)
+        }
+    })
+
+task("deploy-revenue-buy-back")
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const signer = await getSigner(hre, taskArgs.speed)
+
+        const revenueRecipient = await deployRevenueBuyBack(signer, hre)
+
+        console.log(`Set RevenueRecipient to ${revenueRecipient.address}`)
+    })
+
+task("deploy-mock-root-chain-manager", "Deploys a mocked Polygon PoS Bridge")
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const signer = await getSigner(hre, taskArgs.speed)
+
+        await deployContract(new MockRootChainManager__factory(signer), "MockRootChainManager")
     })
 
 module.exports = {}

--- a/tasks/deployFeeders.ts
+++ b/tasks/deployFeeders.ts
@@ -20,7 +20,7 @@ import { deployFeederPool, deployVault, FeederData, VaultData } from "./utils/fe
 import { getChain, getChainAddress, resolveToken } from "./utils/networkAddressFactory"
 
 task("deployFeederPool", "Deploy Feeder Pool")
-    .addParam("masset", "Token symbol of mAsset. eg mUSD or PmUSD for Polygon", "mUSD", types.string)
+    .addParam("masset", "Token symbol of mAsset. eg mUSD", "mUSD", types.string)
     .addParam("fasset", "Token symbol of Feeder Pool asset. eg GUSD, WBTC, PFRAX for Polygon", "alUSD", types.string)
     .addOptionalParam("a", "Amplitude coefficient (A)", 100, types.int)
     .addOptionalParam("min", "Minimum asset weight of the basket as a percentage. eg 10 for 10% of the basket.", 10, types.int)
@@ -84,11 +84,11 @@ task("deployVault", "Deploy Feeder Pool with boosted dual vault")
     .addParam("boosted", "Rewards are boosted by staked MTA (vMTA)", undefined, types.boolean)
     .addParam(
         "stakingToken",
-        "Symbol of token that is being staked. Feeder Pool is just the fAsset. eg mUSD, PmUSD, MTA, GUSD, alUSD",
+        "Symbol of token that is being staked. Feeder Pool is just the fAsset. eg mUSD, MTA, GUSD, alUSD",
         undefined,
         types.string,
     )
-    .addParam("rewardToken", "Token symbol of reward. eg MTA or PMTA for Polygon", undefined, types.string)
+    .addOptionalParam("rewardToken", "Token symbol of reward. eg MTA", "MTA", types.string)
     .addOptionalParam("dualRewardToken", "Token symbol of second reward. eg WMATIC, ALCX, QI", undefined, types.string)
     .addOptionalParam("price", "Price coefficient is the value of the mAsset in USD. eg mUSD/USD = 1, mBTC/USD", 1, types.int)
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)

--- a/tasks/deployIntegration.ts
+++ b/tasks/deployIntegration.ts
@@ -24,7 +24,7 @@ import { verifyEtherscan } from "./utils/etherscan"
 task("integration-aave-deploy", "Deploys an instance of AaveV2Integration contract")
     .addParam(
         "asset",
-        "Symbol of the mAsset or Feeder Pool providing liquidity to the integration. eg mUSD, PmUSD, GUSD or alUSD",
+        "Symbol of the mAsset or Feeder Pool providing liquidity to the integration. eg mUSD, GUSD or alUSD",
         undefined,
         types.string,
     )
@@ -52,7 +52,7 @@ task("integration-aave-deploy", "Deploys an instance of AaveV2Integration contra
 task("integration-paave-deploy", "Deploys mUSD and mBTC instances of PAaveIntegration")
     .addParam(
         "asset",
-        "Symbol of the mAsset or Feeder Pool providing liquidity to the integration. eg mUSD, PmUSD, GUSD or alUSD",
+        "Symbol of the mAsset or Feeder Pool providing liquidity to the integration. eg mUSD, GUSD or alUSD",
         undefined,
         types.string,
     )
@@ -143,7 +143,7 @@ task("liquidator-deploy").setAction(async (_, __, runSuper) => {
 })
 
 subtask("liquidator-create", "Creates a liquidation of a platform reward")
-    .addParam("asset", "Symbol of the mAsset or Feeder Pool. eg mUSD, PmUSD, mBTC, alUSD, HBTC", undefined, types.string)
+    .addParam("asset", "Symbol of the mAsset or Feeder Pool. eg mUSD, mBTC, alUSD, HBTC", undefined, types.string)
     .addParam("rewardToken", "Symbol of the platform reward token. eg COMP, AAVE, stkAAVE, ALCX", undefined, types.string)
     .addParam("bAsset", "Symbol of the bAsset purchased from the rewards. eg USDC, WBTC, alUSD", undefined, types.string)
     .addOptionalParam("maxAmount", "Max amount of bAssets to liquidate. 20,000 USDC from selling COMP", undefined, types.int)

--- a/tasks/deployRevenueForwarder.ts
+++ b/tasks/deployRevenueForwarder.ts
@@ -4,7 +4,6 @@ import { task, types } from "hardhat/config"
 import { RevenueForwarder__factory } from "types/generated"
 import { deployContract } from "./utils/deploy-utils"
 import { getSigner } from "./utils/signerFactory"
-import { verifyEtherscan } from "./utils/etherscan"
 import { getChain, resolveAddress } from "./utils/networkAddressFactory"
 
 task("deploy-RevenueForwarder")
@@ -14,7 +13,7 @@ task("deploy-RevenueForwarder")
         const chain = getChain(hre)
 
         const nexus = resolveAddress("Nexus", chain)
-        const musd = resolveAddress("PmUSD", chain, "address")
+        const musd = resolveAddress("mUSD", chain, "address")
         const keeper = "0xdccb7a6567603af223c090be4b9c83eced210f18"
         const forwarder = "0xd0f0F590585384AF7AB420bE1CFB3A3F8a82D775"
 

--- a/tasks/deployRewards.ts
+++ b/tasks/deployRewards.ts
@@ -25,7 +25,7 @@ task("BoostDirector.deploy", "Deploys a new BoostDirector")
     .addOptionalParam("stakingToken", "Symbol of the staking token", "MTA", types.string)
     .addOptionalParam(
         "vaults",
-        "Comma separated list of vault underlying token symbols, eg RmUSD,RmBTC",
+        "Comma separated list of vault underlying token symbols, eg mUSD,mBTC",
         "mUSD,mBTC,GUSD,BUSD,alUSD,HBTC,TBTC",
         types.string,
     )
@@ -53,8 +53,8 @@ task("Vault.deploy", "Deploys a vault contract")
     .addParam("boosted", "True if a mainnet boosted vault", true, types.boolean)
     .addParam("vaultName", "Vault name", undefined, types.string, false)
     .addParam("vaultSymbol", "Vault symbol", undefined, types.string, false)
-    .addOptionalParam("stakingToken", "Symbol of staking token. eg MTA, BAL, RMTA, mUSD, RmUSD", "MTA", types.string)
-    .addOptionalParam("rewardsToken", "Symbol of rewards token. eg MTA or RMTA for Ropsten", "MTA", types.string)
+    .addOptionalParam("stakingToken", "Symbol of staking token. eg MTA, BAL or mUSD", "MTA", types.string)
+    .addOptionalParam("rewardsToken", "Symbol of rewards token. eg MTA", "MTA", types.string)
     .addOptionalParam("dualRewardsToken", "Symbol of dual rewards token. eg WMATIC", undefined, types.string)
     .addOptionalParam("priceCoeff", "Price coefficient without 18 decimal places. eg 1 or 4800", 1, types.int)
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
@@ -75,9 +75,9 @@ task("Vault.deploy", "Deploys a vault contract")
     })
 
 task("StakedToken.deploy", "Deploys a Staked Token behind a proxy")
-    .addOptionalParam("rewardsToken", "Symbol of rewards token. eg MTA or RMTA for Ropsten", "MTA", types.string)
-    .addOptionalParam("stakedToken", "Symbol of staked token. eg MTA, RMTA, mBPT or RmBPT", "MTA", types.string)
-    .addOptionalParam("balToken", "Symbol of balancer token. eg BAL or RBAL", "BAL", types.string)
+    .addOptionalParam("rewardsToken", "Symbol of rewards token. eg MTA", "MTA", types.string)
+    .addOptionalParam("stakedToken", "Symbol of staked token. eg MTA or mBPT", "MTA", types.string)
+    .addOptionalParam("balToken", "Symbol of balancer token. eg BAL", "BAL", types.string)
     .addOptionalParam("balPoolId", "Balancer Pool Id", "0001", types.string)
     .addOptionalParam("name", "Staked Token name", "Staked MTA", types.string)
     .addOptionalParam("symbol", "Staked Token symbol", "stkMTA", types.string)

--- a/tasks/feeder.ts
+++ b/tasks/feeder.ts
@@ -340,18 +340,8 @@ task("feeder-redeem", "Redeem some Feeder Pool tokens")
     })
 
 task("feeder-swap", "Swap some Feeder Pool tokens")
-    .addParam(
-        "input",
-        "Token symbol of the input token to the swap. eg mUSD, PmUSD, mBTC, HBTC, GUSD, PFRAX or alUSD",
-        undefined,
-        types.string,
-    )
-    .addParam(
-        "output",
-        "Token symbol of the output token from the swap. eg mUSD, PmUSD, mBTC, HBTC, GUSD, PFRAX or alUSD",
-        undefined,
-        types.string,
-    )
+    .addParam("input", "Token symbol of the input token to the swap. eg mUSD, mBTC, HBTC, GUSD, FRAX or alUSD", undefined, types.string)
+    .addParam("output", "Token symbol of the output token from the swap. eg mUSD, mBTC, HBTC, GUSD, FRAX or alUSD", undefined, types.string)
     .addParam("amount", "Amount of input tokens to swap", undefined, types.float)
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
     .setAction(async (taskArgs, hre) => {

--- a/tasks/token.ts
+++ b/tasks/token.ts
@@ -8,7 +8,7 @@ import { deployContract, logTxDetails } from "./utils/deploy-utils"
 import { getChain, resolveAddress, resolveToken } from "./utils/networkAddressFactory"
 
 subtask("token-approve", "Approve address or contract to spend (transferFrom) an amount of tokens from the signer's account")
-    .addParam("asset", "Symbol of the asset being approved. eg mUSD, imUSD, PmUSD, GUSD, alUSD, MTA", undefined, types.string)
+    .addParam("asset", "Symbol of the asset being approved. eg mUSD, imUSD, GUSD, alUSD, MTA", undefined, types.string)
     .addOptionalParam("tokenType", "Asset token type: address, savings, vault or feederPool.", "address", types.string)
     .addParam("spender", "Address or contract name that will send the transferFrom transaction.", undefined, types.string)
     .addOptionalParam(
@@ -76,7 +76,7 @@ task("token-transfer").setAction(async (_, __, runSuper) => {
 })
 
 subtask("token-transfer-from", "Transfer an amount of tokens from the sender to the recipient")
-    .addParam("asset", "Symbol of the asset being approved. eg mUSD, imUSD, PmUSD, GUSD, alUSD, MTA", undefined, types.string)
+    .addParam("asset", "Symbol of the asset being approved. eg mUSD, imUSD, GUSD, alUSD, MTA", undefined, types.string)
     .addOptionalParam("tokenType", "Asset token type: address, savings, vault or feederPool.", "address", types.string)
     .addParam("sender", "Address or contract name the tokens will be sent from.", undefined, types.string)
     .addOptionalParam(
@@ -118,7 +118,7 @@ task("token-transfer-from").setAction(async (_, __, runSuper) => {
 })
 
 subtask("token-allowance", "Logs the amount of tokens a spender can transfer from an owner")
-    .addParam("token", "Symbol of the token. eg mUSD, imUSD, PmUSD, GUSD, alUSD, MTA", undefined, types.string)
+    .addParam("token", "Symbol of the token. eg mUSD, imUSD, GUSD, alUSD, MTA", undefined, types.string)
     .addOptionalParam("tokenType", "Token address, savings, vault or feederPool.", "address", types.string)
     .addParam("owner", "Address or contract name where the tokens are held.", undefined, types.string)
     .addOptionalParam("ownerTokenType", "If owner is a token, then either address, savings, vault or feederPool.", "address", types.string)
@@ -151,7 +151,7 @@ task("token-allowance").setAction(async (_, __, runSuper) => {
 })
 
 subtask("token-balance", "Logs the token balance of an owner")
-    .addParam("token", "Symbol of the token. eg mUSD, imUSD, PmUSD, GUSD, alUSD, MTA", undefined, types.string)
+    .addParam("token", "Symbol of the token. eg mUSD, imUSD, GUSD, alUSD, MTA", undefined, types.string)
     .addOptionalParam("tokenType", "Token address, savings, vault or feederPool.", "address", types.string)
     .addParam("owner", "Address or contract name where the tokens are held.", undefined, types.string)
     .addOptionalParam("ownerTokenType", "If owner is a token, then either address, savings, vault or feederPool.", "address", types.string)

--- a/tasks/utils/emissions-utils.ts
+++ b/tasks/utils/emissions-utils.ts
@@ -1,0 +1,167 @@
+import { Signer } from "@ethersproject/abstract-signer"
+import {
+    AssetProxy__factory,
+    BridgeForwarder,
+    BridgeForwarder__factory,
+    EmissionsController,
+    EmissionsController__factory,
+    L2BridgeRecipient,
+    L2BridgeRecipient__factory,
+    L2EmissionsController,
+    L2EmissionsController__factory,
+} from "types/generated"
+import { deployContract } from "./deploy-utils"
+import { verifyEtherscan } from "./etherscan"
+import { getChain, resolveAddress } from "./networkAddressFactory"
+
+export const deployEmissionsController = async (signer: Signer, hre: any): Promise<EmissionsController> => {
+    const chain = getChain(hre)
+
+    const nexusAddress = resolveAddress("Nexus", chain)
+    const proxyAdminAddress = resolveAddress("DelayedProxyAdmin", chain)
+    const mtaAddress = resolveAddress("MTA", chain)
+    const mtaStakingAddress = resolveAddress("StakedTokenMTA", chain)
+    const mbptStakingAddress = resolveAddress("StakedTokenBPT", chain)
+    const dialRecipients = [
+        mtaStakingAddress,
+        mbptStakingAddress,
+        resolveAddress("mUSD", chain, "vault"),
+        resolveAddress("mBTC", chain, "vault"),
+        resolveAddress("GUSD", chain, "vault"),
+        resolveAddress("BUSD", chain, "vault"),
+        resolveAddress("alUSD", chain, "vault"),
+        resolveAddress("tBTCv2", chain, "vault"),
+        resolveAddress("HBTC", chain, "vault"),
+        resolveAddress("VisorRouter", chain),
+    ]
+    const caps = [10, 10, 0, 0, 0, 0, 0, 0, 0, 0]
+    const notifies = [true, true, true, true, true, true, true, true, true, false]
+
+    const defaultConfig = {
+        A: -166000,
+        B: 180000,
+        C: -180000,
+        D: 166000,
+        EPOCHS: 312,
+    }
+
+    // Deploy logic contract
+    const emissionsControllerImpl = await deployContract(new EmissionsController__factory(signer), "EmissionsController", [
+        nexusAddress,
+        mtaAddress,
+        defaultConfig,
+    ])
+
+    // Deploy proxy and initialize
+    const initializeData = emissionsControllerImpl.interface.encodeFunctionData("initialize", [
+        dialRecipients,
+        caps,
+        notifies,
+        [mtaStakingAddress, mbptStakingAddress],
+    ])
+    const proxy = await deployContract(new AssetProxy__factory(signer), "AssetProxy", [
+        emissionsControllerImpl.address,
+        proxyAdminAddress,
+        initializeData,
+    ])
+    const emissionsController = new EmissionsController__factory(signer).attach(proxy.address)
+
+    // await verifyEtherscan(hre, {
+    //     address: emissionsController.address,
+    // })
+
+    return emissionsController
+}
+
+export const deployL2EmissionsController = async (signer: Signer, hre: any): Promise<L2EmissionsController> => {
+    const chain = getChain(hre)
+
+    const nexusAddress = resolveAddress("Nexus", chain)
+    const proxyAdminAddress = resolveAddress("DelayedProxyAdmin", chain)
+    const mtaAddress = resolveAddress("PMTA", chain)
+
+    // Deploy logic contract
+    const l2EmissionsControllerImpl = await deployContract(new L2EmissionsController__factory(signer), "EmissionsController", [
+        nexusAddress,
+        mtaAddress,
+    ])
+
+    // Deploy proxy and initialize
+    const initializeData = l2EmissionsControllerImpl.interface.encodeFunctionData("initialize", [])
+    const proxy = await deployContract(new AssetProxy__factory(signer), "AssetProxy", [
+        l2EmissionsControllerImpl.address,
+        proxyAdminAddress,
+        initializeData,
+    ])
+    const l2EmissionsController = new L2EmissionsController__factory(signer).attach(proxy.address)
+
+    await verifyEtherscan(hre, {
+        address: l2EmissionsController.address,
+    })
+
+    return l2EmissionsController
+}
+
+export const deployL2BridgeRecipients = async (
+    signer: Signer,
+    hre: any,
+    l2EmissionsControllerAddress: string,
+): Promise<L2BridgeRecipient[]> => {
+    const chain = getChain(hre)
+
+    const mtaAddress = resolveAddress("PMTA", chain)
+
+    const mUSDBridgeRecipient = await deployContract<L2BridgeRecipient>(
+        new L2BridgeRecipient__factory(signer),
+        "mUSD Vault Bridge Recipient",
+        [mtaAddress, l2EmissionsControllerAddress],
+    )
+    console.log(`mUSD Vault L2 Bridge Recipient ${mUSDBridgeRecipient.address}`)
+    await verifyEtherscan(hre, {
+        address: mUSDBridgeRecipient.address,
+    })
+
+    const fraxBridgeRecipient = await deployContract<L2BridgeRecipient>(
+        new L2BridgeRecipient__factory(signer),
+        "FRAX Farm Bridge Recipient",
+        [mtaAddress, l2EmissionsControllerAddress],
+    )
+    console.log(`FRAX Farm L2 Bridge Recipient ${fraxBridgeRecipient.address}`)
+    await verifyEtherscan(hre, {
+        address: fraxBridgeRecipient.address,
+    })
+
+    return [mUSDBridgeRecipient, fraxBridgeRecipient]
+}
+
+export const deployBridgeForwarder = async (signer: Signer, hre: any, bridgeRecipientAddress: string): Promise<BridgeForwarder> => {
+    const chain = getChain(hre)
+
+    const nexusAddress = resolveAddress("Nexus", chain)
+    const mtaAddress = resolveAddress("MTA", chain)
+    const rootChainManagerAddress = resolveAddress("RootChainManager", chain)
+    const proxyAdminAddress = resolveAddress("DelayedProxyAdmin", chain)
+    const emissionsControllerAddress = resolveAddress("EmissionsController", chain)
+
+    const bridgeForrwarderImpl = await deployContract(new BridgeForwarder__factory(signer), "mUSD Vault Bridge Forwarder", [
+        nexusAddress,
+        mtaAddress,
+        rootChainManagerAddress,
+        bridgeRecipientAddress,
+    ])
+
+    // Deploy proxy and initialize
+    const initializeData = bridgeForrwarderImpl.interface.encodeFunctionData("initialize", [emissionsControllerAddress])
+    const proxy = await deployContract(new AssetProxy__factory(signer), "AssetProxy", [
+        bridgeForrwarderImpl.address,
+        proxyAdminAddress,
+        initializeData,
+    ])
+    const bridgeForwarder = new BridgeForwarder__factory(signer).attach(proxy.address)
+
+    await verifyEtherscan(hre, {
+        address: bridgeForwarder.address,
+    })
+
+    return bridgeForwarder
+}

--- a/tasks/utils/networkAddressFactory.ts
+++ b/tasks/utils/networkAddressFactory.ts
@@ -14,6 +14,9 @@ export const contractNames = [
     "SavingsManager",
     "Liquidator",
     "RewardsDistributor",
+    "EmissionsController",
+    "L2EmissionsController",
+    "RootChainManager",
     "BoostDirector",
     "VoterProxy",
     "Collector",
@@ -92,6 +95,10 @@ export const getChainAddress = (contractName: ContractNames, chain: Chain): stri
                 return "0xe595D67181D701A5356e010D9a58EB9A341f1DbD"
             case "RewardsDistributor":
                 return "0x04dfDfa471b79cc9E6E8C355e6C71F8eC4916C50"
+            case "EmissionsController":
+                return DEAD_ADDRESS // TODO set after deployment
+            case "RootChainManager":
+                return "0xA0c68C638235ee32657e8f720a23ceC1bFc77C77"
             case "BoostDirector":
                 return "0xBa05FD2f20AE15B0D3f20DDc6870FeCa6ACd3592"
             case "VoterProxy":

--- a/tasks/utils/networkAddressFactory.ts
+++ b/tasks/utils/networkAddressFactory.ts
@@ -13,8 +13,8 @@ export const contractNames = [
     "BadgerSafe",
     "SavingsManager",
     "Liquidator",
+    // Will become the EmissionsController
     "RewardsDistributor",
-    "EmissionsController",
     "L2EmissionsController",
     "RootChainManager",
     "BoostDirector",
@@ -94,9 +94,8 @@ export const getChainAddress = (contractName: ContractNames, chain: Chain): stri
             case "Liquidator":
                 return "0xe595D67181D701A5356e010D9a58EB9A341f1DbD"
             case "RewardsDistributor":
+                // TODO change after Emissions Controller deployment
                 return "0x04dfDfa471b79cc9E6E8C355e6C71F8eC4916C50"
-            case "EmissionsController":
-                return DEAD_ADDRESS // TODO set after deployment
             case "RootChainManager":
                 return "0xA0c68C638235ee32657e8f720a23ceC1bFc77C77"
             case "BoostDirector":
@@ -237,6 +236,8 @@ export const getChainAddress = (contractName: ContractNames, chain: Chain): stri
                 return "0xeD04Cd19f50F893792357eA53A549E23Baf3F6cB"
             case "DelayedProxyAdmin":
                 return "0x2d369F83E9DC764a759a74e87a9Bc542a2BbfdF0"
+            case "OperationsSigner":
+                return "0xb805220e070bca63441233a1ca569afe392bb840"
             case "BoostDirector":
                 return "0x363FDC050722e74C5549C11B7d2c9d68FB9D7411"
             case "SignatureVerifier":
@@ -260,7 +261,16 @@ export const getChainAddress = (contractName: ContractNames, chain: Chain): stri
             case "QuestSigner":
                 return "0x04617083205b2fdd18b15bcf60d06674c6e2c1dc"
             case "RewardsDistributor":
-                return DEAD_ADDRESS
+                // EmissionsController proxy to 0x127fcF98F9d8Ab68B263081FFDc66BFd76eBFf55
+                return "0x973E0B9E1b0bf43B1B8dDf9D6A2f817138cf3C10"
+            case "RootChainManager":
+                // Is MockRootChainManager
+                return "0x0C4964457610970a2884B8A74a397Eb9ba37D9d4"
+            case "UniswapRouterV3":
+                return "0xE592427A0AEce92De3Edee1F18E0157C05861564"
+            case "RevenueRecipient":
+                // RevenueBuyBack
+                return "0x51E014D7862d4Ba8A14a778dA59890264458F5E4"
             default:
         }
     }

--- a/tasks/utils/tokens.ts
+++ b/tasks/utils/tokens.ts
@@ -1,3 +1,4 @@
+import { DEAD_ADDRESS } from "@utils/constants"
 import { ethereumAddress } from "@utils/regex"
 
 export enum Chain {
@@ -25,6 +26,8 @@ export interface Token {
     vault?: string
     savings?: string // interest-bearing savings contracts
     platformTokenVendor?: string // hold WMATIC on Polygon's v-imUSD vault
+    bridgeForwarder?: string // Mainnet contract that forwards MTA rewards from the Emissions Controller to the L2 Bridge
+    bridgeRecipient?: string // L2 contract that receives bridge MTA rewards from the L2 Bridge
 }
 
 export function isToken(asset: unknown): asset is Token {
@@ -40,6 +43,8 @@ export const assetAddressTypes = [
     "integrator",
     "liquidityProvider",
     "platformTokenVendor",
+    "bridgeForwarder",
+    "bridgeRecipient",
 ] as const
 export type AssetAddressTypes = typeof assetAddressTypes[number]
 
@@ -74,6 +79,8 @@ export const PmUSD: Token = {
     savings: "0x5290Ad3d83476CA6A2b178Cd9727eE1EF72432af",
     vault: "0x32aBa856Dc5fFd5A56Bcd182b13380e5C855aa29",
     platformTokenVendor: "0x7b19a4f4ee26037ffef77bc7d99f56209acc8db1",
+    bridgeForwarder: DEAD_ADDRESS, // TODO after deployment
+    bridgeRecipient: DEAD_ADDRESS, // TODO after deployment
 }
 export const MmUSD: Token = {
     symbol: "MmUSD",
@@ -227,6 +234,8 @@ export const PFRAX: Token = {
     quantityFormatter: "USD",
     parent: "PmUSD",
     feederPool: "0xB30a907084AC8a0d25dDDAB4E364827406Fd09f0",
+    bridgeForwarder: DEAD_ADDRESS, // TODO after deployment
+    bridgeRecipient: DEAD_ADDRESS, // TODO after deployment
 }
 export const MFRAX: Token = {
     symbol: "MFRAX",

--- a/tasks/utils/tokens.ts
+++ b/tasks/utils/tokens.ts
@@ -70,7 +70,7 @@ export const mBTC: Token = {
 
 // mStable on Polygon mainnet
 export const PmUSD: Token = {
-    symbol: "PmUSD",
+    symbol: "mUSD",
     address: "0xE840B73E5287865EEc17d250bFb1536704B43B21",
     integrator: "0xeab7831c96876433dB9B8953B4e7e8f66c3125c3",
     chain: Chain.polygon,
@@ -83,7 +83,7 @@ export const PmUSD: Token = {
     bridgeRecipient: DEAD_ADDRESS, // TODO after deployment
 }
 export const MmUSD: Token = {
-    symbol: "MmUSD",
+    symbol: "mUSD",
     address: "0x0f7a5734f208A356AB2e5Cf3d02129c17028F3cf",
     chain: Chain.mumbai,
     decimals: 18,
@@ -91,7 +91,7 @@ export const MmUSD: Token = {
 }
 // Ropsten
 export const RmUSD: Token = {
-    symbol: "RmUSD",
+    symbol: "mUSD",
     address: "0x4E1000616990D83e56f4b5fC6CC8602DcfD20459",
     chain: Chain.ropsten,
     decimals: 18,
@@ -100,7 +100,7 @@ export const RmUSD: Token = {
     vault: "0xDEFc008BAC1e38F13F081DDD20acf89985DFa7C8",
 }
 export const RmBTC: Token = {
-    symbol: "RmBTC",
+    symbol: "mBTC",
     address: "0x4A677A48A790f26eac4c97f495E537558Abf6A79",
     chain: Chain.ropsten,
     decimals: 18,
@@ -157,35 +157,35 @@ export const DAI: Token = {
 
 // USD Main Pool Assets on Polygon
 export const PUSDC: Token = {
-    symbol: "PUSDC",
+    symbol: "USDC",
     address: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
     chain: Chain.polygon,
     platform: Platform.Aave,
     integrator: "0xeab7831c96876433dB9B8953B4e7e8f66c3125c3",
     decimals: 6,
     quantityFormatter: "USD",
-    parent: "PmUSD",
+    parent: "mUSD",
 }
 
 export const PUSDT: Token = {
-    symbol: "PUSDT",
+    symbol: "USDT",
     address: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
     chain: Chain.polygon,
     platform: Platform.Aave,
     integrator: "0xeab7831c96876433dB9B8953B4e7e8f66c3125c3",
     decimals: 6,
     quantityFormatter: "USD",
-    parent: "PmUSD",
+    parent: "mUSD",
 }
 export const PDAI: Token = {
-    symbol: "PDAI",
+    symbol: "DAI",
     address: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
     chain: Chain.polygon,
     platform: Platform.Aave,
     integrator: "0xeab7831c96876433dB9B8953B4e7e8f66c3125c3",
     decimals: 18,
     quantityFormatter: "USD",
-    parent: "PmUSD",
+    parent: "mUSD",
 }
 
 // USD Feeder Pool Assets on Mainnet
@@ -227,23 +227,23 @@ export const FRAX: Token = {
 }
 // USD Feeder Pool Assets on Polygon
 export const PFRAX: Token = {
-    symbol: "PFRAX",
+    symbol: "FRAX",
     address: "0x104592a158490a9228070E0A8e5343B499e125D0",
     chain: Chain.polygon,
     decimals: 18,
     quantityFormatter: "USD",
-    parent: "PmUSD",
+    parent: "mUSD",
     feederPool: "0xB30a907084AC8a0d25dDDAB4E364827406Fd09f0",
     bridgeForwarder: DEAD_ADDRESS, // TODO after deployment
     bridgeRecipient: DEAD_ADDRESS, // TODO after deployment
 }
 export const MFRAX: Token = {
-    symbol: "MFRAX",
+    symbol: "FRAX",
     address: "0x8F6F8064A0222F138d56C077a7F27009BDBBE3B1",
     chain: Chain.mumbai,
     decimals: 18,
     quantityFormatter: "USD",
-    parent: "MmUSD",
+    parent: "mUSD",
 }
 
 // Alchemix
@@ -338,7 +338,7 @@ export const MTA: Token = {
 }
 
 export const PMTA: Token = {
-    symbol: "PMTA",
+    symbol: "MTA",
     address: "0xF501dd45a1198C2E1b5aEF5314A68B9006D842E0",
     chain: Chain.polygon,
     decimals: 18,
@@ -346,7 +346,7 @@ export const PMTA: Token = {
 }
 
 export const RMTA: Token = {
-    symbol: "RMTA",
+    symbol: "MTA",
     address: "0x273bc479E5C21CAA15aA8538DecBF310981d14C0",
     chain: Chain.ropsten,
     decimals: 18,
@@ -365,7 +365,7 @@ export const vMTA: Token = {
 }
 
 export const PWMATIC: Token = {
-    symbol: "PWMATIC",
+    symbol: "WMATIC",
     address: "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
     chain: Chain.polygon,
     decimals: 18,
@@ -421,7 +421,7 @@ export const BAL: Token = {
 }
 
 export const RBAL: Token = {
-    symbol: "RBAL",
+    symbol: "BAL",
     address: "0x0Aa94D9Db9dA74Bb86A437E28EE4ecf22365843E",
     chain: Chain.ropsten,
     decimals: 18,
@@ -438,7 +438,7 @@ export const mBPT: Token = {
 }
 
 export const RmBPT: Token = {
-    symbol: "RmBPT",
+    symbol: "mBPT",
     address: "0x021c343C6180f03cE9E48FaE3ff432309b9aF199",
     chain: Chain.ropsten,
     decimals: 18,

--- a/tasks/utils/tokens.ts
+++ b/tasks/utils/tokens.ts
@@ -79,7 +79,7 @@ export const PmUSD: Token = {
     savings: "0x5290Ad3d83476CA6A2b178Cd9727eE1EF72432af",
     vault: "0x32aBa856Dc5fFd5A56Bcd182b13380e5C855aa29",
     platformTokenVendor: "0x7b19a4f4ee26037ffef77bc7d99f56209acc8db1",
-    bridgeForwarder: DEAD_ADDRESS, // TODO after deployment
+    bridgeForwarder: DEAD_ADDRESS, // TODO after deployment,
     bridgeRecipient: DEAD_ADDRESS, // TODO after deployment
 }
 export const MmUSD: Token = {
@@ -88,6 +88,8 @@ export const MmUSD: Token = {
     chain: Chain.mumbai,
     decimals: 18,
     quantityFormatter: "USD",
+    bridgeForwarder: "0x1dAdDae168636fE28b5eA34F1b3D4ea9367e8b6F",
+    bridgeRecipient: DEAD_ADDRESS, // TODO after deployment
 }
 // Ropsten
 export const RmUSD: Token = {
@@ -477,6 +479,8 @@ export const tokens = [
     PWMATIC,
     RmUSD,
     RmBTC,
+    MmUSD,
+    MFRAX,
     mBPT,
     RmBPT,
     BAL,

--- a/tasks/weekly.ts
+++ b/tasks/weekly.ts
@@ -106,7 +106,7 @@ task("distribute-mta-polygon", "Distributes MTA and Matic rewards on Polygon")
         console.log("\n\nTransfer 10k MTA to FRAX")
         const fraxAmount = 10000
         await hre.run("token-transfer", {
-            asset: "PMTA",
+            asset: rewardSymbol,
             recipient: "FraxVault",
             amount: fraxAmount,
             speed,

--- a/test/buy-and-make/revenue-buy-back.spec.ts
+++ b/test/buy-and-make/revenue-buy-back.spec.ts
@@ -95,14 +95,13 @@ describe("RevenueBuyBack", () => {
             rewardsToken.address,
             defaultConfig,
         )
-        await rewardsToken.approve(emissionController.address, simpleToExactAmount(10000))
         await emissionController.initialize(
             [staking1.address, staking2.address],
             [10, 10],
             [true, true],
             [staking1.address, staking2.address],
-            simpleToExactAmount(10000),
         )
+        await rewardsToken.transfer(emissionController.address, simpleToExactAmount(10000))
 
         // Deploy and initialize test RevenueBuyBack
         revenueBuyBack = await new RevenueBuyBack__factory(sa.default.signer).deploy(


### PR DESCRIPTION
* Basic RevenueBuyBack unit tests
* Hardhat tasks to deploy mainnet and Polygon contracts for the Emissions Controller
* Added `getDialRecipient` to the `EmissionsController`
* Renamed `EmissionsController.CHILD_RECIPIENT` to `EmissionsController.BRIDGE_RECIPIENT`
* Removed transfer of MTA into the EmissionsController from the `initialize` function. 6 weeks worth of MTA will be pushed from a Gnosis Safe instead.