### PR TITLE
Upgrades to Hardhat tasks

### DIFF
--- a/tasks-fork.config.ts
+++ b/tasks-fork.config.ts
@@ -27,5 +27,6 @@ import "./tasks/stakingV2"
 import "./tasks/token"
 import "./tasks/vault"
 import "./tasks/ens"
+import "./tasks/ironBankMigration"
 
 export default config

--- a/tasks.config.ts
+++ b/tasks.config.ts
@@ -27,5 +27,6 @@ import "./tasks/stakingV2"
 import "./tasks/token"
 import "./tasks/vault"
 import "./tasks/ens"
+import "./tasks/ironBankMigration"
 
 export default config

--- a/tasks/feeder.ts
+++ b/tasks/feeder.ts
@@ -285,6 +285,7 @@ task("FeederWrapper-approve", "Sets approvals for a single token/spender")
 task("feeder-mint", "Mint some Feeder Pool tokens")
     .addOptionalParam("amount", "Amount of the mAsset and fAsset to deposit", undefined, types.float)
     .addParam("fasset", "Token symbol of the feeder pool asset. eg HBTC, GUSD, PFRAX or alUSD", undefined, types.string)
+    .addOptionalParam("single", "Only mint using fasset. If false, does a multi mint using fasset and masset", false, types.boolean)
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
     .setAction(async (taskArgs, hre) => {
         const signer = await getSigner(hre, taskArgs.speed)
@@ -306,12 +307,18 @@ task("feeder-mint", "Mint some Feeder Pool tokens")
 
         const mintAmount = simpleToExactAmount(taskArgs.amount)
 
-        // mint Feeder Pool tokens
-        const tx = await fp.mintMulti([mAssetToken.address, feederPoolToken.address], [mintAmount, mintAmount], 0, signerAddress)
-        await logTxDetails(
-            tx,
-            `Mint ${fpSymbol} from ${formatUnits(mintAmount)} ${mAssetSymbol} and ${formatUnits(mintAmount)} ${fAssetSymbol}`,
-        )
+        if (taskArgs.single) {
+            // mint Feeder Pool tokens
+            const tx = await fp.mint(feederPoolToken.address, mintAmount, 0, signerAddress)
+            await logTxDetails(tx, `Mint ${fpSymbol} from ${formatUnits(mintAmount)} ${fAssetSymbol}`)
+        } else {
+            // multi mint Feeder Pool tokens
+            const tx = await fp.mintMulti([mAssetToken.address, feederPoolToken.address], [mintAmount, mintAmount], 0, signerAddress)
+            await logTxDetails(
+                tx,
+                `Multi mint ${fpSymbol} from ${formatUnits(mintAmount)} ${mAssetSymbol} and ${formatUnits(mintAmount)} ${fAssetSymbol}`,
+            )
+        }
     })
 
 task("feeder-redeem", "Redeem some Feeder Pool tokens")

--- a/tasks/ironBankMigration.ts
+++ b/tasks/ironBankMigration.ts
@@ -2,7 +2,7 @@ import "ts-node/register"
 import "tsconfig-paths/register"
 
 import { task, types } from "hardhat/config"
-import { DudIntegration__factory, DudPlatform, DudPlatform__factory } from "types/generated"
+import { DudIntegration, DudIntegration__factory, DudPlatform, DudPlatform__factory } from "types/generated"
 import { getSigner } from "./utils/signerFactory"
 import { getChain, resolveAddress } from "./utils/networkAddressFactory"
 import { deployContract, logTxDetails } from "./utils/deploy-utils"
@@ -29,7 +29,13 @@ task("deploy-dud-contracts", "Deploys dud platform and integration contracts for
         })
 
         const integrationConstructorArgs = [nexusAddress, feederPoolAddress, mUSD.address, dudPlatform.address]
-        const dudIntegration = await deployContract(new DudIntegration__factory(signer), "DudIntegration", integrationConstructorArgs)
+        const dudIntegration = await deployContract<DudIntegration>(
+            new DudIntegration__factory(signer),
+            "DudIntegration",
+            integrationConstructorArgs,
+        )
+        const tx1 = await dudIntegration["initialize()"]()
+        await logTxDetails(tx1, "DudIntegration.initialize")
 
         await verifyEtherscan(hre, {
             address: dudIntegration.address,
@@ -37,8 +43,8 @@ task("deploy-dud-contracts", "Deploys dud platform and integration contracts for
             contract: "contracts/masset/peripheral/DudIntegration.sol:DudIntegration",
         })
 
-        const tx = await dudPlatform.initialize(dudIntegration.address)
-        await logTxDetails(tx, "DudPlatform.initialize")
+        const tx2 = await dudPlatform.initialize(dudIntegration.address)
+        await logTxDetails(tx2, "DudPlatform.initialize")
     })
 
 module.exports = {}

