### PR TITLE
feat: unliquidator

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -7,6 +7,7 @@ module.exports = {
         "integrations",
         "masset/peripheral",
         "masset/versions",
+        "masset/liquidator/Unliquidator.sol",
         "peripheral",
         "savings/peripheral",
         "upgradability",

--- a/contracts/masset/liquidator/Unliquidator.sol
+++ b/contracts/masset/liquidator/Unliquidator.sol
@@ -70,7 +70,7 @@ contract Unliquidator is ImmutableModule {
     /**
      * @notice Sends rewards them to the receiverSafe, without claiming them e.g. COMP can be claimed by anyone
      * @param  _integration  Integration address, this contract should have permissions to spend the token
-     * @param  _token  Address of the token that are claimed and send
+     * @param  _token  Address of the token that are transferred
      */
     function triggerDistribute(address _integration, address _token) external {
         require(_integration != address(0), "Invalid integration address");

--- a/contracts/masset/liquidator/Unliquidator.sol
+++ b/contracts/masset/liquidator/Unliquidator.sol
@@ -10,10 +10,10 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 /**
  * @title   Unliquidator
  * @author  mStable
- * @notice  The Liquidator allows rewards to be swapped for another token
- *          and returned to a calling contract
- * @dev     VERSION: 1.3
- *          DATE:    2021-05-28
+ * @notice  Replacement Contract for the Liquidator.
+ *          Does not liquidate the tokens but sends them to the treasury or a set address
+ * @dev     VERSION: 1
+ *          DATE:    2022-02-10
  */
 contract Unliquidator is ImmutableModule {
     using SafeERC20 for IERC20;
@@ -35,6 +35,7 @@ contract Unliquidator is ImmutableModule {
 
     /**
      * @notice Sets a new receive address for the tokens
+     * @param  _receiver  Address to which the tokens will be send at the end
      */
 
     function setReceiver(address _receiver) external onlyGovernance {
@@ -50,7 +51,9 @@ contract Unliquidator is ImmutableModule {
     ****************************************/
 
     /**
-     * @notice Triggers to claim rewards for all integration contracts
+     * @notice Claims the rewards and sends them to the receiverSafe, e.g. claims and sends stkAave
+     * @param  _integration  Integration address, this contract should have permissions to spend the token
+     * @param  _token  Address of the token that are claimed and send
      */
     function triggerClaimAndDistribute(address _integration, address _token) external {
         //
@@ -64,6 +67,11 @@ contract Unliquidator is ImmutableModule {
         _sendRewards(_integration, _token);
     }
 
+    /**
+     * @notice Sends rewards them to the receiverSafe, without claiming them e.g. COMP can be claimed by anyone
+     * @param  _integration  Integration address, this contract should have permissions to spend the token
+     * @param  _token  Address of the token that are claimed and send
+     */
     function triggerDistribute(address _integration, address _token) external {
         require(_integration != address(0), "Invalid integration address");
         require(_token != address(0), "Invalid token address");

--- a/contracts/masset/liquidator/Unliquidator.sol
+++ b/contracts/masset/liquidator/Unliquidator.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity 0.8.6;
+
+import { IClaimRewards } from "../../polygon/IClaimRewards.sol";
+import { ImmutableModule } from "../../shared/ImmutableModule.sol";
+
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title   Unliquidator
+ * @author  mStable
+ * @notice  The Liquidator allows rewards to be swapped for another token
+ *          and returned to a calling contract
+ * @dev     VERSION: 1.3
+ *          DATE:    2021-05-28
+ */
+contract Unliquidator is ImmutableModule {
+    using SafeERC20 for IERC20;
+
+    event ClaimedAndSendRewards(address from, address token, uint256 amount, address to);
+    event NewReceiver(address receiver);
+
+    /// @notice Address to which the tokens will be send at the end
+    address public receiverSafe;
+
+    constructor(address _nexus, address _receiverSafe) ImmutableModule(_nexus) {
+        require(_receiverSafe != address(0), "Invalid receiver address");
+        receiverSafe = _receiverSafe;
+    }
+
+    /***************************************
+                    GOVERNANCE
+    ****************************************/
+
+    /**
+     * @notice Sets a new receive address for the tokens
+     */
+
+    function setReceiver(address _receiver) external onlyGovernance {
+        //
+        require(_receiver != address(0), "Invalid receiver address");
+        receiverSafe = _receiver;
+
+        emit NewReceiver(_receiver);
+    }
+
+    /***************************************
+                    CLAIM REWARDS
+    ****************************************/
+
+    /**
+     * @notice Triggers to claim rewards for all integration contracts
+     */
+    function triggerClaimAndDistribute(address _integration, address _token) external {
+        //
+        require(_integration != address(0), "Invalid integration address");
+        require(_token != address(0), "Invalid token address");
+
+        // 1. Claim rewards for the integration contract
+        IClaimRewards(_integration).claimRewards();
+
+        // 2. Send aave rewards to receiverSafe
+        _sendRewards(_integration, _token);
+    }
+
+    function triggerDistribute(address _integration, address _token) external {
+        require(_integration != address(0), "Invalid integration address");
+        require(_token != address(0), "Invalid token address");
+
+        _sendRewards(_integration, _token);
+    }
+
+    function _sendRewards(address _from, address _token) internal {
+        //
+        // 1. Get balances of the token
+        uint256 amount = IERC20(_token).balanceOf(_from);
+        require(amount > 0, "No rewards to send");
+
+        // 2. Send the tokens to the receiverSafe
+        IERC20(_token).transferFrom(_from, receiverSafe, amount);
+
+        // 3. Emit the event
+        emit ClaimedAndSendRewards(_from, _token, amount, receiverSafe);
+    }
+}

--- a/tasks/utils/networkAddressFactory.ts
+++ b/tasks/utils/networkAddressFactory.ts
@@ -13,6 +13,7 @@ export const contractNames = [
     "BadgerSafe",
     "SavingsManager",
     "Liquidator",
+    "Unliquidator",
     // Will become the EmissionsController
     "RewardsDistributor",
     "EmissionsController",
@@ -102,6 +103,8 @@ export const getChainAddress = (contractName: ContractNames, chain: Chain): stri
                 return "0xBC3B550E0349D74bF5148D86114A48C3B4Aa856F"
             case "Liquidator":
                 return "0xe595D67181D701A5356e010D9a58EB9A341f1DbD"
+            case "Unliquidator":
+                return "0xC643B9D66C68d06EA844251a441A0a1211E60656"
             case "RewardsDistributor":
             case "EmissionsController":
                 return "0xBa69e6FC7Df49a3b75b565068Fb91ff2d9d91780"

--- a/test-fork/savings/unliquidator.spec.ts
+++ b/test-fork/savings/unliquidator.spec.ts
@@ -1,0 +1,246 @@
+import { impersonateAccount } from "@utils/fork"
+import { ethers, network } from "hardhat"
+import { Account } from "types"
+import { stkAAVE, USDC, COMP } from "tasks/utils/tokens"
+import {
+    Unliquidator,
+    Unliquidator__factory,
+    ERC20,
+    ERC20__factory,
+    Nexus,
+    Nexus__factory,
+    PAaveIntegration,
+    PAaveIntegration__factory,
+    CompoundIntegration,
+    CompoundIntegration__factory,
+} from "types/generated"
+import { Comptroller__factory } from "types/generated/factories/Comptroller__factory"
+
+import { expect } from "chai"
+import { BN, simpleToExactAmount } from "@utils/math"
+import { increaseTime } from "@utils/time"
+import { ONE_HOUR, ONE_WEEK, ZERO_ADDRESS, MAX_UINT256, DEAD_ADDRESS } from "@utils/constants"
+
+import { resolveAddress } from "tasks/utils/networkAddressFactory"
+
+import { keccak256, toUtf8Bytes } from "ethers/lib/utils"
+
+const governorAddress = resolveAddress("Governor")
+const liquidatorAddress = resolveAddress("Liquidator")
+const treasuryAddress = resolveAddress("mStableDAO")
+
+const ethWhaleAddress = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+
+const aaveMusdIntegrationAddress = "0xA2a3CAe63476891AB2d640d9a5A800755Ee79d6E"
+const aaveMbtcIntegrationAddress = "0xC9451a4483d1752a3E9A3f5D6b1C7A6c34621fC6"
+const compoundIntegrationAddress = "0xD55684f4369040C12262949Ff78299f2BC9dB735"
+const nexusAddress = "0xAFcE80b19A8cE13DEc0739a1aaB7A028d6845Eb3"
+
+const toEther = (amount: BN) => ethers.utils.formatEther(amount)
+
+context("Unliquidator forked network tests", async () => {
+    let ops: Account
+    let governor: Account
+    let ethWhale: Account
+    let stkAaveToken: ERC20
+    let compToken: ERC20
+    let nexus: Nexus
+    let aaveMusdIntegration: PAaveIntegration
+    let aaveMbtcIntegration: PAaveIntegration
+    let compoundIntegration: CompoundIntegration
+
+    const runSetup = async (blockNumber: number) => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: process.env.NODE_URL,
+                        blockNumber,
+                    },
+                },
+            ],
+        })
+        ops = await impersonateAccount(resolveAddress("OperationsSigner"))
+        governor = await impersonateAccount(governorAddress)
+        ethWhale = await impersonateAccount(ethWhaleAddress)
+
+        // send some Ether to the impersonated multisig contract as it doesn't have Ether
+        await ethWhale.signer.sendTransaction({
+            to: governorAddress,
+            value: simpleToExactAmount(5),
+        })
+
+        nexus = Nexus__factory.connect(nexusAddress, governor.signer)
+        stkAaveToken = ERC20__factory.connect(stkAAVE.address, ops.signer)
+        compToken = ERC20__factory.connect(COMP.address, ops.signer)
+
+        aaveMusdIntegration = PAaveIntegration__factory.connect(aaveMusdIntegrationAddress, governor.signer)
+        aaveMbtcIntegration = PAaveIntegration__factory.connect(aaveMbtcIntegrationAddress, governor.signer)
+        compoundIntegration = CompoundIntegration__factory.connect(compoundIntegrationAddress, governor.signer)
+    }
+
+    it("Test connectivity", async () => {
+        const currentBlock = await ethers.provider.getBlockNumber()
+        console.log(`Current block ${currentBlock}`)
+    })
+
+    describe("Unliquidator", async () => {
+        let unliquidator: Unliquidator
+
+        before("reset block number", async () => {
+            await runSetup(14179191)
+        })
+        it("Should deploy Unliquidator", async () => {
+            unliquidator = await new Unliquidator__factory(governor.signer).deploy(resolveAddress("Nexus"), treasuryAddress)
+            // eslint-disable-next-line
+            expect(unliquidator.address).to.be.properAddress
+            expect(await unliquidator.receiverSafe()).to.eq(treasuryAddress)
+        })
+        it("Should propose Module in Nexus", async () => {
+            expect(await nexus.getModule(keccak256(toUtf8Bytes("Liquidator")))).to.eq(liquidatorAddress)
+            await nexus.proposeModule(keccak256(toUtf8Bytes("Liquidator")), unliquidator.address)
+            expect(await nexus.getModule(keccak256(toUtf8Bytes("Liquidator")))).to.not.eq(unliquidator.address)
+        })
+        it("Should accept Module in Nexus", async () => {
+            increaseTime(ONE_WEEK.add(ONE_HOUR))
+            await nexus.acceptProposedModule(keccak256(toUtf8Bytes("Liquidator")))
+            expect(await nexus.getModule(keccak256(toUtf8Bytes("Liquidator")))).to.eq(unliquidator.address)
+        })
+        it("Should reapprove permissions to new Unliquidator", async () => {
+            // Before no permissions
+            expect(await stkAaveToken.allowance(aaveMbtcIntegrationAddress, unliquidator.address)).to.eq(0)
+            expect(await stkAaveToken.allowance(aaveMusdIntegrationAddress, unliquidator.address)).to.eq(0)
+            expect(await compToken.allowance(compoundIntegrationAddress, unliquidator.address)).to.eq(0)
+
+            // Approve tx
+            await aaveMbtcIntegration.approveRewardToken()
+            await aaveMusdIntegration.approveRewardToken()
+            await compoundIntegration.approveRewardToken()
+
+            // After permissions
+            expect(await stkAaveToken.allowance(aaveMbtcIntegrationAddress, unliquidator.address)).to.eq(MAX_UINT256)
+            expect(await stkAaveToken.allowance(aaveMusdIntegrationAddress, unliquidator.address)).to.eq(MAX_UINT256)
+            // For some reason the approval is only for 79228162514264337593543950335
+            expect(await compToken.allowance(compoundIntegrationAddress, unliquidator.address)).to.gt(0)
+        })
+        it("Should claim stkAave from mUSD and transfer to Treasury", async () => {
+            // Before
+            const treasuryBalBefore = await stkAaveToken.balanceOf(treasuryAddress)
+            expect(await stkAaveToken.balanceOf(unliquidator.address)).to.eq(0)
+
+            console.log(`Treasury balance before ${toEther(treasuryBalBefore)}`)
+
+            // Claim
+            expect(await unliquidator.triggerClaimAndDistribute(aaveMusdIntegrationAddress, stkAAVE.address)).to.emit(
+                unliquidator,
+                "ClaimedAndSendRewards",
+            )
+
+            console.log(`Treasury balance after ${toEther(await stkAaveToken.balanceOf(treasuryAddress))}`)
+
+            // After
+            expect(await stkAaveToken.balanceOf(unliquidator.address)).to.eq(0)
+            expect(await stkAaveToken.balanceOf(treasuryAddress)).to.gt(treasuryBalBefore)
+        })
+        it("Should claim stkAave from mBTC and transfer to Treasury", async () => {
+            // Before
+            const treasuryBalBefore = await stkAaveToken.balanceOf(treasuryAddress)
+            expect(await stkAaveToken.balanceOf(unliquidator.address)).to.eq(0)
+
+            console.log(`Treasury balance before ${toEther(treasuryBalBefore)}`)
+
+            // Claim
+            expect(await unliquidator.triggerClaimAndDistribute(aaveMbtcIntegrationAddress, stkAAVE.address)).to.emit(
+                unliquidator,
+                "ClaimedAndSendRewards",
+            )
+
+            console.log(`Treasury balance after ${toEther(await stkAaveToken.balanceOf(treasuryAddress))}`)
+
+            // After
+            expect(await stkAaveToken.balanceOf(unliquidator.address)).to.eq(0)
+            expect(await stkAaveToken.balanceOf(treasuryAddress)).to.gt(treasuryBalBefore)
+        })
+        it("Should transfer COMP from integration to Treasury", async () => {
+            // Claim on behalf first
+            const compControllerAddress = resolveAddress("CompController")
+            const compController = Comptroller__factory.connect(compControllerAddress, governor.signer)
+            await compController["claimComp(address,address[])"](USDC.integrator, [USDC.liquidityProvider])
+
+            // Before
+            const treasuryBalBefore = await compToken.balanceOf(treasuryAddress)
+            expect(await compToken.balanceOf(unliquidator.address)).to.eq(0)
+
+            console.log(`Treasury balance before ${toEther(treasuryBalBefore)}`)
+
+            // Claim
+            expect(await unliquidator.triggerDistribute(compoundIntegrationAddress, COMP.address)).to.emit(
+                unliquidator,
+                "ClaimedAndSendRewards",
+            )
+
+            console.log(`Treasury balance after ${toEther(await compToken.balanceOf(treasuryAddress))}`)
+
+            // After
+            expect(await compToken.balanceOf(unliquidator.address)).to.eq(0)
+            expect(await compToken.balanceOf(treasuryAddress)).to.gt(treasuryBalBefore)
+        })
+        it("Should set new Receiver", async () => {
+            expect(await unliquidator.receiverSafe()).to.eq(treasuryAddress)
+            expect(await unliquidator.connect(governor.signer).setReceiver(governor.address))
+                .to.emit(unliquidator, "NewReceiver")
+                .withArgs(governor.address)
+            expect(await unliquidator.receiverSafe()).to.eq(governor.address)
+        })
+    })
+    describe("Unliquidator should fail to deploy in the following cases", async () => {
+        before("reset block number", async () => {
+            await runSetup(14179191)
+        })
+        it("Should not deploy with nexus 0", async () => {
+            expect(new Unliquidator__factory(governor.signer).deploy(ZERO_ADDRESS, treasuryAddress)).to.be.revertedWith(
+                "Nexus address is zero",
+            )
+        })
+        it("Should not deploy with receiver 0", async () => {
+            expect(new Unliquidator__factory(governor.signer).deploy(nexus.address, ZERO_ADDRESS)).to.be.revertedWith(
+                "Invalid receiver address",
+            )
+        })
+    })
+    describe("Unliquidator should fail after deploy", async () => {
+        let unliquidator: Unliquidator
+
+        beforeEach("reset block number", async () => {
+            await runSetup(14179191)
+            unliquidator = await new Unliquidator__factory(governor.signer).deploy(nexusAddress, treasuryAddress)
+        })
+        it("Should fail to set Receiver 0", async () => {
+            expect(unliquidator.connect(governor.signer).setReceiver(ZERO_ADDRESS)).to.be.revertedWith("Invalid receiver address")
+        })
+        it("Should fail to set Receiver from non-Governor address", async () => {
+            expect(unliquidator.connect(ops.signer).setReceiver(ops.address)).to.be.revertedWith("Only governance can execute")
+        })
+        it("Should fail to triggerClaimAndDistribute with address 0", async () => {
+            expect(unliquidator.connect(governor.signer).triggerClaimAndDistribute(ZERO_ADDRESS, stkAAVE.address)).to.be.revertedWith(
+                "Invalid integration address",
+            )
+            expect(
+                unliquidator.connect(governor.signer).triggerClaimAndDistribute(aaveMusdIntegrationAddress, ZERO_ADDRESS),
+            ).to.be.revertedWith("Invalid token address")
+        })
+        it("Should failt to triggerClaimAndDistribute with wrong contract", async () => {
+            // eslint-disable-next-line
+            expect(unliquidator.connect(governor.signer).triggerClaimAndDistribute(DEAD_ADDRESS, stkAAVE.address)).to.be.reverted
+        })
+        it("Should fail to triggerDistribute with address 0", async () => {
+            expect(unliquidator.connect(governor.signer).triggerDistribute(ZERO_ADDRESS, stkAAVE.address)).to.be.revertedWith(
+                "Invalid integration address",
+            )
+            expect(unliquidator.connect(governor.signer).triggerDistribute(aaveMusdIntegrationAddress, ZERO_ADDRESS)).to.be.revertedWith(
+                "Invalid token address",
+            )
+        })
+    })
+})

--- a/test-fork/savings/unliquidator.spec.ts
+++ b/test-fork/savings/unliquidator.spec.ts
@@ -92,6 +92,7 @@ context("Unliquidator forked network tests", async () => {
 
     describe("Unliquidator", async () => {
         let unliquidator: Unliquidator
+        const liquidatorModuleKey = keccak256(toUtf8Bytes("Liquidator"))
 
         before("reset block number", async () => {
             await runSetup(14179191)
@@ -103,14 +104,15 @@ context("Unliquidator forked network tests", async () => {
             expect(await unliquidator.receiverSafe()).to.eq(treasuryAddress)
         })
         it("Should propose Module in Nexus", async () => {
-            expect(await nexus.getModule(keccak256(toUtf8Bytes("Liquidator")))).to.eq(liquidatorAddress)
-            await nexus.proposeModule(keccak256(toUtf8Bytes("Liquidator")), unliquidator.address)
-            expect(await nexus.getModule(keccak256(toUtf8Bytes("Liquidator")))).to.not.eq(unliquidator.address)
+            expect(await nexus.getModule(liquidatorModuleKey)).to.eq(liquidatorAddress)
+            console.log(`Liquidator key ${liquidatorModuleKey}`)
+            await nexus.proposeModule(liquidatorModuleKey, unliquidator.address)
+            expect(await nexus.getModule(liquidatorModuleKey)).to.not.eq(unliquidator.address)
         })
         it("Should accept Module in Nexus", async () => {
             increaseTime(ONE_WEEK.add(ONE_HOUR))
-            await nexus.acceptProposedModule(keccak256(toUtf8Bytes("Liquidator")))
-            expect(await nexus.getModule(keccak256(toUtf8Bytes("Liquidator")))).to.eq(unliquidator.address)
+            await nexus.acceptProposedModule(liquidatorModuleKey)
+            expect(await nexus.getModule(liquidatorModuleKey)).to.eq(unliquidator.address)
         })
         it("Should reapprove permissions to new Unliquidator", async () => {
             // Before no permissions

--- a/test-fork/savings/unliquidator.spec.ts
+++ b/test-fork/savings/unliquidator.spec.ts
@@ -132,9 +132,9 @@ context("Unliquidator forked network tests", async () => {
             console.log(`Treasury balance before ${toEther(treasuryBalBefore)}`)
 
             // Claim
-            expect(await unliquidator.triggerClaimAndDistribute(aaveMusdIntegrationAddress, stkAAVE.address)).to.emit(
+            expect(await unliquidator.claimAndDistributeRewards(aaveMusdIntegrationAddress, stkAAVE.address)).to.emit(
                 unliquidator,
-                "ClaimedAndSendRewards",
+                "DistributedRewards",
             )
 
             console.log(`Treasury balance after ${toEther(await stkAaveToken.balanceOf(treasuryAddress))}`)
@@ -151,9 +151,9 @@ context("Unliquidator forked network tests", async () => {
             console.log(`Treasury balance before ${toEther(treasuryBalBefore)}`)
 
             // Claim
-            expect(await unliquidator.triggerClaimAndDistribute(aaveMbtcIntegrationAddress, stkAAVE.address)).to.emit(
+            expect(await unliquidator.claimAndDistributeRewards(aaveMbtcIntegrationAddress, stkAAVE.address)).to.emit(
                 unliquidator,
-                "ClaimedAndSendRewards",
+                "DistributedRewards",
             )
 
             console.log(`Treasury balance after ${toEther(await stkAaveToken.balanceOf(treasuryAddress))}`)
@@ -175,9 +175,9 @@ context("Unliquidator forked network tests", async () => {
             console.log(`Treasury balance before ${toEther(treasuryBalBefore)}`)
 
             // Claim
-            expect(await unliquidator.triggerDistribute(compoundIntegrationAddress, COMP.address)).to.emit(
+            expect(await unliquidator.distributeRewards(compoundIntegrationAddress, COMP.address)).to.emit(
                 unliquidator,
-                "ClaimedAndSendRewards",
+                "DistributedRewards",
             )
 
             console.log(`Treasury balance after ${toEther(await compToken.balanceOf(treasuryAddress))}`)
@@ -189,7 +189,7 @@ context("Unliquidator forked network tests", async () => {
         it("Should set new Receiver", async () => {
             expect(await unliquidator.receiverSafe()).to.eq(treasuryAddress)
             expect(await unliquidator.connect(governor.signer).setReceiver(governor.address))
-                .to.emit(unliquidator, "NewReceiver")
+                .to.emit(unliquidator, "ReceiverUpdated")
                 .withArgs(governor.address)
             expect(await unliquidator.receiverSafe()).to.eq(governor.address)
         })
@@ -223,22 +223,22 @@ context("Unliquidator forked network tests", async () => {
             expect(unliquidator.connect(ops.signer).setReceiver(ops.address)).to.be.revertedWith("Only governance can execute")
         })
         it("Should fail to triggerClaimAndDistribute with address 0", async () => {
-            expect(unliquidator.connect(governor.signer).triggerClaimAndDistribute(ZERO_ADDRESS, stkAAVE.address)).to.be.revertedWith(
+            expect(unliquidator.connect(governor.signer).claimAndDistributeRewards(ZERO_ADDRESS, stkAAVE.address)).to.be.revertedWith(
                 "Invalid integration address",
             )
             expect(
-                unliquidator.connect(governor.signer).triggerClaimAndDistribute(aaveMusdIntegrationAddress, ZERO_ADDRESS),
+                unliquidator.connect(governor.signer).claimAndDistributeRewards(aaveMusdIntegrationAddress, ZERO_ADDRESS),
             ).to.be.revertedWith("Invalid token address")
         })
         it("Should failt to triggerClaimAndDistribute with wrong contract", async () => {
             // eslint-disable-next-line
-            expect(unliquidator.connect(governor.signer).triggerClaimAndDistribute(DEAD_ADDRESS, stkAAVE.address)).to.be.reverted
+            expect(unliquidator.connect(governor.signer).claimAndDistributeRewards(DEAD_ADDRESS, stkAAVE.address)).to.be.reverted
         })
         it("Should fail to triggerDistribute with address 0", async () => {
-            expect(unliquidator.connect(governor.signer).triggerDistribute(ZERO_ADDRESS, stkAAVE.address)).to.be.revertedWith(
+            expect(unliquidator.connect(governor.signer).distributeRewards(ZERO_ADDRESS, stkAAVE.address)).to.be.revertedWith(
                 "Invalid integration address",
             )
-            expect(unliquidator.connect(governor.signer).triggerDistribute(aaveMusdIntegrationAddress, ZERO_ADDRESS)).to.be.revertedWith(
+            expect(unliquidator.connect(governor.signer).distributeRewards(aaveMusdIntegrationAddress, ZERO_ADDRESS)).to.be.revertedWith(
                 "Invalid token address",
             )
         })


### PR DESCRIPTION
Contract `Unliquidator.sol` for MIP 26. To stop liquidating stkAave and COMP and transfer to a set address (in this case Asset Management SubDao).
Done fork tests in `unliquidator.spec.ts` on Ethereum mainnet.