### PR TITLE
test: adds test for emission controller when dials are disabled

### DIFF
--- a/test/emissions/emission-controller.spec.ts
+++ b/test/emissions/emission-controller.spec.ts
@@ -1479,15 +1479,13 @@ describe("EmissionsController", async () => {
                 // Balance on dial 2, is the full first epoch emission + the adjusted dial 2 second emission
                 expect((await emissionsController.dials(1)).balance, "dial 2 balance after").to.eq(nextEpochEmission[0].add(adjustedDial2))
                 expect((await emissionsController.dials(2)).balance, "dial 3 balance after").to.eq(0)
-                dialAfter[0] = await snapDial(emissionsController, 0)
-                dialAfter[1] = await snapDial(emissionsController, 1)
 
                 // New votes should be cast for enabled dials
-                expect(dialBefore[0].voteHistory.length + 1, "dial 1 vote history should change").to.eq(dialAfter[0].voteHistory.length)
-                expect(dialBefore[0].voteHistory.slice(-1)[0].vote, "dial 1 vote weight should not change").to.eq(dialBefore[0].voteHistory.slice(-1)[0].vote)
+                expect(dialBefore[0].voteHistory.length + 1, "dial 1 vote history should increase").to.eq(dialAfter[0].voteHistory.length)
+                expect(dialBefore[0].voteHistory.slice(-1)[0].vote, "dial 1 vote weight should not change").to.eq(dialAfter[0].voteHistory.slice(-1)[0].vote)
 
-                expect(dialBefore[1].voteHistory.length + 2, "dial 2 vote history should change").to.eq(dialAfter[1].voteHistory.length)
-                expect(dialBefore[1].voteHistory.slice(-1)[0].vote, "dial 2 vote weight should not change").to.eq(dialBefore[1].voteHistory.slice(-1)[0].vote)
+                expect(dialBefore[1].voteHistory.length + 2, "dial 2 vote history should increase").to.eq(dialAfter[1].voteHistory.length)
+                expect(dialBefore[1].voteHistory.slice(-1)[0].vote, "dial 2 vote weight should not change").to.eq(dialAfter[1].voteHistory.slice(-1)[0].vote)
 
             })
         })

--- a/test/emissions/emission-controller.spec.ts
+++ b/test/emissions/emission-controller.spec.ts
@@ -35,6 +35,14 @@ interface VoteHistoryExpectation {
     lastVote: number | BN
     lastEpoch: number
 }
