### PR TITLE
chore: add boostCoeff to hh task params

### DIFF
--- a/tasks/deployFeeders.ts
+++ b/tasks/deployFeeders.ts
@@ -55,7 +55,6 @@ task("deployFeederPool", "Deploy Feeder Pool")
         await deployFeederPool(signer, poolData, hre)
     })
 
-// hh --config tasks-fork.config.ts --network hardhat deployNonPeggedFeederPool --masset mUSD --fasset RAI
 task("deployNonPeggedFeederPool", "Deploy Non Pegged Feeder Pool")
     .addParam("masset", "Token symbol of mAsset. eg mUSD or PmUSD for Polygon", "mUSD", types.string)
     .addParam("fasset", "Token symbol of Feeder Pool asset. eg GUSD, WBTC, PFRAX for Polygon", "alUSD", types.string)
@@ -118,9 +117,6 @@ task("deployAlcxInt", "Deploy Alchemix integration contract for alUSD Feeder Poo
         console.log(`migrateBassets data:\n${migrateData}`)
     })
 
-// vault:
-// // hh --config tasks-fork.config.ts --network hardhat deployVault --name "mUSD/RAI fPool Vault" --symbol v-fPmUSD/RAI
-//                                     --boosted true --stakingToken mUSD --rewardToken MTA --dualRewardToken FLX --price ?
 task("deployVault", "Deploy Feeder Pool with boosted dual vault")
     .addParam("name", "Token name of the vault. eg mUSD/alUSD fPool Vault", undefined, types.string)
     .addParam("symbol", "Token symbol of the vault. eg v-fPmUSD/alUSD", undefined, types.string)
@@ -134,6 +130,7 @@ task("deployVault", "Deploy Feeder Pool with boosted dual vault")
     .addOptionalParam("rewardToken", "Token symbol of reward. eg MTA", "MTA", types.string)
     .addOptionalParam("dualRewardToken", "Token symbol of second reward. eg WMATIC, ALCX, QI", undefined, types.string)
     .addOptionalParam("price", "Price coefficient is the value of the mAsset in USD. eg mUSD/USD = 1, mBTC/USD", 1, types.int)
+    .addOptionalParam("boostCoeff", "Boost coefficient", 9, types.int)
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
     .setAction(async (taskArgs, hre) => {
         const chain = getChain(hre)
@@ -156,6 +153,8 @@ task("deployVault", "Deploy Feeder Pool with boosted dual vault")
 
         if (taskArgs.price < 0 || taskArgs.price >= simpleToExactAmount(1)) throw Error(`Invalid price coefficient ${taskArgs.price}`)
 
+        if (taskArgs.boostCoeff < 1 || taskArgs.boostCoeff > 10) throw Error(`Invalid boost coefficient ${taskArgs.boostCoeff}`)
+
         const dualRewardToken = tokens.find((t) => t.symbol === taskArgs.dualRewardToken)
 
         const vaultData: VaultData = {
@@ -166,6 +165,7 @@ task("deployVault", "Deploy Feeder Pool with boosted dual vault")
             stakingToken: stakingTokenAddress,
             rewardToken: rewardToken.address,
             dualRewardToken: dualRewardToken?.address,
+            boostCoeff: taskArgs.boostCoeff,
         }
 
         await deployVault(hre, vaultData)

--- a/tasks/deployRewards.ts
+++ b/tasks/deployRewards.ts
@@ -58,6 +58,7 @@ task("Vault.deploy", "Deploys a vault contract")
     .addOptionalParam("rewardsToken", "Symbol of rewards token. eg MTA", "MTA", types.string)
     .addOptionalParam("dualRewardsToken", "Symbol of dual rewards token. eg WMATIC", undefined, types.string)
     .addOptionalParam("priceCoeff", "Price coefficient without 18 decimal places. eg 1 or 4800", 1, types.int)
+    .addOptionalParam("boostCoeff", "Boost coefficient", 9, types.int)
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
     .setAction(async (taskArgs, hre) => {
         const chain = getChain(hre)
@@ -70,6 +71,7 @@ task("Vault.deploy", "Deploys a vault contract")
             stakingToken: resolveAddress(taskArgs.stakingToken, chain, taskArgs.stakingType),
             rewardToken: resolveAddress(taskArgs.rewardsToken, chain),
             dualRewardToken: taskArgs.dualRewardsToken ? resolveAddress(taskArgs.dualRewardsToken, chain) : undefined,
+            boostCoeff: taskArgs.boostCoeff,
         }
 
         await deployVault(hre, vaultData)

--- a/tasks/utils/feederUtils.ts
+++ b/tasks/utils/feederUtils.ts
@@ -55,6 +55,7 @@ export interface VaultData {
     stakingToken: string
     rewardToken: string
     dualRewardToken?: string
+    boostCoeff?: number
 }
 
 export const deployFasset = async (
@@ -156,17 +157,12 @@ export const deployFeederPool = async (signer: Signer, feederData: FeederData, h
 
 export const deployVault = async (
     hre: HardhatRuntimeEnvironment,
-    vaultParams: VaultData,
+    vaultData: VaultData,
 ): Promise<BoostedDualVault | BoostedVault | StakingRewardsWithPlatformToken | StakingRewards> => {
     const signer = await getSigner(hre)
     const chain = getChain(hre)
-
-    const vaultData: VaultData = {
-        priceCoeff: simpleToExactAmount(1),
-        ...vaultParams,
-    }
     const rewardsDistributorAddress = getChainAddress("RewardsDistributor", chain)
-    const boostCoeff = 48
+
     let vault: BoostedDualVault | BoostedVault | StakingRewardsWithPlatformToken | StakingRewards
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let constructorArguments: any[]
@@ -177,7 +173,7 @@ export const deployVault = async (
                 vaultData.stakingToken,
                 getChainAddress("BoostDirector", chain),
                 vaultData.priceCoeff,
-                boostCoeff,
+                vaultData.boostCoeff,
                 vaultData.rewardToken,
                 vaultData.dualRewardToken,
             ]
@@ -188,7 +184,7 @@ export const deployVault = async (
                 vaultData.stakingToken,
                 getChainAddress("BoostDirector", chain),
                 vaultData.priceCoeff,
-                boostCoeff,
+                vaultData.boostCoeff,
                 vaultData.rewardToken,
             ]
             vault = await deployContract<BoostedVault>(new BoostedVault__factory(signer), "BoostedVault", constructorArguments)
@@ -206,7 +202,7 @@ export const deployVault = async (
             vaultData.stakingToken,
             getChainAddress("BoostDirector", chain),
             vaultData.priceCoeff,
-            boostCoeff,
+            vaultData.boostCoeff,
             vaultData.rewardToken,
         ]
         vault = await deployContract<StakingRewards>(new StakingRewards__factory(signer), "StakingRewards", constructorArguments)


### PR DESCRIPTION
added the boostCoeff for the deployVault hh task as on optional param, default to 9 as per Staking V2 update.