--- a/tasks/ironBankMigration.ts
+++ b/tasks/ironBankMigration.ts
@@ -1,0 +1,44 @@
+import "ts-node/register"
+import "tsconfig-paths/register"
+
+import { task, types } from "hardhat/config"
+import { DudIntegration__factory, DudPlatform, DudPlatform__factory } from "types/generated"
+import { getSigner } from "./utils/signerFactory"
+import { getChain, resolveAddress } from "./utils/networkAddressFactory"
+import { deployContract, logTxDetails } from "./utils/deploy-utils"
+import { mUSD } from "./utils/tokens"
+import { verifyEtherscan } from "./utils/etherscan"
+
+task("deploy-dud-contracts", "Deploys dud platform and integration contracts for migration mUSD migration from Iron Bank")
+    .addParam("feeder", "Token symbol or address of the Feeder Pool.", undefined, types.string, false)
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const signer = await getSigner(hre, taskArgs.speed)
+        const chain = getChain(hre)
+
+        const nexusAddress = resolveAddress("Nexus", chain)
+        const feederPoolAddress = resolveAddress(taskArgs.feeder, chain, "feederPool")
+
+        const platformConstructorArgs = [nexusAddress, mUSD.address]
+        const dudPlatform = await deployContract<DudPlatform>(new DudPlatform__factory(signer), "DudPlatform", platformConstructorArgs)
+
+        await verifyEtherscan(hre, {
+            address: dudPlatform.address,
+            constructorArguments: platformConstructorArgs,
+            contract: "contracts/masset/peripheral/DudPlatform.sol:DudPlatform",
+        })
+
+        const integrationConstructorArgs = [nexusAddress, feederPoolAddress, mUSD.address, dudPlatform.address]
+        const dudIntegration = await deployContract(new DudIntegration__factory(signer), "DudIntegration", integrationConstructorArgs)
+
+        await verifyEtherscan(hre, {
+            address: dudIntegration.address,
+            constructorArguments: integrationConstructorArgs,
+            contract: "contracts/masset/peripheral/DudIntegration.sol:DudIntegration",
+        })
+
+        const tx = await dudPlatform.initialize(dudIntegration.address)
+        await logTxDetails(tx, "DudPlatform.initialize")
+    })
+
+module.exports = {}

--- a/tasks/ops.ts
+++ b/tasks/ops.ts
@@ -44,8 +44,8 @@ task("collect-interest", "Collects and streams interest from platforms")
         const lastBatchDate = new Date(lastBatchCollected.mul(1000).toNumber())
         console.log(`The last interest collection was ${lastBatchDate.toUTCString()}, epoch ${lastBatchCollected} seconds`)
 
-        const currentEpoch= new Date().getTime() / 1000
-        if (currentEpoch- lastBatchCollected.toNumber() < 60 * 60 * 6) {
+        const currentEpoch = new Date().getTime() / 1000
+        if (currentEpoch - lastBatchCollected.toNumber() < 60 * 60 * 6) {
             console.error(`Can not run again as the last run was less then 6 hours ago`)
             process.exit(3)
         }
@@ -172,9 +172,10 @@ task("quest-add", "Adds a quest to the staked token")
     })
 
 task("quest-complete-queue", "Completes all user quests in the quests queue")
-    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
     .addParam("signerKey", "Signer API key", undefined, types.string, false)
     .addParam("signerSecret", "Signer API secret", undefined, types.string, false)
