### PR TITLE
chore: adds task votium-forward

### DIFF
--- a/tasks/emissions.ts
+++ b/tasks/emissions.ts
@@ -181,8 +181,8 @@ task("revenue-donate-rewards").setAction(async (_, __, runSuper) => {
 })
 
 subtask("votium-forward", "Forwards votium bribe. from votium dial")
+    .addParam("proposal", "Convex finance proposal for Weekly Gauge Weight", undefined, types.string)
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "average", types.string)
-    .addOptionalParam("proposal", "Convex finance proposal for Weekly Gauge Weight", undefined, types.string)
     .setAction(async (taskArgs, hre) => {
         // For example on the URL  https://vote.convexfinance.com/#/proposal/QmZpsJAvbKEY9YKFCZBUzzSMC5Y9vfy6QPA4HoXGsiLUyg
         // the proposal is QmZpsJAvbKEY9YKFCZBUzzSMC5Y9vfy6QPA4HoXGsiLUyg
@@ -205,9 +205,6 @@ subtask("votium-forward", "Forwards votium bribe. from votium dial")
 
         if (mtaBalance.lte(MIN_BRIBE_AMOUNT)) {
             throw new Error("MTA balance to low")
-        }
-        if (taskArgs.proposal === undefined) {
-            throw new Error("Proposal not specified")
         }
         const proposal = hashFn(taskArgs.proposal)
         console.log(`MTA ${mtaBalance.toString()} to deposit into proposal ${proposal} with choiceIndex ${choiceIndex}`)

--- a/tasks/emissions.ts
+++ b/tasks/emissions.ts
@@ -250,8 +250,9 @@ task("emissions-process", "Weekly mainnet emissions process")
         // await hre.run("emission-dist", { speed, dialIds: "2,3,4,5,6,7,8,9,10" })
 
         // Dial 15 (Votium) is skipped for now
-        await hre.run("votium-forward", { speed, proposal })
-
+        if (proposal === undefined) {
+            await hre.run("votium-forward", { speed, proposal })
+        }        
         // Distributes to dial 16
         await hre.run("emission-dist", { speed, dialIds: "16" })
 

--- a/test/emissions/votium-bribe-forwarder.spec.ts
+++ b/test/emissions/votium-bribe-forwarder.spec.ts
@@ -2,7 +2,6 @@ import { MAX_UINT256, ZERO_ADDRESS } from "@utils/constants"
 import { MassetMachine, StandardAccounts } from "@utils/machines"
 import { simpleToExactAmount } from "@utils/math"
 import { expect } from "chai"
-import { formatBytes32String } from "ethers/lib/utils"
 import { ethers } from "hardhat"
 import { Account } from "types/common"
 import {
@@ -15,7 +14,8 @@ import {
     VotiumBribeForwarder__factory,
 } from "types/generated"
 
-const PROPOSAL = formatBytes32String("PROPOSAL")
+export const hashFn = (str: string): string => ethers.utils.keccak256(ethers.utils.toUtf8Bytes(str))
+const PROPOSAL = hashFn("QmZpsJAvbKEY9YKFCZBUzzSMC5Y9vfy6QPA4HoXGsiLUyg")
 
 describe("VotiumBribeForwarder", () => {
     let sa: StandardAccounts


### PR DESCRIPTION
Adds new task to forward bribes on votium. 

Run as follows :
For example on the URL  https://vote.convexfinance.com/#/proposal/QmZpsJAvbKEY9YKFCZBUzzSMC5Y9vfy6QPA4HoXGsiLUyg
the proposal is `QmZpsJAvbKEY9YKFCZBUzzSMC5Y9vfy6QPA4HoXGsiLUyg`

```
yarn task:fork votium-forward  --proposal  "QmZpsJAvbKEY9YKFCZBUzzSMC5Y9vfy6QPA4HoXGsiLUyg"
```