### PR TITLE
Emissions tests

### DIFF
--- a/contracts/buy-and-make/RevenueBuyBack.sol
+++ b/contracts/buy-and-make/RevenueBuyBack.sol
@@ -41,8 +41,8 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
     );
     event DonatedRewards(uint256 totalRewards);
     event AddedMassetConfig(
-        address mAsset,
-        address bAsset,
+        address indexed mAsset,
+        address indexed bAsset,
         uint128 minMasset2BassetPrice,
         uint128 minBasset2RewardsPrice,
         bytes uniswapPath

--- a/contracts/buy-and-make/RevenueForwarder.sol
+++ b/contracts/buy-and-make/RevenueForwarder.sol
@@ -18,7 +18,7 @@ contract RevenueForwarder is IRevenueRecipient, ImmutableModule {
 
     event RevenueReceived(address indexed mAsset, uint256 amountIn);
     event Withdrawn(uint256 amountOut);
-    event SetForwarder(address newForwarder);
+    event SetForwarder(address indexed newForwarder);
 
     IERC20 public immutable mAsset;
 

--- a/contracts/emissions/BasicRewardsForwarder.sol
+++ b/contracts/emissions/BasicRewardsForwarder.sol
@@ -77,6 +77,7 @@ contract BasicRewardsForwarder is
      * @param _endRecipient The account the reward tokens are sent to
      */
     function setEndRecipient(address _endRecipient) external onlyOwner {
+        require(endRecipient != _endRecipient, "Same end recipient");
         endRecipient = _endRecipient;
 
         emit RecipientChanged(_endRecipient);

--- a/contracts/emissions/EmissionsController.sol
+++ b/contracts/emissions/EmissionsController.sol
@@ -109,8 +109,8 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
     ///         A user can not issue more than 100% of their voting power across dials.
     mapping(address => VoterPreferences) public voterPreferences;
 
-    event AddedDial(uint256 indexed id, address indexed recipient);
-    event UpdatedDial(uint256 indexed id, bool disabled);
+    event AddedDial(uint256 indexed dialId, address indexed recipient);
+    event UpdatedDial(uint256 indexed dialId, bool disabled);
     event AddStakingContract(address indexed stakingContract);
 
     event PeriodRewards(uint256[] amounts);
@@ -118,7 +118,7 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
     event DistributedReward(uint256 indexed dialId, uint256 amount);
 
     event PreferencesChanged(address indexed voter, Preference[] preferences);
-    event VotesCast(address from, address to, uint256 amount);
+    event VotesCast(address indexed from, address indexed to, uint256 amount);
     event SourcesPoked(address indexed voter);
 
     /***************************************

--- a/contracts/rewards/InitializableRewardsDistributionRecipient.sol
+++ b/contracts/rewards/InitializableRewardsDistributionRecipient.sol
@@ -23,6 +23,7 @@ abstract contract InitializableRewardsDistributionRecipient is
 
     /** @dev Recipient is a module, governed by mStable governance */
     function _initialize(address _rewardsDistributor) internal virtual {
+        require(_rewardsDistributor != address(0), "Rewards distributor is zero");
         rewardsDistributor = _rewardsDistributor;
     }
 

--- a/contracts/rewards/InitializableRewardsDistributionRecipient.sol
+++ b/contracts/rewards/InitializableRewardsDistributionRecipient.sol
@@ -23,7 +23,6 @@ abstract contract InitializableRewardsDistributionRecipient is
 
     /** @dev Recipient is a module, governed by mStable governance */
     function _initialize(address _rewardsDistributor) internal virtual {
-        require(_rewardsDistributor != address(0), "Rewards distributor is zero");
         rewardsDistributor = _rewardsDistributor;
     }
 

--- a/test/buy-and-make/revenue-forwarder.spec.ts
+++ b/test/buy-and-make/revenue-forwarder.spec.ts
@@ -178,6 +178,17 @@ describe("RevenueForwarder", () => {
             expect(await mAsset.balanceOf(revenueForwarder.address), "revenue forwarder's mAsset bal after").to.eq(0)
             expect(await mAsset.balanceOf(forwarderAddress), "forwarder's mAsset bal after").to.eq(notificationAmount)
         })
+        it("should forward with no rewards balance", async () => {
+            // Forward whatever balance it currently has
+            await revenueForwarder.connect(keeper.signer).forward()
+
+            expect(await mAsset.balanceOf(revenueForwarder.address), "revenue forwarder's mAsset bal before").to.eq(0)
+
+            const tx = await revenueForwarder.connect(keeper.signer).forward()
+
+            await expect(tx).to.not.emit(revenueForwarder, "Withdrawn")
+            expect(await mAsset.balanceOf(revenueForwarder.address), "revenue forwarder's mAsset bal after").to.eq(0)
+        })
         it("Not governor or keeper fail set new forwarder", async () => {
             const tx = revenueForwarder.connect(sa.dummy1.signer).forward()
 

--- a/test/buy-and-make/revenue-forwarder.spec.ts
+++ b/test/buy-and-make/revenue-forwarder.spec.ts
@@ -1,0 +1,203 @@
+import { ethers } from "hardhat"
+import { expect } from "chai"
+
+import { simpleToExactAmount } from "@utils/math"
+import { MassetMachine, StandardAccounts } from "@utils/machines"
+
+import {
+    MockNexus__factory,
+    MockNexus,
+    MockMasset__factory,
+    MockMasset,
+    RevenueForwarder__factory,
+    RevenueForwarder,
+} from "types/generated"
+import { ZERO_ADDRESS } from "@utils/constants"
+import { Wallet } from "@ethersproject/wallet"
+import { Account } from "types/common"
+
+describe("RevenueForwarder", () => {
+    let sa: StandardAccounts
+    let mAssetMachine: MassetMachine
+    let nexus: MockNexus
+    let revenueForwarder: RevenueForwarder
+    let mAsset: MockMasset
+    let keeper: Account
+    let forwarderAddress: string
+
+    /*
+        Test Data
+        mAssets: mUSD and mBTC with 18 decimals
+     */
+    const setup = async (): Promise<void> => {
+        mAsset = await new MockMasset__factory(sa.default.signer).deploy(
+            "meta USD",
+            "mUSD",
+            18,
+            sa.default.address,
+            simpleToExactAmount(1000000),
+        )
+
+        // Deploy mock Nexus
+        nexus = await new MockNexus__factory(sa.default.signer).deploy(
+            sa.governor.address,
+            sa.mockSavingsManager.address,
+            sa.mockInterestValidator.address,
+        )
+        keeper = sa.fundManager
+        forwarderAddress = Wallet.createRandom().address
+
+        // Deploy aRevenueForwarder
+        revenueForwarder = await new RevenueForwarder__factory(sa.default.signer).deploy(
+            nexus.address,
+            mAsset.address,
+            keeper.address,
+            forwarderAddress,
+        )
+    }
+
+    before(async () => {
+        const accounts = await ethers.getSigners()
+        mAssetMachine = await new MassetMachine().initAccounts(accounts)
+        sa = mAssetMachine.sa
+
+        await setup()
+    })
+
+    describe("creating new instance", () => {
+        it("should have immutable variables set", async () => {
+            expect(await revenueForwarder.nexus(), "Nexus").eq(nexus.address)
+            expect(await revenueForwarder.mAsset(), "mAsset").eq(mAsset.address)
+            expect(await revenueForwarder.keeper(), "Keeper").eq(keeper.address)
+            expect(await revenueForwarder.forwarder(), "Forwarder").eq(forwarderAddress)
+        })
+        describe("it should fail if zero", () => {
+            it("nexus", async () => {
+                const tx = new RevenueForwarder__factory(sa.default.signer).deploy(
+                    ZERO_ADDRESS,
+                    mAsset.address,
+                    keeper.address,
+                    forwarderAddress,
+                )
+                await expect(tx).to.revertedWith("Nexus address is zero")
+            })
+            it("mAsset", async () => {
+                const tx = new RevenueForwarder__factory(sa.default.signer).deploy(
+                    nexus.address,
+                    ZERO_ADDRESS,
+                    keeper.address,
+                    forwarderAddress,
+                )
+                await expect(tx).to.revertedWith("mAsset is zero")
+            })
+            it("Keeper", async () => {
+                const tx = new RevenueForwarder__factory(sa.default.signer).deploy(
+                    nexus.address,
+                    mAsset.address,
+                    ZERO_ADDRESS,
+                    forwarderAddress,
+                )
+                await expect(tx).to.revertedWith("Keeper is zero")
+            })
+            it("Forwarder", async () => {
+                const tx = new RevenueForwarder__factory(sa.default.signer).deploy(
+                    nexus.address,
+                    mAsset.address,
+                    keeper.address,
+                    ZERO_ADDRESS,
+                )
+                await expect(tx).to.revertedWith("Forwarder is zero")
+            })
+        })
+    })
+    describe("notification of revenue", () => {
+        it("should simply transfer from the sender", async () => {
+            const senderBalBefore = await mAsset.balanceOf(sa.default.address)
+            const revenueBuyBackBalBefore = await mAsset.balanceOf(revenueForwarder.address)
+            const notificationAmount = simpleToExactAmount(100, 18)
+            expect(senderBalBefore.gte(notificationAmount), "sender rewards bal before").to.be.true
+
+            // approve
+            await mAsset.approve(revenueForwarder.address, notificationAmount)
+            // call
+            const tx = await revenueForwarder.notifyRedistributionAmount(mAsset.address, notificationAmount)
+            await expect(tx).to.emit(revenueForwarder, "RevenueReceived").withArgs(mAsset.address, notificationAmount)
+
+            // check output balances: mAsset sender/recipient
+            expect(await mAsset.balanceOf(sa.default.address), "mAsset sender bal after").eq(senderBalBefore.sub(notificationAmount))
+            expect(await mAsset.balanceOf(revenueForwarder.address), "mAsset RevenueForwarder bal after").eq(
+                revenueBuyBackBalBefore.add(notificationAmount),
+            )
+        })
+        describe("it should fail if", () => {
+            it("not configured mAsset", async () => {
+                await expect(revenueForwarder.notifyRedistributionAmount(sa.dummy1.address, simpleToExactAmount(1, 18))).to.be.revertedWith(
+                    "Recipient is not mAsset",
+                )
+            })
+            it("approval is not given from sender", async () => {
+                await expect(revenueForwarder.notifyRedistributionAmount(mAsset.address, simpleToExactAmount(100, 18))).to.be.revertedWith(
+                    "ERC20: transfer amount exceeds allowance",
+                )
+            })
+            it("sender has insufficient balance", async () => {
+                await mAsset.transfer(sa.dummy1.address, simpleToExactAmount(1, 18))
+                await mAsset.connect(sa.dummy1.signer).approve(revenueForwarder.address, simpleToExactAmount(100))
+                await expect(
+                    revenueForwarder.connect(sa.dummy1.signer).notifyRedistributionAmount(mAsset.address, simpleToExactAmount(2, 18)),
+                ).to.be.revertedWith("ERC20: transfer amount exceeds balance")
+            })
+        })
+    })
+    describe("forward", () => {
+        const notificationAmount = simpleToExactAmount(20000)
+        beforeEach(async () => {
+            await setup()
+            // approve
+            await mAsset.approve(revenueForwarder.address, notificationAmount)
+            // call
+            await revenueForwarder.notifyRedistributionAmount(mAsset.address, notificationAmount)
+        })
+        it("keeper should forward received mAssets", async () => {
+            expect(await mAsset.balanceOf(revenueForwarder.address), "revenue forwarder's mAsset bal before").to.eq(notificationAmount)
+            expect(await mAsset.balanceOf(forwarderAddress), "forwarder's mAsset bal before").to.eq(0)
+
+            const tx = await revenueForwarder.connect(keeper.signer).forward()
+
+            await expect(tx).to.emit(revenueForwarder, "Withdrawn").withArgs(notificationAmount)
+            expect(await mAsset.balanceOf(revenueForwarder.address), "revenue forwarder's mAsset bal after").to.eq(0)
+            expect(await mAsset.balanceOf(forwarderAddress), "forwarder's mAsset bal after").to.eq(notificationAmount)
+        })
+        it("governor should forward received mAssets", async () => {
+            expect(await mAsset.balanceOf(revenueForwarder.address), "revenue forwarder's mAsset bal before").to.eq(notificationAmount)
+            expect(await mAsset.balanceOf(forwarderAddress), "forwarder's mAsset bal before").to.eq(0)
+
+            const tx = await revenueForwarder.connect(sa.governor.signer).forward()
+
+            await expect(tx).to.emit(revenueForwarder, "Withdrawn").withArgs(notificationAmount)
+            expect(await mAsset.balanceOf(revenueForwarder.address), "revenue forwarder's mAsset bal after").to.eq(0)
+            expect(await mAsset.balanceOf(forwarderAddress), "forwarder's mAsset bal after").to.eq(notificationAmount)
+        })
+        it("Not governor or keeper fail set new forwarder", async () => {
+            const tx = revenueForwarder.connect(sa.dummy1.signer).forward()
+
+            await expect(tx).to.revertedWith("Only keeper or governor")
+        })
+    })
+    describe("setConfig", () => {
+        const newForwarderAddress = Wallet.createRandom().address
+        it("governor should set new forwarder", async () => {
+            expect(await revenueForwarder.forwarder(), "forwarder before").to.eq(forwarderAddress)
+
+            const tx = await revenueForwarder.connect(sa.governor.signer).setConfig(newForwarderAddress)
+
+            await expect(tx).to.emit(revenueForwarder, "SetForwarder").withArgs(newForwarderAddress)
+            expect(await revenueForwarder.forwarder(), "forwarder after").to.eq(newForwarderAddress)
+        })
+        it("keeper fail set new forwarder", async () => {
+            const tx = revenueForwarder.connect(keeper.signer).setConfig(newForwarderAddress)
+
+            await expect(tx).to.revertedWith("Only governor can execute")
+        })
+    })
+})

--- a/test/buy-and-make/revenue-forwarder.spec.ts
+++ b/test/buy-and-make/revenue-forwarder.spec.ts
@@ -205,10 +205,15 @@ describe("RevenueForwarder", () => {
             await expect(tx).to.emit(revenueForwarder, "SetForwarder").withArgs(newForwarderAddress)
             expect(await revenueForwarder.forwarder(), "forwarder after").to.eq(newForwarderAddress)
         })
-        it("keeper fail set new forwarder", async () => {
+        it("keeper should fail to set new forwarder", async () => {
             const tx = revenueForwarder.connect(keeper.signer).setConfig(newForwarderAddress)
 
             await expect(tx).to.revertedWith("Only governor can execute")
+        })
+        it("should fail to set zero forwarder", async () => {
+            const tx = revenueForwarder.connect(sa.governor.signer).setConfig(ZERO_ADDRESS)
+
+            await expect(tx).to.revertedWith("Invalid forwarder")
         })
     })
 })

--- a/test/emissions/basic-rewards-forwarder.spec.ts
+++ b/test/emissions/basic-rewards-forwarder.spec.ts
@@ -1,0 +1,130 @@
+import { ethers } from "hardhat"
+import { expect } from "chai"
+
+import { simpleToExactAmount } from "@utils/math"
+import { MassetMachine, StandardAccounts } from "@utils/machines"
+
+import { MockNexus__factory, MockNexus, BasicRewardsForwarder, BasicRewardsForwarder__factory, MockERC20 } from "types/generated"
+import { MAX_UINT256, ZERO_ADDRESS } from "@utils/constants"
+import { Wallet } from "@ethersproject/wallet"
+import { Account } from "types/common"
+
+describe("BasicRewardsForwarder", () => {
+    let sa: StandardAccounts
+    let mAssetMachine: MassetMachine
+    let nexus: MockNexus
+    let rewardsToken: MockERC20
+    let endRecipientAddress: string
+    let owner: Account
+    let emissionsController: Account
+    let forwarder: BasicRewardsForwarder
+
+    /*
+        Test Data
+        mAssets: mUSD and mBTC with 18 decimals
+     */
+    const setup = async (): Promise<void> => {
+        // Deploy mock Nexus
+        nexus = await new MockNexus__factory(sa.default.signer).deploy(
+            sa.governor.address,
+            sa.mockSavingsManager.address,
+            sa.mockInterestValidator.address,
+        )
+
+        rewardsToken = await mAssetMachine.loadBassetProxy("Rewards Token", "RWD", 18)
+        owner = sa.dummy1
+        emissionsController = sa.dummy2
+        endRecipientAddress = Wallet.createRandom().address
+
+        // Deploy aRevenueForwarder
+        forwarder = await new BasicRewardsForwarder__factory(owner.signer).deploy(nexus.address, rewardsToken.address)
+        await forwarder.initialize(emissionsController.address, endRecipientAddress)
+
+        await rewardsToken.transfer(emissionsController.address, simpleToExactAmount(10000))
+        await rewardsToken.connect(emissionsController.signer).approve(forwarder.address, MAX_UINT256)
+    }
+
+    before(async () => {
+        const accounts = await ethers.getSigners()
+        mAssetMachine = await new MassetMachine().initAccounts(accounts)
+        sa = mAssetMachine.sa
+
+        await setup()
+    })
+
+    describe("creating new instance", () => {
+        it("should have immutable variables set", async () => {
+            expect(await forwarder.nexus(), "Nexus").eq(nexus.address)
+            expect(await forwarder.REWARDS_TOKEN(), "rewards token").eq(rewardsToken.address)
+            expect(await forwarder.getRewardToken(), "rewards token").eq(rewardsToken.address)
+            expect(await forwarder.rewardsDistributor(), "Emissions controller").eq(emissionsController.address)
+            expect(await forwarder.endRecipient(), "End recipient").eq(endRecipientAddress)
+        })
+        describe("it should fail if zero", () => {
+            it("nexus", async () => {
+                const tx = new BasicRewardsForwarder__factory(sa.default.signer).deploy(ZERO_ADDRESS, rewardsToken.address)
+                await expect(tx).to.revertedWith("Nexus address is zero")
+            })
+            it("rewards token", async () => {
+                const tx = new BasicRewardsForwarder__factory(sa.default.signer).deploy(nexus.address, ZERO_ADDRESS)
+                await expect(tx).to.revertedWith("Rewards token is zero")
+            })
+            it("Emissions controller", async () => {
+                const newForwarder = await new BasicRewardsForwarder__factory(sa.default.signer).deploy(nexus.address, rewardsToken.address)
+                const tx = newForwarder.initialize(ZERO_ADDRESS, endRecipientAddress)
+                await expect(tx).to.revertedWith("Rewards distributor is zero")
+            })
+            it("End recipient", async () => {
+                const newForwarder = await new BasicRewardsForwarder__factory(sa.default.signer).deploy(nexus.address, rewardsToken.address)
+                const tx = newForwarder.initialize(emissionsController.address, ZERO_ADDRESS)
+                await expect(tx).to.revertedWith("Recipient address is zero")
+            })
+        })
+    })
+    describe("notify reward amount", () => {
+        it("should transfer rewards to forwarder", async () => {
+            const endRecipientBalBefore = await rewardsToken.balanceOf(endRecipientAddress)
+            const notificationAmount = simpleToExactAmount(100, 18)
+
+            // Simulate the emissions controller calling the forwarder
+            await rewardsToken.transfer(forwarder.address, notificationAmount)
+            const tx = await forwarder.connect(emissionsController.signer).notifyRewardAmount(notificationAmount)
+
+            await expect(tx).to.emit(forwarder, "RewardsReceived").withArgs(notificationAmount)
+
+            // check output balances: mAsset sender/recipient
+            expect(await rewardsToken.balanceOf(endRecipientAddress), "end recipient bal after").eq(
+                endRecipientBalBefore.add(notificationAmount),
+            )
+        })
+        describe("should fail if", () => {
+            it("not emissions controller", async () => {
+                const tx = forwarder.notifyRewardAmount(simpleToExactAmount(1))
+                await expect(tx).to.be.revertedWith("Caller is not reward distributor")
+            })
+        })
+    })
+    describe("setEndRecipient", () => {
+        const newEndRecipientAddress = Wallet.createRandom().address
+        it("owner should set new end recipient", async () => {
+            expect(await forwarder.endRecipient(), "end recipient before").to.eq(endRecipientAddress)
+
+            const tx = await forwarder.connect(owner.signer).setEndRecipient(newEndRecipientAddress)
+
+            await expect(tx).to.emit(forwarder, "RecipientChanged").withArgs(newEndRecipientAddress)
+            expect(await forwarder.endRecipient(), "end recipient after").to.eq(newEndRecipientAddress)
+        })
+        it("governor should fail to set new end recipient", async () => {
+            const tx = forwarder.connect(sa.governor.signer).setEndRecipient(newEndRecipientAddress)
+
+            await expect(tx).to.revertedWith("Ownable: caller is not the owner")
+        })
+        it("owner should fail to set same end recipient", async () => {
+            const currentEndRecipient = await forwarder.endRecipient()
+
+            const tx = forwarder.connect(owner.signer).setEndRecipient(currentEndRecipient)
+
+            await expect(tx).to.revertedWith("Same end recipient")
+        })
+    })
+})

--- a/test/emissions/basic-rewards-forwarder.spec.ts
+++ b/test/emissions/basic-rewards-forwarder.spec.ts
@@ -69,11 +69,6 @@ describe("BasicRewardsForwarder", () => {
                 const tx = new BasicRewardsForwarder__factory(sa.default.signer).deploy(nexus.address, ZERO_ADDRESS)
                 await expect(tx).to.revertedWith("Rewards token is zero")
             })
-            it("Emissions controller", async () => {
-                const newForwarder = await new BasicRewardsForwarder__factory(sa.default.signer).deploy(nexus.address, rewardsToken.address)
-                const tx = newForwarder.initialize(ZERO_ADDRESS, endRecipientAddress)
-                await expect(tx).to.revertedWith("Rewards distributor is zero")
-            })
             it("End recipient", async () => {
                 const newForwarder = await new BasicRewardsForwarder__factory(sa.default.signer).deploy(nexus.address, rewardsToken.address)
                 const tx = newForwarder.initialize(emissionsController.address, ZERO_ADDRESS)


### PR DESCRIPTION
* Made `RevenueForwarder` more generic with `mAsset` rather than `musd`
* `RevenueForwarder.setConfig` now emits 
* `EmissionsController` lint and Natspec tidy
* `RevenueForwarder` unit tests
* `BasicRewardsForwarder` unit tests
* More unit tests for `EmissionsController.setVoterDialWeights`
* Improved unit test coverage of `RevenueBuyBack`