+    .addOptionalParam("qid", "Queue identified", 2, types.int)
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
     .setAction(async (taskArgs, hre) => {
         const opsSigner = await getSigner(hre, taskArgs.speed)
         const chain = getChain(hre)
@@ -182,8 +183,8 @@ task("quest-complete-queue", "Completes all user quests in the quests queue")
         const questManager = QuestManager__factory.connect(questManagerAddress, opsSigner)
 
         // get users who have completed quests from the queue
-        const migrationQuestId = 0
-        const queuedUsers = await getQueuedUsersForQuest(migrationQuestId)
+        const questId = taskArgs.qid
+        const queuedUsers = await getQueuedUsersForQuest(questId)
         if (queuedUsers.length === 0) {
             console.error(`No user completed quests`)
             process.exit(0)
@@ -191,14 +192,15 @@ task("quest-complete-queue", "Completes all user quests in the quests queue")
         console.log(`${queuedUsers.length} users in the completion queue.`)
 
         // Need to filter out any users that completed the quest themselves
-        const hasCompletedPromises = queuedUsers.map((user) => questManager.hasCompleted(user, migrationQuestId))
+        const hasCompletedPromises = queuedUsers.map((user) => questManager.hasCompleted(user, questId))
         const hasCompleted = await Promise.all(hasCompletedPromises)
         const usersUnclaimed = queuedUsers.filter((user, i) => hasCompleted[i] === false)
 
         console.log(`${usersUnclaimed.length} users have not claimed the quest on-chain: ${usersUnclaimed}`)
 
         // Filter out any user that have not completed the migration but in somehow in the queue
-        const usersCheckedPromises = usersUnclaimed.map((user) => hasUserCompletedQuest(user, "theGreatMigration"))
+        const questNames = ["theGreatMigration", "theGreatMigration", "metanautSpaceProgram"]
+        const usersCheckedPromises = usersUnclaimed.map((user) => hasUserCompletedQuest(user, questNames[questId]))
         const usersChecked = await Promise.all(usersCheckedPromises)
         const usersUnclaimedChecked = usersUnclaimed.filter((user, i) => usersChecked[i] === true)
 
@@ -213,9 +215,9 @@ task("quest-complete-queue", "Completes all user quests in the quests queue")
         const questSigner = new DefenderRelaySigner(credentials, provider, { speed: taskArgs.speed })
 
         // Quest Signer signs the users as having completed the migration quest
-        const sig = await signQuestUsers(0, usersUnclaimedChecked, questSigner)
+        const sig = await signQuestUsers(questId, usersUnclaimedChecked, questSigner)
 
         // Complete the quests in the Quest Manager contract
-        const tx = await questManager.completeQuestUsers(0, usersUnclaimedChecked, sig)
+        const tx = await questManager.completeQuestUsers(questId, usersUnclaimedChecked, sig)
         await logTxDetails(tx, "complete quest users")
     })

--- a/tasks/rewards.ts
+++ b/tasks/rewards.ts
@@ -1,17 +1,15 @@
 /* eslint-disable no-restricted-syntax */
 import { BN, simpleToExactAmount } from "@utils/math"
 import { subtask, task, types } from "hardhat/config"
-import { RewardsDistributorEth__factory } from "types/generated/factories/RewardsDistributorEth__factory"
-import { RewardsDistributor__factory } from "types/generated/factories/RewardsDistributor__factory"
 import { formatUnits } from "ethers/lib/utils"
 import { TransactionResponse } from "@ethersproject/providers"
 import { Collector__factory, Liquidator__factory } from "types/generated"
 import { Comptroller__factory } from "types/generated/factories/Comptroller__factory"
 import rewardsFiles from "./balancer-mta-rewards/20210817.json"
-import { Chain, logTxDetails, mBTC, mUSD, USDC, usdFormatter } from "./utils"
+import { logTxDetails, mBTC, mUSD, USDC, usdFormatter } from "./utils"
 import { getAaveTokens, getAlcxTokens, getBlock, getCompTokens } from "./utils/snap-utils"
 import { getSigner } from "./utils/signerFactory"
-import { getChain, getChainAddress, resolveAddress, resolveToken } from "./utils/networkAddressFactory"
+import { getChain, resolveAddress, resolveToken } from "./utils/networkAddressFactory"
 import { sendPrivateTransaction } from "./utils/flashbots"
 
 task("sum-rewards", "Totals the rewards in a disperse json file")

--- a/tasks/stakingV2.ts
+++ b/tasks/stakingV2.ts
@@ -34,12 +34,14 @@ subtask("staked-snap", "Dumps a user's staking token details.")
         const effectiveMultiplier = rawBalance.gt(0) ? boostedBalance.mul(10000).div(rawBalance) : BN.from(0)
         const delegatee = await stakingToken.delegates(userAddress, callOverride)
         const priceCoeff = taskArgs.asset === "MTA" ? BN.from(10000) : await stakingToken.priceCoefficient()
+        const userData = await stakingToken.userData(userAddress, callOverride)
 
         console.log(`Raw balance          ${usdFormatter(rawBalance)}`)
         console.log(`Boosted balance      ${usdFormatter(boostedBalance)}`)
         console.log(`Delegated votes      ${usdFormatter(delegatedVotes)}`)
         console.log(`Cooldown balance     ${usdFormatter(cooldownBalance)}`)
         console.log(`Voting power         ${usdFormatter(votes)}`)
+        console.log(`Claimable MTA        ${usdFormatter(userData.rewards)}`)
 
         const balanceData = await stakingToken.balanceData(userAddress, callOverride)
 

--- a/tasks/stakingV2.ts
+++ b/tasks/stakingV2.ts
@@ -34,14 +34,14 @@ subtask("staked-snap", "Dumps a user's staking token details.")
         const effectiveMultiplier = rawBalance.gt(0) ? boostedBalance.mul(10000).div(rawBalance) : BN.from(0)
         const delegatee = await stakingToken.delegates(userAddress, callOverride)
         const priceCoeff = taskArgs.asset === "MTA" ? BN.from(10000) : await stakingToken.priceCoefficient()
-        const userData = await stakingToken.userData(userAddress, callOverride)
+        const earnedRewards = await stakingToken.earned(userAddress, callOverride)
 
         console.log(`Raw balance          ${usdFormatter(rawBalance)}`)
         console.log(`Boosted balance      ${usdFormatter(boostedBalance)}`)
         console.log(`Delegated votes      ${usdFormatter(delegatedVotes)}`)
         console.log(`Cooldown balance     ${usdFormatter(cooldownBalance)}`)
         console.log(`Voting power         ${usdFormatter(votes)}`)
-        console.log(`Claimable MTA        ${usdFormatter(userData.rewards)}`)
+        console.log(`Earned Rewards       ${usdFormatter(earnedRewards)}`)
 
         const balanceData = await stakingToken.balanceData(userAddress, callOverride)
 

--- a/tasks/utils/quest-utils.ts
+++ b/tasks/utils/quest-utils.ts
@@ -26,7 +26,7 @@ export const getQueuedUsersForQuest = async (questId: number): Promise<string[]>
         console.log(response?.data)
         throw Error(`Failed to get quests from queue`)
     }
