### PR TITLE
test: adds tests to EmissionsController.topLineEmission function (9702)

### DIFF
--- a/contracts/emissions/EmissionsController.sol
+++ b/contracts/emissions/EmissionsController.sol
@@ -110,7 +110,7 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
     mapping(address => VoterPreferences) public voterPreferences;
 
     event AddedDial(uint256 indexed id, address indexed recipient);
-    event UpdatedDial(uint256 indexed id, bool diabled);
+    event UpdatedDial(uint256 indexed id, bool disabled);
     event AddStakingContract(address indexed stakingContract);
 
     event PeriodRewards(uint256[] amounts);
@@ -160,7 +160,7 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
         address[] memory _stakingContracts
     ) external initializer {
         uint256 len = _recipients.length;
-        require(_notifies.length == len && _caps.length == len, "Initialize args mistmatch");
+        require(_notifies.length == len && _caps.length == len, "Initialize args mismatch");
 
         // 1.0 - Add each of the dials
         for (uint256 i = 0; i < len; i++) {

--- a/contracts/emissions/EmissionsController.sol
+++ b/contracts/emissions/EmissionsController.sol
@@ -138,11 +138,11 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
     ) ImmutableModule(_nexus) {
         require(_rewardToken != address(0), "Reward token address is zero");
         REWARD_TOKEN = IERC20(_rewardToken);
-        A = _config.A * 1e12;
-        B = _config.B * 1e12;
-        C = _config.C * 1e12;
-        D = _config.D * 1e12;
-        EPOCHS = _config.EPOCHS * 1e6;
+        A = _config.A * 1e3;
+        B = _config.B * 1e3;
+        C = _config.C * 1e3;
+        D = _config.D * 1e3;
+        EPOCHS = _config.EPOCHS;
     }
 
     /**
@@ -203,19 +203,19 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
      * @return emissionForEpoch Units of MTA to be distributed at this epoch
      */
     function topLineEmission(uint32 epoch) public view returns (uint256 emissionForEpoch) {
-        // e.g. week 1, A = -166000e12, B = 180000e12, C = -180000e12, D = 166000e12
-        // e.g. epochDelta = 1e18
-        uint128 epochDelta = (epoch - epochs.startEpoch) * 1e18;
-        // e.g. x = 1e18 / 312e6 = 3205128205
-        int256 x = SafeCast.toInt256(epochDelta / EPOCHS);
+        require(epochs.startEpoch < epoch && epoch<= epochs.startEpoch + 312 , "Wrong epoch number");
+        // e.g. week 1, A = -166000e12, B = 168479942061125e3, C = -168479942061125e3, D = 166000e12
+        // e.g. epochDelta = 1
+        uint128 epochDelta = (epoch - epochs.startEpoch);
+        // e.g. x = 1e12 / 312 = 3205128205
+        int256 x = SafeCast.toInt256(epochDelta  * 1e12 / EPOCHS);
         emissionForEpoch =
             SafeCast.toUint256(
-                ((A * (x**3)) / 1e36) + // e.g. -166000e12 * (3205128205 ^ 3) / 1e36 =   -5465681315
-                    ((B * (x**2)) / 1e24) + // e.g.  180000e12 * (3205128205 ^ 2) / 1e24.0 = 1849112425887
-                    ((C * (x)) / 1e12) + // e.g. -180000e12 * 3205128205 / 1e12 =    -576923076900000
-                    D // e.g.                                   166000000000000000
-            ) *
-            1e6; // e.g. SUM = 1,6542492e17 * 1e6 = 165424e18
+                ((A * (x**3)) / 1e36) + // e.g. -166000e12         * (3205128205 ^ 3) / 1e36 = -5465681315
+                ((B * (x**2)) / 1e24) + // e.g.  168479942061125e3 * (3205128205 ^ 2) / 1e24 =  1730768635433
+                ((C * (x))    / 1e12) + // e.g. -168479942061125e3 *  3205128205      / 1e12 = -539999814276877
+                  D                     // e.g.  166000e12
+            ) * 1e6; // e.g. SUM = 165461725488677241 * 1e6 = 165461e18
     }
 
     /**

--- a/tasks/feeder.ts
+++ b/tasks/feeder.ts
@@ -391,8 +391,8 @@ task("feeder-collect-interest", "Collects and interest from feeder pools")
         const lastBatchDate = new Date(lastBatchCollected.mul(1000).toNumber())
         console.log(`The last interest collection was ${lastBatchDate.toUTCString()}, epoch ${lastBatchCollected} seconds`)
 
-        const currentEpoc = new Date().getTime() / 1000
-        if (currentEpoc - lastBatchCollected.toNumber() < 60 * 60 * 12) {
+        const currentEpoch = new Date().getTime() / 1000
+        if (currentEpoch - lastBatchCollected.toNumber() < 60 * 60 * 12) {
             console.error(`Can not run again as the last run was less then 12 hours ago`)
             process.exit(3)
         }

--- a/tasks/ops.ts
+++ b/tasks/ops.ts
@@ -44,8 +44,8 @@ task("collect-interest", "Collects and streams interest from platforms")
         const lastBatchDate = new Date(lastBatchCollected.mul(1000).toNumber())
         console.log(`The last interest collection was ${lastBatchDate.toUTCString()}, epoch ${lastBatchCollected} seconds`)
 
-        const currentEpoc = new Date().getTime() / 1000
-        if (currentEpoc - lastBatchCollected.toNumber() < 60 * 60 * 6) {
+        const currentEpoch= new Date().getTime() / 1000
+        if (currentEpoch- lastBatchCollected.toNumber() < 60 * 60 * 6) {
             console.error(`Can not run again as the last run was less then 6 hours ago`)
             process.exit(3)
         }

--- a/test/emissions/emission-controller.spec.ts
+++ b/test/emissions/emission-controller.spec.ts
@@ -35,12 +35,12 @@ const defaultConfig = {
 const calcWeeklyReward = (epochDelta: number): BN => {
     const { A, B, C, D, EPOCHS } = defaultConfig
     const inputScale = simpleToExactAmount(1, 3)
-    const calulationScale = 12
+    const calculationScale = 12
 
-    const x = BN.from(epochDelta).mul(simpleToExactAmount(1,calulationScale)).div(BN.from(EPOCHS))
-    const a = BN.from(A).mul(inputScale).mul(x.pow(3)).div(simpleToExactAmount(1, calulationScale * 3))
-    const b = BN.from(B).mul(inputScale).mul(x.pow(2)).div(simpleToExactAmount(1, calulationScale * 2))
-    const c = BN.from(C).mul(inputScale).mul(x).div(simpleToExactAmount(1, calulationScale))
+    const x = BN.from(epochDelta).mul(simpleToExactAmount(1,calculationScale)).div(BN.from(EPOCHS))
+    const a = BN.from(A).mul(inputScale).mul(x.pow(3)).div(simpleToExactAmount(1, calculationScale * 3))
+    const b = BN.from(B).mul(inputScale).mul(x.pow(2)).div(simpleToExactAmount(1, calculationScale * 2))
+    const c = BN.from(C).mul(inputScale).mul(x).div(simpleToExactAmount(1, calculationScale))
     const d = BN.from(D).mul(inputScale)
     return a.add(b).add(c).add(d).mul(simpleToExactAmount(1, 6))
 }
@@ -61,11 +61,11 @@ const nextRewardAmount = async (emissionsController: EmissionsController, epoch 
  *
  * @param {EmissionsController} emissionsController
  * @param {number} startingEpoch - The starting epoch.
- * @param {number} deltaEpoc - The delta epoch.
+ * @param {number} deltaEpoch- The delta epoch.
  */
