### PR TITLE
Gas optimisation for Emissions Controller

### DIFF
--- a/contracts/emissions/EmissionsController.sol
+++ b/contracts/emissions/EmissionsController.sol
@@ -33,9 +33,9 @@ struct DialData {
 
 struct Preference {
     // ID of the dial (array position)
-    uint8 dialId;
+    uint256 dialId;
     // % weight applied to this dial, where 200 = 100% and 1 = 0.5%
-    uint8 weight;
+    uint256 weight;
 }
 
 struct VoterPreferences {
@@ -691,10 +691,10 @@ contract EmissionsController is IGovernanceHook, Initializable, ImmutableModule 
 
         // 1.0 - Loop through voter preferences until dialId == 255 or until end
         for (uint256 i = 0; i < 16; i++) {
-            uint8 dialId = uint8(preferences.dialWeights >> (i * 16) + 8);
+            uint256 dialId = uint8(preferences.dialWeights >> (i * 16) + 8);
             if (dialId == 255) break;
             
-            uint8 weight = uint8(preferences.dialWeights >> i * 16);
+            uint256 weight = uint8(preferences.dialWeights >> i * 16);
 
             // 1.1 - Scale the vote by dial weight
             //       e.g. 5e17 * 1e18 / 1e18 * 100e18 / 1e18 = 50e18

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -53,6 +53,7 @@ export const hardhatConfig = {
                 "*": {
                     Masset: ["storageLayout"],
                     FeederPool: ["storageLayout"],
+                    EmissionsController: ["storageLayout"],
                 },
             },
         },


### PR DESCRIPTION
* using a `uint256` for the `dialWeights` in the `VoterPreferences` struct and bit operations to turn it into an array of 16 `Preference` items.

Gas from `./test/emissions/emission-controller.spec.ts ` test before change
```
|  Contract             ·  Method               ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  addDial              ·     140684  ·     180555  ·     150511  ·           36  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  addStakingContract   ·          -  ·          -  ·      90432  ·            8  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  calculateRewards     ·     108758  ·     212864  ·     168413  ·           65  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  distributeRewards    ·      29410  ·     164485  ·     110809  ·           19  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  donate               ·      64902  ·      93677  ·      79043  ·           16  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  pokeSources          ·      31415  ·     119649  ·      63968  ·           10  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  setVoterDialWeights  ·     114828  ·     561130  ·     197687  ·          109  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  updateDial           ·      43328  ·      43340  ·      43335  ·            9  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  MockERC20            ·  approve              ·      46251  ·      46275  ·      46269  ·           14  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  MockERC20            ·  transfer             ·      51597  ·      51621  ·      51620  ·           80  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  MockStakingContract  ·  setGovernanceHook    ·      43890  ·      43914  ·      43913  ·          166  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  MockStakingContract  ·  setVotes             ·      37453  ·     132161  ·      65887  ·          277  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  MockStakingContract  ·  transferVotes        ·          -  ·          -  ·     150094  ·            2  ·          -  │
```

Gas used after
```
|  Methods                                                                                                              │
························|·······················|·············|·············|·············|···············|··············
|  Contract             ·  Method               ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  addDial              ·     140662  ·     180533  ·     150489  ·           36  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  addStakingContract   ·          -  ·          -  ·      90432  ·           14  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  calculateRewards     ·     108758  ·     212864  ·     168212  ·           77  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  distributeRewards    ·      29388  ·     164463  ·     110787  ·           19  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  donate               ·      64902  ·      93677  ·      79043  ·           16  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  pokeSources          ·      31393  ·      85883  ·      54897  ·           12  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  setVoterDialWeights  ·      74428  ·     223281  ·     119749  ·          116  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  EmissionsController  ·  updateDial           ·      43328  ·      43340  ·      43335  ·            9  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  MockERC20            ·  approve              ·      46251  ·      46275  ·      46268  ·           14  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  MockERC20            ·  transfer             ·      51597  ·      51621  ·      51620  ·           83  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  MockStakingContract  ·  setGovernanceHook    ·      43890  ·      43914  ·      43913  ·          172  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  MockStakingContract  ·  setVotes             ·      37453  ·      98616  ·      62756  ·          292  ·          -  │
························|·······················|·············|·············|·············|···············|··············
|  MockStakingContract  ·  transferVotes        ·          -  ·          -  ·      82194  ·            2  ·          -  │
```