-    // filter users to just the migration quest
+    // filter users to just the requested quest identifier
     const usersInQueue = queue.filter((quest) => quest.ethereumId === questId)
     const usersForQuest = usersInQueue.map((quest) => quest.userId)
 

--- a/tasks/utils/snap-utils.ts
+++ b/tasks/utils/snap-utils.ts
@@ -758,7 +758,9 @@ export const getCompTokens = async (
     totalComp = totalComp.add(compLiquidatorBal)
     console.log(`Liquidator  ${quantityFormatter(compLiquidatorBal)}`)
 
-    const compUsdc = await quoteSwap(signer, COMP, USDC, totalComp, toBlock)
+    const compUsdc: SwapQuote = totalComp.gt(0)
+        ? await quoteSwap(signer, COMP, USDC, totalComp, toBlock)
+        : { outAmount: BN.from(0), exchangeRate: BN.from(0) }
     console.log(`Total       ${quantityFormatter(totalComp)} ${quantityFormatter(compUsdc.outAmount, USDC.decimals)} USDC`)
     console.log(`COMP/USDC exchange rate: ${compUsdc.exchangeRate}`)
 


### PR DESCRIPTION
Changed Hardhat tasks
* `rewards` now includes min AAVE/GUSD and AAVE/WBTC rates
* `rewards` fixed so it can handle zero COMP accrued
* `staked-snap` now has optional block argument to get historical data
* `staked-snap` now reports earned MTA
* `deploy-dud-contracts` for migration of mUSD from Iron Bank for BUSD and GUSD Feeder Pools
* `quest-complete-queue` can now run again different quests. eg the new Metanaut Space Program
* `feeder-mint` can now do a single mint or multi mint

Extra fork tests
* Liquidating `stkAAVE` from BUSD and RAI Feeder Pools
* Migrating `mUSD` from Iron Bank for the BUSD and GUSD Feeder Pools