-const expectTopLineEmissionForEpoc = (emissionsController: EmissionsController, startingEpoch: number) => async (deltaEpoc: number) => {
-    const emissionForEpoch = await emissionsController.topLineEmission(startingEpoch + deltaEpoc)
-    const expectedEmissionAmount = await nextRewardAmount(emissionsController, deltaEpoc)
+const expectTopLineEmissionForEpoch = (emissionsController: EmissionsController, startingEpoch: number) => async (deltaEpoch: number) => {
+    const emissionForEpoch = await emissionsController.topLineEmission(startingEpoch + deltaEpoch)
+    const expectedEmissionAmount = await nextRewardAmount(emissionsController, deltaEpoch)
     expect(emissionForEpoch).eq(expectedEmissionAmount)
 }
 
@@ -220,7 +220,7 @@ describe("EmissionsController", async () => {
                 it(test.desc, async () => {
                     const recipients = test.dialIndexes.map((i) => dials[i].address)
                     const tx = emissionsController.initialize(recipients, test.caps, test.notifies, test.stakingContracts)
-                    await expect(tx).to.revertedWith("Initialize args mistmatch")
+                    await expect(tx).to.revertedWith("Initialize args mismatch")
                 })
             }
             it("First staking contract is zero", async () => {
@@ -236,7 +236,7 @@ describe("EmissionsController", async () => {
         })
     })
     describe("calling view functions", () => {
-        // TODO - `getVotes` and `topLineEmission`
+                // TODO - `getVotes`
 
         describe("fetch weekly emissions", () => {
             let startingEpoch
@@ -244,7 +244,7 @@ describe("EmissionsController", async () => {
             before(async () => {
                 await deployEmissionsController()
                 ;[startingEpoch] = await emissionsController.epochs()
-                expectTopLineEmissions= expectTopLineEmissionForEpoc(emissionsController, startingEpoch);
+                expectTopLineEmissions= expectTopLineEmissionForEpoch(emissionsController, startingEpoch);
             })
             it("fails fetching an smaller epoch than deployed time", async () => {
                 const tx = emissionsController.topLineEmission(startingEpoch - 1)
@@ -529,7 +529,7 @@ describe("EmissionsController", async () => {
     // TODO - add tests for:
     //        - new epoch, update balances, then calculate (should read most recent)
     //        - updating voteHistory during calculate
-    //        - reading votehistory of NEW dials, and of OLD dials
+    //        - reading voteHistory of NEW dials, and of OLD dials
     //        - dials that go enabled -> disabled and vice versa
     //        - capped dials and vote redistribution
     //          - cap not met (< maxVotes)


### PR DESCRIPTION

- Change consturctor, as now the it is required to  numbers of 9 digits on the configuration to avoid loosing precision.
    From `A = _config.A * 1e12;`  to `A = _config.A * 1e3;`
- Fix overflow execption while calculating epochDelta 
```
// Uncaught Error: VM Exception while processing transaction: reverted with panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)
 uint128 epochDelta = (epoch - epochs.startEpoch) * 1e18; 
```