+interface DialData {
+        disabled: boolean
+        notify: boolean
+        cap: number
+        balance: BN
+        recipient: string
+        voteHistory: { votes: BN; epoch: number }[]
+}
 
 /**
  * Expectations for the last vote casted by the Dial
@@ -131,14 +139,7 @@ const expectTopLineEmissionForEpoch = (emissionsController: EmissionsController,
 const snapDial = async (
     emissionsController: EmissionsController,
     dialId: number,
-): Promise<{
-    disabled: boolean
-    notify: boolean
-    cap: number
-    balance: BN
-    recipient: string
-    voteHistory: { votes: BN; epoch: number }[]
-}> => {
+): Promise<DialData> => {
     const dialData = await emissionsController.dials(dialId)
     const voteHistory = await emissionsController.getDialVoteHistory(dialId)
     return {
@@ -1387,6 +1388,8 @@ describe("EmissionsController", async () => {
             let startEpoch: number
             beforeEach(async () => {
                 ;[startEpoch] = await emissionsController.epochs()
+                await emissionsController.connect(voter1.signer).setVoterDialWeights([{ dialId: 0, weight: 200 }])
+                await emissionsController.connect(voter2.signer).setVoterDialWeights([{ dialId: 1, weight: 200 }])
             })
             it("disabled should not receive any distribution", async () => {
                 // Given that dial 1 is disabled, and dial 2 is enabled
@@ -1394,8 +1397,6 @@ describe("EmissionsController", async () => {
                 // and dial 3 does not have any vote weight 
                 const dialBefore = [];
                 let tx = await emissionsController.connect(sa.governor.signer).updateDial(0, true)
-                await emissionsController.connect(voter1.signer).setVoterDialWeights([{ dialId: 0, weight: 200 }])
-                await emissionsController.connect(voter2.signer).setVoterDialWeights([{ dialId: 1, weight: 200 }])
                 dialBefore[0] = await snapDial(emissionsController, 0)
                 dialBefore[1] = await snapDial(emissionsController, 1)
                 expect(dialBefore[0].disabled, "dial 1 disabled before").to.eq(true)
@@ -1425,17 +1426,14 @@ describe("EmissionsController", async () => {
                 // No new votes should be cast for disabled dials
                 expect(dialBefore[0].voteHistory.length, "dial 1 vote history should not change").to.eq(dialAfter[0].voteHistory.length)
                 expectDialVotesHistoryWithoutChangeOnWeights(emissionsController, [dialVoteHistory[1]])
-
-
             })
             it("disabled then re-enabled it should receive distribution", async () => {
-                // Given a dial 1 is enable, and dial 2 is enabled
+                // Given a dial 1 is enabled, and dial 2 is enabled
                 // and voter 1 gives all its votes to dial 1, and voter 2 gives all its votes to dial 2,
                 // and dial 3 does not have any vote weight 
-                const dialBefore = [];
+                const dialBefore:Array<DialData> = [];
+                const dialAfter:Array<DialData> = [];
                 let tx = await emissionsController.connect(sa.governor.signer).updateDial(0, true)
-                await emissionsController.connect(voter1.signer).setVoterDialWeights([{ dialId: 0, weight: 200 }])
-                await emissionsController.connect(voter2.signer).setVoterDialWeights([{ dialId: 1, weight: 200 }])
 
                 dialBefore[0] = await snapDial(emissionsController, 0)
                 dialBefore[1] = await snapDial(emissionsController, 1)
@@ -1452,7 +1450,6 @@ describe("EmissionsController", async () => {
                 const nextEpochEmission = [await nextRewardAmount(emissionsController)]
                 tx = await emissionsController.calculateRewards()
 
-                const dialAfter = [];
                 dialAfter[0] = await snapDial(emissionsController, 0)
                 dialAfter[1] = await snapDial(emissionsController, 1)
 
@@ -1482,14 +1479,104 @@ describe("EmissionsController", async () => {
 
                 // New votes should be cast for enabled dials
                 expect(dialBefore[0].voteHistory.length + 1, "dial 1 vote history should increase").to.eq(dialAfter[0].voteHistory.length)
-                expect(dialBefore[0].voteHistory.slice(-1)[0].vote, "dial 1 vote weight should not change").to.eq(dialAfter[0].voteHistory.slice(-1)[0].vote)
+                expect(dialBefore[0].voteHistory.slice(-1)[0].votes, "dial 1 vote weight should not change").to.eq(dialAfter[0].voteHistory.slice(-1)[0].votes)
 
                 expect(dialBefore[1].voteHistory.length + 2, "dial 2 vote history should increase").to.eq(dialAfter[1].voteHistory.length)
-                expect(dialBefore[1].voteHistory.slice(-1)[0].vote, "dial 2 vote weight should not change").to.eq(dialAfter[1].voteHistory.slice(-1)[0].vote)
+                expect(dialBefore[1].voteHistory.slice(-1)[0].votes, "dial 2 vote weight should not change").to.eq(dialAfter[1].voteHistory.slice(-1)[0].votes)
 
             })
+            // TODO after a new dial was added that was not in previous distributions
+            it("added that was not in previous distributions", async () => {
+                // --- Given ---
+                // that dial 1,2 and 3 are enabled
+                // and voter 1 gives all its votes to dial 1, and voter 2 gives all its votes to dial 2, and dial 3 does not have any vote weight 
+
+                const dialBefore:Array<DialData> = [];
+                const dialAfter:Array<DialData> = [];
+                const adjustedDials:BN[][] = [[]]
+
+                dialBefore[0] = await snapDial(emissionsController, 0)
+                dialBefore[1] = await snapDial(emissionsController, 1)
+                expect(dialBefore[0].disabled, "dial 1 disabled before").to.eq(false)
+                expect(dialBefore[1].disabled, "dial 2 disabled before").to.eq(false)
+                const dialVoteHistory = [
+                    { dialId: 0, votesNo: 1, lastVote: VOTERS["1"].votes, lastEpoch: startEpoch },
+                    { dialId: 1, votesNo: 1, lastVote: VOTERS["2"].votes, lastEpoch: startEpoch },
+                    { dialId: 2, votesNo: 1, lastVote: 0, lastEpoch: startEpoch },
+                ]
+                await expectDialVotesHistoryForDials(emissionsController, dialVoteHistory)
+
+                // it calculates rewards for week one
+                await increaseTime(ONE_WEEK)
+                let nextEpochEmission = await nextRewardAmount(emissionsController)
+                let tx = await emissionsController.calculateRewards()
+
+                
+                dialAfter[0] = await snapDial(emissionsController, 0)
+                dialAfter[1] = await snapDial(emissionsController, 1)
+
+                adjustedDials[0] = []
+                adjustedDials[1] = []
+                adjustedDials[3] = []
+
+                // Voter 1 has 300 of the 900 votes (1/3)
+                adjustedDials[0][0] = nextEpochEmission.div(3)
+                // Voter 2 has 600 of the 900 votes (2/3)
+                adjustedDials[1][0] = nextEpochEmission.mul(2).div(3)
+                // Then disabled dials should not receive any distribution
+                await expect(tx).to.emit(emissionsController, "PeriodRewards").withArgs([adjustedDials[0][0], adjustedDials[1][0], 0])
+                expect((await emissionsController.dials(0)).balance, "dial 1 balance after").to.eq(adjustedDials[0][0])
+                expect((await emissionsController.dials(1)).balance, "dial 2 balance after").to.eq(adjustedDials[1][0])
+                expect((await emissionsController.dials(2)).balance, "dial 3 balance after").to.eq(0)
+                expectDialVotesHistoryWithoutChangeOnWeights(emissionsController, dialVoteHistory)
+
+                // -- When --
+                // it adds a new dial and calculates the distribution
+
+                const newDial = await new MockRewardsDistributionRecipient__factory(sa.default.signer).deploy(rewardToken.address, DEAD_ADDRESS)
+                tx = await emissionsController.connect(sa.governor.signer).addDial(newDial.address, 0, true)
+                await expect(tx).to.emit(emissionsController, "AddedDial").withArgs(3, newDial.address) 
+
+                // Assign voters 3 weight  to new dial 
+                await emissionsController.connect(voter3.signer).setVoterDialWeights([{ dialId: 3, weight: 200 }])                
+                dialBefore[3] = await snapDial(emissionsController, 3)
+
+                // calculates distribution
+
+                await increaseTime(ONE_WEEK)
+                 nextEpochEmission = await nextRewardAmount(emissionsController)
+                 tx = await emissionsController.calculateRewards()
+
+                 dialAfter[0] = await snapDial(emissionsController, 0)
+                 dialAfter[1] = await snapDial(emissionsController, 1)
+                 dialAfter[3] = await snapDial(emissionsController, 3)
+
+                // -- Then --
+                // the new dial should receive emissions after calculating rewards
+                // Voter 1 has 300 of the 1200 votes (1/4)
+                adjustedDials[0][1] = nextEpochEmission.div(4)
+                // Voter 2 has 600 of the 1200 votes (2/4)
+                adjustedDials[1][1] = nextEpochEmission.div(2)
+                // Voter 3 has 300 of the 1200 votes (2/5)
+                adjustedDials[3][0] = BN.from(0)
+                adjustedDials[3][1] = nextEpochEmission.div(4)                
+                // Then disabled dials should not receive any distribution
+                
+                await expect(tx).to.emit(emissionsController, "PeriodRewards").withArgs([adjustedDials[0][1], adjustedDials[1][1], 0, adjustedDials[3][1]])
+                const sum = (a:BN, b:BN) => a.add(b);
+                console.log("adjustedDials[0][1]", adjustedDials[0][1].toString(), adjustedDials[0].reduce(sum).toString())
+                console.log("adjustedDials[1][1]", adjustedDials[1][1].toString(), adjustedDials[1].reduce(sum).toString())
+                console.log("adjustedDials[2][1]", adjustedDials[3][1].toString(), adjustedDials[3].reduce(sum).toString())
+
+                expect((await emissionsController.dials(0)).balance, "dial 1 balance after").to.eq(adjustedDials[0].reduce(sum))
+                expect((await emissionsController.dials(1)).balance, "dial 2 balance after").to.eq(adjustedDials[1].reduce(sum))
+                expect((await emissionsController.dials(2)).balance, "dial 3 balance after").to.eq(0)
+                expect((await emissionsController.dials(3)).balance, "dial new balance after").to.eq(adjustedDials[3].reduce(sum))
+                // New votes should be cast for new dial
+                expect(dialBefore[3].voteHistory.length + 1, "dial new vote history should increase").to.eq(dialAfter[3].voteHistory.length)
+                expect(dialBefore[3].voteHistory.slice(-1)[0].votes, "dial 1 vote weight should not change").to.eq(dialAfter[3].voteHistory.slice(-1)[0].votes)
+            })
         })
-        // TODO after a new dial was added that was not in previous distributions
         // TODO after a new staking contract was added that was not in previous distributions
     })
     describe("distributing rewards", () => {

--- a/test/emissions/emission-controller.spec.ts
+++ b/test/emissions/emission-controller.spec.ts
@@ -1485,7 +1485,7 @@ describe("EmissionsController", async () => {
                 expect(dialBefore[1].voteHistory.slice(-1)[0].votes, "dial 2 vote weight should not change").to.eq(dialAfter[1].voteHistory.slice(-1)[0].votes)
 
             })
-            // TODO after a new dial was added that was not in previous distributions
+            // TODO after a new dial was added that was not in previous distributions [DONE]
             it("added that was not in previous distributions", async () => {
                 // --- Given ---
                 // that dial 1,2 and 3 are enabled
@@ -1523,7 +1523,6 @@ describe("EmissionsController", async () => {
                 adjustedDials[0][0] = nextEpochEmission.div(3)
                 // Voter 2 has 600 of the 900 votes (2/3)
                 adjustedDials[1][0] = nextEpochEmission.mul(2).div(3)
-                // Then disabled dials should not receive any distribution
                 await expect(tx).to.emit(emissionsController, "PeriodRewards").withArgs([adjustedDials[0][0], adjustedDials[1][0], 0])
                 expect((await emissionsController.dials(0)).balance, "dial 1 balance after").to.eq(adjustedDials[0][0])
                 expect((await emissionsController.dials(1)).balance, "dial 2 balance after").to.eq(adjustedDials[1][0])
@@ -1564,9 +1563,6 @@ describe("EmissionsController", async () => {
                 
                 await expect(tx).to.emit(emissionsController, "PeriodRewards").withArgs([adjustedDials[0][1], adjustedDials[1][1], 0, adjustedDials[3][1]])
                 const sum = (a:BN, b:BN) => a.add(b);
-                console.log("adjustedDials[0][1]", adjustedDials[0][1].toString(), adjustedDials[0].reduce(sum).toString())
-                console.log("adjustedDials[1][1]", adjustedDials[1][1].toString(), adjustedDials[1].reduce(sum).toString())
-                console.log("adjustedDials[2][1]", adjustedDials[3][1].toString(), adjustedDials[3].reduce(sum).toString())
 
                 expect((await emissionsController.dials(0)).balance, "dial 1 balance after").to.eq(adjustedDials[0].reduce(sum))
                 expect((await emissionsController.dials(1)).balance, "dial 2 balance after").to.eq(adjustedDials[1].reduce(sum))


### PR DESCRIPTION
- Adds tests for emissions controller, calculate rewards when dials are enabled , disabled 
- Adds tests for emissions controller, after a new dial was added that was not in previous distributions