### PR TITLE
Feature share revenue

### DIFF
--- a/contracts/buy-and-make/RevenueBuyBack.sol
+++ b/contracts/buy-and-make/RevenueBuyBack.sol
@@ -11,17 +11,6 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IUniswapV3SwapRouter } from "../peripheral/Uniswap/IUniswapV3SwapRouter.sol";
 
-struct RevenueBuyBackConfig {
-    // Minimum price of bAssets compared to mAssets scaled to 1e18 (CONFIG_SCALE).
-    uint128 minMasset2BassetPrice;
-    // Minimum price of rewards token compared to bAssets scaled to 1e18 (CONFIG_SCALE).
-    uint128 minBasset2RewardsPrice;
-    // base asset of the mAsset that is being redeemed and then sold for reward tokens.
-    address bAsset;
-    // Uniswap V3 path
-    bytes uniswapPath;
-}
-
 /**
  * @title   RevenueBuyBack
  * @author  mStable
@@ -41,15 +30,10 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
         uint256 rewardsAmount
     );
     event DonatedRewards(uint256 totalRewards);
-    event AddedMassetConfig(
-        address indexed mAsset,
-        address indexed bAsset,
-        uint128 minMasset2BassetPrice,
-        uint128 minBasset2RewardsPrice,
-        bytes uniswapPath
-    );
+    event MappedBasset(address indexed mAsset, address indexed bAsset);
     event AddedStakingContract(uint16 stakingDialId);
     event ProtocolFeeChanged(uint256 protocolFee);
+    event TreasuryChanged(address treasury);
 
     /// @notice scale of the `minMasset2BassetPrice` and `minBasset2RewardsPrice` configuration properties.
     uint256 public constant CONFIG_SCALE = 1e18;
@@ -61,13 +45,16 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
     /// @notice Uniswap V3 Router address
     IUniswapV3SwapRouter public immutable UNISWAP_ROUTER;
 
-    /// @notice Mapping of mAssets to RevenueBuyBack config
-    mapping(address => RevenueBuyBackConfig) public massetConfig;
+    /// @notice Mapping of mAssets to bAssets
+    mapping(address => address) public bassets;
     /// @notice Emissions Controller dial ids for all staking contracts that will receive reward tokens.
     uint256[] public stakingDialIds;
 
     /// @notice ProtocolFee, how much does go back to the Treasury? 100% = 1e18
     uint256 public protocolFee;
+
+    /// @notice address the Treasury fees are transferred to.
+    address public treasury;
 
     /**
      * @param _nexus mStable system Nexus address
@@ -91,20 +78,24 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
         require(_emissionsController != address(0), "Emissions controller is zero");
         EMISSIONS_CONTROLLER = IEmissionsController(_emissionsController);
 
-        require(_protocolFee <= 1e18, "Invalid protocol fee");
+        require(_protocolFee <= CONFIG_SCALE, "Invalid protocol fee");
         protocolFee = _protocolFee;
     }
 
     /**
      * @param _stakingDialIds Emissions Controller dial ids for all staking contracts that will receive reward tokens.
+     * @param _treasury Address the treasury fees are transferred to.
      */
-    function initialize(uint16[] memory _stakingDialIds) external initializer {
+    function initialize(uint16[] memory _stakingDialIds, address _treasury) external initializer {
         for (uint256 i = 0; i < _stakingDialIds.length; i++) {
             _addStakingContract(_stakingDialIds[i]);
         }
 
         // RevenueBuyBack approves the Emissions Controller to transfer rewards. eg MTA
         REWARDS_TOKEN.safeApprove(address(EMISSIONS_CONTROLLER), type(uint256).max);
+
+        require(_treasury != address(0), "Treasury is zero");
+        treasury = _treasury;
     }
 
     /***************************************
@@ -117,7 +108,7 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
      * @param _amount Units of mAsset collected
      */
     function notifyRedistributionAmount(address _mAsset, uint256 _amount) external override {
-        require(massetConfig[_mAsset].bAsset != address(0), "Invalid mAsset");
+        require(bassets[_mAsset] != address(0), "Invalid mAsset");
 
         // Transfer from sender to here
         IERC20(_mAsset).safeTransferFrom(msg.sender, address(this), _amount);
@@ -127,65 +118,104 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
 
     /**
      * @notice Buys reward tokens, eg MTA, using mAssets like mUSD or mBTC from protocol revenue.
-     * @param _mAssets Addresses of mAssets that are to be sold for rewards. eg mUSD and mBTC.
+     * @param mAssets Addresses of mAssets that are to be sold for rewards. eg mUSD and mBTC.
+     * @param minMasset2BassetPrices Minimum prices of bAssets compared to mAssets scaled to 1e18 (CONFIG_SCALE).
+     * eg USDC/mUSD and wBTC/mBTC exchange rates.
+     * USDC has 6 decimal places so `minMasset2BassetPrice` with no slippage is 1e6.
+     * If a 2% slippage is allowed, the `minMasset2BassetPrice` is 98e4.
+     * WBTC has 8 decimal places so `minMasset2BassetPrice` with no slippage is 1e8.
+     * If a 5% slippage is allowed, the `minMasset2BassetPrice` is 95e6.
+     * @param minBasset2RewardsPrices Minimum prices of rewards token compared to bAssets scaled to 1e18 (CONFIG_SCALE).
+     * eg USDC/MTA and wBTC/MTA exchange rates scaled to 1e18.
+     * USDC only has 6 decimal places
+     * 2 MTA/USDC = 0.5 USDC/MTA * (1e18 / 1e6) * 1e18 = 0.5e30 = 5e29
+     * wBTC only has 8 decimal places
+     * 0.000033 MTA/wBTC = 30,000 WBTC/MTA * (1e18 / 1e8) * 1e18 = 3e4 * 1e28 = 3e32
+     * @param uniswapPaths The Uniswap V3 bytes encoded paths.
      */
-    function buyBackRewards(address[] calldata _mAssets) external onlyKeeperOrGovernor {
-        uint256 len = _mAssets.length;
-        require(len > 0, "Invalid args");
-
-        address treasury = nexus.getModule(keccak256("Treasury"));
+    function buyBackRewards(
+        address[] calldata mAssets,
+        uint256[] memory minMasset2BassetPrices,
+        uint256[] memory minBasset2RewardsPrices,
+        bytes[] calldata uniswapPaths
+    ) external onlyKeeperOrGovernor {
+        uint256 len = mAssets.length;
+        require(len > 0, "Invalid mAssets");
+        require(minMasset2BassetPrices.length == len, "Invalid minMasset2BassetPrices");
+        require(minBasset2RewardsPrices.length == len, "Invalid minBasset2RewardsPrices");
+        require(uniswapPaths.length == len, "Invalid uniswapPaths");
 
         // for each mAsset
         for (uint256 i = 0; i < len; i++) {
-            // Get config for mAsset
-            RevenueBuyBackConfig memory config = massetConfig[_mAssets[i]];
-            require(config.bAsset != address(0), "Invalid mAsset");
+            // Get bAsset for mAsset
+            address bAsset = bassets[mAssets[i]];
+            require(bAsset != address(0), "Invalid mAsset");
+            // Validate Uniswap path
+            require(
+                _validUniswapPath(bAsset, address(REWARDS_TOKEN), uniswapPaths[i]),
+                "Invalid uniswap path"
+            );
 
             // Get mAsset revenue
-            uint256 mAssetBal = IERC20(_mAssets[i]).balanceOf(address(this));
+            uint256 mAssetBal = IERC20(mAssets[i]).balanceOf(address(this));
             uint256 mAssetToTreasury = 0;
 
             if (protocolFee > 0) {
                 // STEP 1: Send mAsset to treasury
                 mAssetToTreasury =
-                    (IERC20(_mAssets[i]).balanceOf(address(this)) * protocolFee) /
-                    1e18;
-                IERC20(_mAssets[i]).safeTransfer(treasury, mAssetToTreasury);
+                    (IERC20(mAssets[i]).balanceOf(address(this)) * protocolFee) /
+                    CONFIG_SCALE;
+                IERC20(mAssets[i]).safeTransfer(treasury, mAssetToTreasury);
             }
-            // STEP 2 - Redeem mAssets for bAssets
-            IMasset mAsset = IMasset(_mAssets[i]);
-            uint256 mAssetBalAfterFee = IERC20(_mAssets[i]).balanceOf(address(this));
-            uint256 minBassetOutput = (mAssetBalAfterFee * config.minMasset2BassetPrice) /
-                CONFIG_SCALE;
-            uint256 bAssetAmount = mAsset.redeem(
-                config.bAsset,
-                mAssetBalAfterFee,
-                minBassetOutput,
-                address(this)
-            );
 
+            // STEP 2 - Redeem mAssets for bAssets
             // STEP 3 - Swap bAssets for rewards using Uniswap V3
-            IERC20(config.bAsset).safeApprove(address(UNISWAP_ROUTER), bAssetAmount);
-            uint256 minRewardsAmount = (bAssetAmount * config.minBasset2RewardsPrice) /
-                CONFIG_SCALE;
-            IUniswapV3SwapRouter.ExactInputParams memory param = IUniswapV3SwapRouter
-            .ExactInputParams(
-                config.uniswapPath,
-                address(this),
-                block.timestamp,
-                bAssetAmount,
-                minRewardsAmount
+            (uint256 bAssetAmount, uint256 rewardsAmount) = _redeemAndSwap(
+                mAssets[i],
+                bAsset,
+                minMasset2BassetPrices[i],
+                minBasset2RewardsPrices[i],
+                uniswapPaths[i]
             );
-            uint256 rewardsAmount = UNISWAP_ROUTER.exactInput(param);
 
             emit BuyBackRewards(
-                _mAssets[i],
+                mAssets[i],
                 mAssetBal,
                 mAssetToTreasury,
                 bAssetAmount,
                 rewardsAmount
             );
         }
+    }
+
+    function _redeemAndSwap(
+        address mAsset,
+        address bAsset,
+        uint256 minMasset2BassetPrice,
+        uint256 minBasset2RewardsPrice,
+        bytes memory uniswapPath
+    ) internal returns (uint256 bAssetAmount, uint256 rewardsAmount) {
+        // STEP 2 - Redeem mAssets for bAssets
+        uint256 mAssetBalAfterFee = IERC20(mAsset).balanceOf(address(this));
+        uint256 minBassetOutput = (mAssetBalAfterFee * minMasset2BassetPrice) / CONFIG_SCALE;
+        bAssetAmount = IMasset(mAsset).redeem(
+            bAsset,
+            mAssetBalAfterFee,
+            minBassetOutput,
+            address(this)
+        );
+
+        // STEP 3 - Swap bAssets for rewards using Uniswap V3
+        IERC20(bAsset).safeApprove(address(UNISWAP_ROUTER), bAssetAmount);
+        uint256 minRewardsAmount = (bAssetAmount * minBasset2RewardsPrice) / CONFIG_SCALE;
+        IUniswapV3SwapRouter.ExactInputParams memory param = IUniswapV3SwapRouter.ExactInputParams(
+            uniswapPath,
+            address(this),
+            block.timestamp,
+            bAssetAmount,
+            minRewardsAmount
+        );
+        rewardsAmount = UNISWAP_ROUTER.exactInput(param);
     }
 
     /**
@@ -231,65 +261,38 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
     ****************************************/
 
     /**
-     * @notice Adds or updates rewards buyback config for a mAsset.
+     * @notice Maps a mAsset to bAsset.
      * @param _mAsset Address of the meta asset that is received as protocol revenue.
      * @param _bAsset Address of the base asset that is redeemed from the mAsset.
-     * @param _minMasset2BassetPrice Minimum price of bAssets compared to mAssets scaled to 1e18 (CONFIG_SCALE).
-     * eg USDC/mUSD and wBTC/mBTC exchange rates.
-     * USDC has 6 decimal places so `minMasset2BassetPrice` with no slippage is 1e6.
-     * If a 2% slippage is allowed, the `minMasset2BassetPrice` is 98e4.
-     * WBTC has 8 decimal places so `minMasset2BassetPrice` with no slippage is 1e8.
-     * If a 5% slippage is allowed, the `minMasset2BassetPrice` is 95e6.
-     * @param _minBasset2RewardsPrice Minimum price of rewards token compared to bAssets scaled to 1e18 (CONFIG_SCALE).
-     * eg USDC/MTA and wBTC/MTA exchange rates scaled to 1e18.
-     * USDC only has 6 decimal places
-     * 2 MTA/USDC = 0.5 USDC/MTA * (1e18 / 1e6) * 1e18 = 0.5e30 = 5e29
-     * wBTC only has 8 decimal places
-     * 0.000033 MTA/wBTC = 30,000 WBTC/MTA * (1e18 / 1e8) * 1e18 = 3e4 * 1e28 = 3e32
-     * @param _uniswapPath The Uniswap V3 bytes encoded path.
      */
-    function setMassetConfig(
-        address _mAsset,
-        address _bAsset,
-        uint128 _minMasset2BassetPrice,
-        uint128 _minBasset2RewardsPrice,
-        bytes calldata _uniswapPath
-    ) external onlyGovernor {
+    function mapBasset(address _mAsset, address _bAsset) external onlyGovernor {
         require(_mAsset != address(0), "mAsset token is zero");
         require(_bAsset != address(0), "bAsset token is zero");
-        // bAsset slippage must be plus or minus 10%
-        require(_minMasset2BassetPrice > 0, "Invalid min bAsset price");
-        require(_minBasset2RewardsPrice > 0, "Invalid min reward price");
-        require(
-            _validUniswapPath(_bAsset, address(REWARDS_TOKEN), _uniswapPath),
-            "Invalid uniswap path"
-        );
 
-        massetConfig[_mAsset] = RevenueBuyBackConfig({
-            bAsset: _bAsset,
-            minMasset2BassetPrice: _minMasset2BassetPrice,
-            minBasset2RewardsPrice: _minBasset2RewardsPrice,
-            uniswapPath: _uniswapPath
-        });
+        bassets[_mAsset] = _bAsset;
 
-        emit AddedMassetConfig(
-            _mAsset,
-            _bAsset,
-            _minMasset2BassetPrice,
-            _minBasset2RewardsPrice,
-            _uniswapPath
-        );
+        emit MappedBasset(_mAsset, _bAsset);
     }
 
     /**
      * @notice Sets the protocol fee. Protocol fees are paid to the Treasury
      * @param _protocolFee The protocol fee in 100% = 1e18.
      */
-
     function setProtocolFee(uint128 _protocolFee) external onlyGovernor {
-        require(_protocolFee <= 1e18, "Invalid protocol fee");
+        require(_protocolFee <= CONFIG_SCALE, "Invalid protocol fee");
         protocolFee = _protocolFee;
         emit ProtocolFeeChanged(protocolFee);
+    }
+
+    /**
+     * @notice Sets the address the treasury fees are transerred to.
+     * @param _treasury Address the treasury fees are transferred to.
+     */
+    function setTreasury(address _treasury) external onlyGovernor {
+        require(_treasury != address(0), "Treasury is zero");
+        treasury = _treasury;
+
+        emit TreasuryChanged(_treasury);
     }
 
     /**

--- a/contracts/buy-and-make/RevenueBuyBack.sol
+++ b/contracts/buy-and-make/RevenueBuyBack.sol
@@ -143,11 +143,13 @@ contract RevenueBuyBack is IRevenueRecipient, Initializable, ImmutableModule {
 
             // Get mAsset revenue
             uint256 mAssetBal = IERC20(_mAssets[i]).balanceOf(address(this));
+            uint256 mAssetToTreasury = 0;
 
             if (protocolFee > 0) {
                 // STEP 1: Send mAsset to treasury
-                uint256 mAssetToTreasury = (IERC20(_mAssets[i]).balanceOf(address(this)) *
-                    protocolFee) / 1e18;
+                mAssetToTreasury =
+                    (IERC20(_mAssets[i]).balanceOf(address(this)) * protocolFee) /
+                    1e18;
                 IERC20(_mAssets[i]).safeTransfer(treasury, mAssetToTreasury);
             }
             // STEP 2 - Redeem mAssets for bAssets

--- a/contracts/buy-and-make/RevenueSplitBuyBack.sol
+++ b/contracts/buy-and-make/RevenueSplitBuyBack.sol
@@ -83,7 +83,11 @@ contract RevenueSplitBuyBack is IRevenueRecipient, Initializable, ImmutableModul
      * @param _treasury Address the treasury fees are transferred to.
      * @param _protocolFee percentage of governence fee to be sent to treasury where 100% = 1e18.
      */
-    function initialize(uint16[] memory _stakingDialIds, address _treasury, uint256 _protocolFee) external initializer {
+    function initialize(
+        uint16[] memory _stakingDialIds,
+        address _treasury,
+        uint256 _protocolFee
+    ) external initializer {
         for (uint256 i = 0; i < _stakingDialIds.length; i++) {
             _addStakingContract(_stakingDialIds[i]);
         }
@@ -169,7 +173,7 @@ contract RevenueSplitBuyBack is IRevenueRecipient, Initializable, ImmutableModul
 
             if (protocolFee > 0) {
                 // STEP 1: Send mAsset to treasury
-                mAssetToTreasury = mAssetBal * protocolFee / CONFIG_SCALE;
+                mAssetToTreasury = (mAssetBal * protocolFee) / CONFIG_SCALE;
                 IERC20(mAssets[i]).safeTransfer(treasury, mAssetToTreasury);
             }
             uint256 mAssetsSellAmount = mAssetBal - mAssetToTreasury;
@@ -184,7 +188,8 @@ contract RevenueSplitBuyBack is IRevenueRecipient, Initializable, ImmutableModul
 
             // STEP 3 - Swap bAssets for rewards using Uniswap V3
             IERC20(bAsset).safeApprove(address(UNISWAP_ROUTER), bAssetAmount);
-            IUniswapV3SwapRouter.ExactInputParams memory param = IUniswapV3SwapRouter.ExactInputParams(
+            IUniswapV3SwapRouter.ExactInputParams memory param = IUniswapV3SwapRouter
+            .ExactInputParams(
                 uniswapPaths[i],
                 address(this),
                 block.timestamp,
@@ -269,7 +274,7 @@ contract RevenueSplitBuyBack is IRevenueRecipient, Initializable, ImmutableModul
 
     function _setProtocolFee(uint256 _protocolFee) internal {
         require(1e15 <= _protocolFee && _protocolFee <= CONFIG_SCALE, "Invalid protocol fee");
-        
+
         protocolFee = _protocolFee;
 
         emit ProtocolFeeChanged(protocolFee);

--- a/contracts/z_mocks/nexus/MockNexus.sol
+++ b/contracts/z_mocks/nexus/MockNexus.sol
@@ -24,6 +24,10 @@ contract MockNexus is ModuleKeys {
         return _initialized;
     }
 
+    function setModule(bytes32 _key, address _module) external {
+        modules[_key] = _module;
+    }
+
     function getModule(bytes32 _key) external view returns (address) {
         return modules[_key];
     }

--- a/tasks/deployEmissionsController.ts
+++ b/tasks/deployEmissionsController.ts
@@ -99,12 +99,12 @@ task("deploy-split-revenue-buy-back")
     .setAction(async (taskArgs, hre) => {
         const signer = await getSigner(hre, taskArgs.speed)
 
-        const treasuryFee = simpleToExactAmount(taskArgs.fee, 1e16)
+        const treasuryFee = simpleToExactAmount(taskArgs.fee, 16)
 
         const revenueRecipient = await deploySplitRevenueBuyBack(signer, hre, treasuryFee)
 
+        console.log(`Governor call RevenueSplitBuyBack.mapBasset for mUSD and mBTC`)
         console.log(`Governor call SavingsManager.setRevenueRecipient to ${revenueRecipient.address} for mUSD and mBTC`)
-        console.log(`Governor call mapBasset for mUSD and mBTC`)
     })
 
 task("deploy-mock-root-chain-manager", "Deploys a mocked Polygon PoS Bridge")

--- a/tasks/utils/networkAddressFactory.ts
+++ b/tasks/utils/networkAddressFactory.ts
@@ -28,6 +28,7 @@ export const contractNames = [
     "SaveWrapper",
     "RevenueRecipient",
     "RevenueBuyBack",
+    "RevenueSplitBuyBack",
     "MassetManager",
     "FeederManager",
     "FeederLogic",
@@ -128,6 +129,8 @@ export const getChainAddress = (contractName: ContractNames, chain: Chain): stri
                 return "0xA7824292efDee1177a1C1BED0649cfdD6114fed5"
             case "RevenueBuyBack":
                 return "0xE301087C087cB9b86068352F0F75073C4c6aA74F"
+            case "RevenueSplitBuyBack":
+                return "0x0E423505A4EB417a75b21f7A35E84ae378e665b9"
             case "MassetManager":
                 return "0x1E91F826fa8aA4fa4D3F595898AF3A64dd188848"
             case "FeederManager":

--- a/test-fork/buy-and-make/revenue-split.spec.ts
+++ b/test-fork/buy-and-make/revenue-split.spec.ts
@@ -1,0 +1,152 @@
+import { network } from "hardhat"
+import * as hre from "hardhat"
+
+import { impersonate, impersonateAccount } from "@utils/fork"
+import { Signer } from "ethers"
+import { resolveAddress } from "tasks/utils/networkAddressFactory"
+import { deploySplitRevenueBuyBack } from "tasks/utils/emissions-utils"
+import { expect } from "chai"
+import { simpleToExactAmount } from "@utils/math"
+import { DAI, mBTC, MTA, mUSD, USDC, WBTC } from "tasks/utils/tokens"
+import {
+    EmissionsController,
+    EmissionsController__factory,
+    IERC20,
+    IERC20__factory,
+    RevenueSplitBuyBack,
+    SavingsManager,
+    SavingsManager__factory,
+} from "types/generated"
+import { Account } from "types/common"
+import { encodeUniswapPath } from "@utils/peripheral/uniswap"
+import { keccak256 } from "@ethersproject/keccak256"
+import { toUtf8Bytes } from "ethers/lib/utils"
+
+const keeperKey = keccak256(toUtf8Bytes("Keeper"))
+console.log(`Keeper ${keeperKey}`)
+
+const mtaUsdPrice = 42
+const btcUsdPrice = 42300
+
+const uniswapEthToken = resolveAddress("UniswapEthToken")
+const musdUniswapPath = encodeUniswapPath([USDC.address, uniswapEthToken, MTA.address], [3000, 3000])
+// const mbtcUniswapPath = encodeUniswapPath([WBTC.address, uniswapEthToken, MTA.address], [3000, 3000])
+const mbtcUniswapPath = encodeUniswapPath([WBTC.address, uniswapEthToken, DAI.address, MTA.address], [3000, 3000, 3000])
+
+describe("Fork test deploy of RevenueSplitBuyBack", async () => {
+    let ops: Signer
+    let governor: Signer
+    let treasury: Account
+    let emissionsController: EmissionsController
+    let savingsManager: SavingsManager
+    let mta: IERC20
+    let revenueBuyBack: RevenueSplitBuyBack
+
+    const setup = async (blockNumber?: number) => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: process.env.NODE_URL,
+                        blockNumber,
+                    },
+                },
+            ],
+        })
+        ops = await impersonate(resolveAddress("OperationsSigner"))
+        governor = await impersonate(resolveAddress("Governor"))
+        treasury = await impersonateAccount("0x3dd46846eed8d147841ae162c8425c08bd8e1b41")
+
+        mta = IERC20__factory.connect(MTA.address, treasury.signer)
+
+        const emissionsControllerAddress = resolveAddress("EmissionsController")
+        emissionsController = EmissionsController__factory.connect(emissionsControllerAddress, ops)
+        savingsManager = SavingsManager__factory.connect(resolveAddress("SavingsManager"), governor)
+
+        // revenueBuyBack = RevenueSplitBuyBack__factory.connect(resolveAddress("RevenueBuyBack"), ops)
+    }
+
+    describe("Next revenue buy back", () => {
+        let musdToken: IERC20
+        let mbtcToken: IERC20
+
+        before(async () => {
+            // 23 March before fees were collected
+            await setup(14439160)
+
+            mbtcToken = IERC20__factory.connect(mBTC.address, ops)
+            musdToken = IERC20__factory.connect(mUSD.address, ops)
+        })
+        it("Deploy RevenueSplitBuyBack", async () => {
+            revenueBuyBack = await deploySplitRevenueBuyBack(ops, hre, simpleToExactAmount(5, 17))
+        })
+        it("Configure RevenueSplitBuyBack", async () => {
+            await revenueBuyBack.connect(governor).mapBasset(mUSD.address, USDC.address)
+            await revenueBuyBack.connect(governor).mapBasset(mBTC.address, WBTC.address)
+        })
+        it("Config SavingsManager", async () => {
+            await savingsManager.setRevenueRecipient(mUSD.address, revenueBuyBack.address)
+            await savingsManager.setRevenueRecipient(mBTC.address, revenueBuyBack.address)
+        })
+        context("buy back MTA using mUSD and mBTC", () => {
+            before(async () => {})
+            it("Distribute unallocated mUSD in Savings Manager", async () => {
+                expect(await musdToken.balanceOf(revenueBuyBack.address), "mUSD bal before").to.eq(0)
+
+                await savingsManager.distributeUnallocatedInterest(mUSD.address)
+
+                expect(await musdToken.balanceOf(revenueBuyBack.address), "mUSD bal after").to.gt(0)
+            })
+            it("Distribute unallocated mBTC in Savings Manager", async () => {
+                expect(await mbtcToken.balanceOf(revenueBuyBack.address), "mBTC bal before").to.eq(0)
+
+                await savingsManager.distributeUnallocatedInterest(mBTC.address)
+
+                expect(await mbtcToken.balanceOf(revenueBuyBack.address), "mBTC bal after").to.gt(0)
+            })
+            it("Buy back MTA using mUSD", async () => {
+                const musdRbbBalBefore = await musdToken.balanceOf(revenueBuyBack.address)
+                expect(musdRbbBalBefore, "mUSD bal before").to.gt(0)
+                expect(await mta.balanceOf(revenueBuyBack.address), "RBB MTA bal before").to.eq(0)
+
+                // 1% slippage on redeem, 50% to treasury and convert from 18 to 6 decimals
+                const minBassets = musdRbbBalBefore.mul(99).div(100).div(2).div(1e12)
+                console.log(`minBassets ${minBassets} = ${musdRbbBalBefore} * 98% / 1e12`)
+                // MTA = USD * MTA/USD price * 10^(18-6) to convert from 6 to 18 decimals
+                const minMta = minBassets.mul(mtaUsdPrice).div(100).mul(1e12)
+                await revenueBuyBack.buyBackRewards([mUSD.address], [minBassets], [minMta], [musdUniswapPath.encoded])
+
+                expect(await musdToken.balanceOf(revenueBuyBack.address), "mUSD bal after").to.eq(0)
+                expect(await mta.balanceOf(revenueBuyBack.address), "RBB MTA bal after").to.gt(1)
+            })
+            it("Buy back MTA using mBTC", async () => {
+                const mbtcRbbBalBefore = await mbtcToken.balanceOf(revenueBuyBack.address)
+                const mtaRbbBalBefore = await mta.balanceOf(revenueBuyBack.address)
+
+                // 1% slippage on redeem, 50% to treasury and convert from 18 to 8 decimals
+                const minBassets = mbtcRbbBalBefore.mul(99).div(100).div(2).div(1e10)
+                console.log(`minBassets ${minBassets} = ${mbtcRbbBalBefore} * 98% / 1e10`)
+                // MTA = BTC * BTC/USD price * MTA/USD price * 10^(18-8) to convert from 8 to 18 decimals
+                const minMta = minBassets.mul(btcUsdPrice).mul(mtaUsdPrice).div(100).mul(1e10)
+                await revenueBuyBack.buyBackRewards([mBTC.address], [minBassets], [minMta], [mbtcUniswapPath.encoded])
+
+                expect(await mbtcToken.balanceOf(revenueBuyBack.address), "mBTC bal after").to.eq(0)
+
+                expect(await mta.balanceOf(revenueBuyBack.address), "RBB MTA bal after").to.gt(mtaRbbBalBefore)
+            })
+            it("Donate MTA to Emissions Controller staking dials", async () => {
+                const mtaEcBalBefore = await mta.balanceOf(emissionsController.address)
+                const mtaRbbBalBefore = await mta.balanceOf(revenueBuyBack.address)
+                expect(mtaRbbBalBefore, "RBB MTA bal before").to.gt(0)
+
+                await revenueBuyBack.donateRewards()
+
+                expect(await mta.balanceOf(revenueBuyBack.address), "RBB MTA bal after").to.lte(1)
+                expect(await mta.balanceOf(emissionsController.address), "EC MTA bal after").to.eq(
+                    mtaEcBalBefore.add(mtaRbbBalBefore).sub(1),
+                )
+            })
+        })
+    })
+})

--- a/test-fork/buy-and-make/revenue-split.spec.ts
+++ b/test-fork/buy-and-make/revenue-split.spec.ts
@@ -19,11 +19,6 @@ import {
 } from "types/generated"
 import { Account } from "types/common"
 import { encodeUniswapPath } from "@utils/peripheral/uniswap"
-import { keccak256 } from "@ethersproject/keccak256"
-import { toUtf8Bytes } from "ethers/lib/utils"
-
-const keeperKey = keccak256(toUtf8Bytes("Keeper"))
-console.log(`Keeper ${keeperKey}`)
 
 const mtaUsdPrice = 42
 const btcUsdPrice = 42300

--- a/test/buy-and-make/revenue-buy-back.spec.ts
+++ b/test/buy-and-make/revenue-buy-back.spec.ts
@@ -261,7 +261,7 @@ describe("RevenueBuyBack", () => {
             })
             it("approval is not given from sender", async () => {
                 await expect(revenueBuyBack.notifyRedistributionAmount(mUSD.address, simpleToExactAmount(100, 18))).to.be.revertedWith(
-                    "ERC20: insufficient allowance",
+                    "ERC20: transfer amount exceeds allowance",
                 )
             })
             it("sender has insufficient balance", async () => {

--- a/test/buy-and-make/revenue-split-buy-back.spec.ts
+++ b/test/buy-and-make/revenue-split-buy-back.spec.ts
@@ -127,8 +127,6 @@ describe("RevenueSplitBuyBack", () => {
         const accounts = await ethers.getSigners()
         mAssetMachine = await new MassetMachine().initAccounts(accounts)
         sa = mAssetMachine.sa
-
-        await setupRevenueBuyBack(treasuryFee)
     })
 
     describe("creating new instance", () => {

--- a/test/buy-and-make/revenue-split-buy-back.spec.ts
+++ b/test/buy-and-make/revenue-split-buy-back.spec.ts
@@ -1,0 +1,610 @@
+import { ethers } from "hardhat"
+import { expect } from "chai"
+
+import { simpleToExactAmount } from "@utils/math"
+import { MassetMachine, StandardAccounts } from "@utils/machines"
+
+import {
+    MockERC20,
+    MockNexus__factory,
+    MockNexus,
+    RevenueSplitBuyBack__factory,
+    RevenueSplitBuyBack,
+    MockUniswapV3,
+    MockUniswapV3__factory,
+    EmissionsController,
+    MockStakingContract,
+    MockStakingContract__factory,
+    MockMasset__factory,
+    MockMasset,
+    EmissionsController__factory,
+} from "types/generated"
+import { EncodedPaths, encodeUniswapPath } from "@utils/peripheral/uniswap"
+import { DEAD_ADDRESS, ZERO_ADDRESS } from "@utils/constants"
+import { BigNumber, Signer, Wallet } from "ethers"
+
+describe("RevenueSplitBuyBack", () => {
+    let sa: StandardAccounts
+    let mAssetMachine: MassetMachine
+    let nexus: MockNexus
+    let revenueBuyBack: RevenueSplitBuyBack
+    let mUSD: MockMasset
+    let mBTC: MockMasset
+    let bAsset1: MockERC20
+    let bAsset2: MockERC20
+    let rewardsToken: MockERC20
+    let staking1: MockStakingContract
+    let staking2: MockStakingContract
+    let emissionController: EmissionsController
+    let uniswap: MockUniswapV3
+    let uniswapMusdBasset1Paths: EncodedPaths
+    let uniswapMbtcBasset2Paths: EncodedPaths
+
+    const protocolFee = simpleToExactAmount(0.4)
+    const treasury: Signer = ethers.Wallet.createRandom()
+
+    /*
+        Test Data
+        mAssets: mUSD and mBTC with 18 decimals
+     */
+    const setupRevenueBuyBack = async (_protocolFee: BigNumber): Promise<void> => {
+        mUSD = await new MockMasset__factory(sa.default.signer).deploy(
+            "meta USD",
+            "mUSD",
+            18,
+            sa.default.address,
+            simpleToExactAmount(1000000),
+        )
+        bAsset1 = await mAssetMachine.loadBassetProxy("USD bAsset", "bUSD", 18)
+
+        mBTC = await new MockMasset__factory(sa.default.signer).deploy("meta BTC", "mBTC", 18, sa.default.address, simpleToExactAmount(100))
+        bAsset2 = await mAssetMachine.loadBassetProxy("USD bAsset", "bUSD", 6)
+
+        rewardsToken = await mAssetMachine.loadBassetProxy("Rewards Token", "RWD", 18)
+
+        // staking contracts
+        staking1 = await new MockStakingContract__factory(sa.default.signer).deploy()
+        staking2 = await new MockStakingContract__factory(sa.default.signer).deploy()
+        await staking1.setTotalSupply(simpleToExactAmount(3000000))
+        await staking2.setTotalSupply(simpleToExactAmount(1000000))
+
+        // Deploy mock Nexus
+        nexus = await new MockNexus__factory(sa.default.signer).deploy(
+            sa.governor.address,
+            sa.mockSavingsManager.address,
+            sa.mockInterestValidator.address,
+        )
+        await nexus.setKeeper(sa.keeper.address)
+
+        // Mocked Uniswap V3
+        uniswap = await new MockUniswapV3__factory(sa.default.signer).deploy()
+        // Add rewards to Uniswap
+        await rewardsToken.transfer(uniswap.address, simpleToExactAmount(500000))
+        // Add bAsset to rewards exchange rates
+        await uniswap.setRate(bAsset1.address, rewardsToken.address, simpleToExactAmount(80, 16)) // 0.8 MTA/USD
+        await uniswap.setRate(bAsset2.address, rewardsToken.address, simpleToExactAmount(50, 33)) // 50,000 MTA/BTC
+        // Uniswap paths
+        uniswapMusdBasset1Paths = encodeUniswapPath([bAsset1.address, DEAD_ADDRESS, rewardsToken.address], [3000, 3000])
+        uniswapMbtcBasset2Paths = encodeUniswapPath([bAsset2.address, DEAD_ADDRESS, rewardsToken.address], [3000, 3000])
+
+        // Deploy Emissions Controller
+        const defaultConfig = {
+            A: -166000,
+            B: 180000,
+            C: -180000,
+            D: 166000,
+            EPOCHS: 312,
+        }
+        emissionController = await new EmissionsController__factory(sa.default.signer).deploy(
+            nexus.address,
+            rewardsToken.address,
+            defaultConfig,
+        )
+        await emissionController.initialize(
+            [staking1.address, staking2.address],
+            [10, 10],
+            [true, true],
+            [staking1.address, staking2.address],
+        )
+        await rewardsToken.transfer(emissionController.address, simpleToExactAmount(10000))
+
+        // Deploy and initialize test RevenueSplitBuyBack
+        revenueBuyBack = await new RevenueSplitBuyBack__factory(sa.default.signer).deploy(
+            nexus.address,
+            rewardsToken.address,
+            uniswap.address,
+            emissionController.address,
+        )
+        // reverse the order to make sure dial id != staking contract id for testing purposes
+        await revenueBuyBack.initialize([1, 0], await treasury.getAddress(), _protocolFee)
+
+        // Add config to buy rewards from mAssets
+        await revenueBuyBack.connect(sa.governor.signer).mapBasset(mUSD.address, bAsset1.address)
+        await revenueBuyBack.connect(sa.governor.signer).mapBasset(mBTC.address, bAsset2.address)
+    }
+
+    before(async () => {
+        const accounts = await ethers.getSigners()
+        mAssetMachine = await new MassetMachine().initAccounts(accounts)
+        sa = mAssetMachine.sa
+
+        await setupRevenueBuyBack(protocolFee)
+    })
+
+    describe("creating new instance", () => {
+        before(async () => {
+            await setupRevenueBuyBack(protocolFee)
+        })
+        it("should have immutable variables set", async () => {
+            expect(await revenueBuyBack.nexus(), "Nexus").eq(nexus.address)
+            expect(await revenueBuyBack.REWARDS_TOKEN(), "Rewards Token").eq(rewardsToken.address)
+            expect(await revenueBuyBack.UNISWAP_ROUTER(), "Uniswap Router").eq(uniswap.address)
+            expect(await revenueBuyBack.EMISSIONS_CONTROLLER(), "Emissions Controller").eq(emissionController.address)
+        })
+        it("should have storage variables set", async () => {
+            expect(await revenueBuyBack.protocolFee(), "Protocol Fee").eq(protocolFee)
+            expect(await revenueBuyBack.stakingDialIds(0), "Staking Contract 1 dial id").eq(1)
+            expect(await revenueBuyBack.stakingDialIds(1), "Staking Contract 2 dial id").eq(0)
+            expect((await emissionController.dials(0)).recipient, "first dial is first staking contract").to.eq(staking1.address)
+            expect((await emissionController.dials(1)).recipient, "second dial is second staking contract").to.eq(staking2.address)
+
+            expect(await revenueBuyBack.protocolFee(), "Protocol Fee").eq(protocolFee)
+        })
+        describe("when setting new protocol fee", async () => {
+            it("should update protocol fee", async () => {
+                expect(await revenueBuyBack.protocolFee(), "Protocol Fee").eq(protocolFee)
+                const newProtocolFee = simpleToExactAmount(0.6)
+                const tx = revenueBuyBack.connect(sa.governor.signer).setProtocolFee(newProtocolFee)
+                await expect(tx).to.emit(revenueBuyBack, "ProtocolFeeChanged").withArgs(newProtocolFee)
+                expect(await revenueBuyBack.protocolFee(), "Protocol Fee").eq(newProtocolFee)
+            })
+            it("should not update if not governor", async () => {
+                const newProtocolFee = simpleToExactAmount(0.6)
+                const tx = revenueBuyBack.connect(sa.default.signer).setProtocolFee(newProtocolFee)
+                await expect(tx).to.be.revertedWith("Only governor can execute")
+            })
+            it("should not update if invalid amount", async () => {
+                const newProtocolFee = simpleToExactAmount(1.6)
+                const tx = revenueBuyBack.connect(sa.governor.signer).setProtocolFee(newProtocolFee)
+                await expect(tx).to.be.revertedWith("Invalid protocol fee")
+            })
+        })
+        describe("should fail deploy if invalid", () => {
+            it("nexus", async () => {
+                const tx = new RevenueSplitBuyBack__factory(sa.default.signer).deploy(
+                    ZERO_ADDRESS,
+                    rewardsToken.address,
+                    uniswap.address,
+                    emissionController.address,
+                )
+                await expect(tx).to.revertedWith("Nexus address is zero")
+            })
+            it("rewards token", async () => {
+                const tx = new RevenueSplitBuyBack__factory(sa.default.signer).deploy(
+                    nexus.address,
+                    ZERO_ADDRESS,
+                    uniswap.address,
+                    emissionController.address,
+                )
+                await expect(tx).to.revertedWith("Rewards token is zero")
+            })
+            it("Uniswap router", async () => {
+                const tx = new RevenueSplitBuyBack__factory(sa.default.signer).deploy(
+                    nexus.address,
+                    rewardsToken.address,
+                    ZERO_ADDRESS,
+                    emissionController.address,
+                )
+                await expect(tx).to.revertedWith("Uniswap Router is zero")
+            })
+        })
+        describe("should fail initialize if", () => {
+            before(async () => {
+                revenueBuyBack = await new RevenueSplitBuyBack__factory(sa.default.signer).deploy(
+                    nexus.address,
+                    rewardsToken.address,
+                    uniswap.address,
+                    emissionController.address,
+                )
+            })
+            it("zero treasury address", async () => {
+                const tx = revenueBuyBack.initialize([1, 0], ZERO_ADDRESS, protocolFee)
+                await expect(tx).to.revertedWith("Treasury is zero")
+            })
+            it("protocol fee too small", async () => {
+                const tx = revenueBuyBack.initialize([1, 0], await treasury.getAddress(), simpleToExactAmount(1, 14))
+                await expect(tx).to.revertedWith("Invalid protocol fee")
+            })
+            it("protocol fee too big", async () => {
+                const tx = revenueBuyBack.initialize([1, 0], await treasury.getAddress(), simpleToExactAmount(11, 17))
+                await expect(tx).to.revertedWith("Invalid protocol fee")
+            })
+            it("initialize called again", async () => {
+                await revenueBuyBack.initialize([1, 0], await treasury.getAddress(), protocolFee)
+                const tx = revenueBuyBack.initialize([1, 0], await treasury.getAddress(), protocolFee)
+                await expect(tx).to.revertedWith("Initializable: contract is already initialized")
+            })
+        })
+    })
+    describe("notification of revenue", () => {
+        before(async () => {
+            await setupRevenueBuyBack(protocolFee)
+        })
+        it("should simply transfer from the sender", async () => {
+            const senderBalBefore = await mUSD.balanceOf(sa.default.address)
+            const revenueBuyBackBalBefore = await mUSD.balanceOf(revenueBuyBack.address)
+            const notificationAmount = simpleToExactAmount(100, 18)
+            expect(senderBalBefore.gte(notificationAmount), "sender rewards bal before").to.eq(true)
+
+            // approve
+            await mUSD.approve(revenueBuyBack.address, notificationAmount)
+            // call
+            const tx = revenueBuyBack.notifyRedistributionAmount(mUSD.address, notificationAmount)
+            await expect(tx).to.emit(revenueBuyBack, "RevenueReceived").withArgs(mUSD.address, notificationAmount)
+
+            // check output balances: mAsset sender/recipient
+            expect(await mUSD.balanceOf(sa.default.address), "mUSD sender bal after").eq(senderBalBefore.sub(notificationAmount))
+            expect(await mUSD.balanceOf(revenueBuyBack.address), "mUSD RevenueBuyBack bal after").eq(
+                revenueBuyBackBalBefore.add(notificationAmount),
+            )
+        })
+        describe("it should fail if", () => {
+            it("not configured mAsset", async () => {
+                await expect(revenueBuyBack.notifyRedistributionAmount(sa.dummy1.address, simpleToExactAmount(1, 18))).to.be.revertedWith(
+                    "Invalid mAsset",
+                )
+            })
+            it("approval is not given from sender", async () => {
+                await expect(revenueBuyBack.notifyRedistributionAmount(mUSD.address, simpleToExactAmount(100, 18))).to.be.revertedWith(
+                    "ERC20: transfer amount exceeds allowance",
+                )
+            })
+            it("sender has insufficient balance", async () => {
+                await mUSD.transfer(sa.dummy1.address, simpleToExactAmount(1, 18))
+                await mUSD.connect(sa.dummy1.signer).approve(revenueBuyBack.address, simpleToExactAmount(100))
+                await expect(
+                    revenueBuyBack.connect(sa.dummy1.signer).notifyRedistributionAmount(mUSD.address, simpleToExactAmount(2, 18)),
+                ).to.be.revertedWith("ERC20: transfer amount exceeds balance")
+            })
+        })
+    })
+    describe("buy back MTA rewards", () => {
+        const musdRevenue = simpleToExactAmount(20000)
+        const mbtcRevenue = simpleToExactAmount(2)
+        let bAsset1Amount: BigNumber
+        let bAsset2Amount: BigNumber
+        let musdRewardsAmount: BigNumber
+        let mbtcRewardsAmount: BigNumber
+        beforeEach(async () => {
+            await setupRevenueBuyBack(protocolFee)
+
+            // Put some bAssets to the mAssets
+            await bAsset1.transfer(mUSD.address, musdRevenue)
+            await bAsset2.transfer(mBTC.address, mbtcRevenue.div(1e12))
+
+            // Distribute revenue to RevenueBuyBack
+            await mUSD.approve(revenueBuyBack.address, musdRevenue)
+            await mBTC.approve(revenueBuyBack.address, mbtcRevenue)
+            await revenueBuyBack.notifyRedistributionAmount(mUSD.address, musdRevenue)
+            await revenueBuyBack.notifyRedistributionAmount(mBTC.address, mbtcRevenue)
+
+            bAsset1Amount = musdRevenue.mul(simpleToExactAmount(1).sub(protocolFee)).div(simpleToExactAmount(1)).mul(98).div(100)
+            // Exchange rate = 0.80 MTA/USD = 8 / 18
+            // Swap fee is 0.3% = 997 / 1000
+            musdRewardsAmount = bAsset1Amount.mul(8).div(10).mul(997).div(1000)
+            bAsset2Amount = mbtcRevenue.mul(simpleToExactAmount(1).sub(protocolFee)).div(simpleToExactAmount(1)).mul(98).div(100).div(1e12)
+            // Exchange rate = 50,000 MTA/BTC
+            // Swap fee is 0.3% = 997 / 1000
+            mbtcRewardsAmount = bAsset2Amount.mul(50000).mul(997).div(1000).mul(1e12)
+        })
+        it("should sell mUSD for MTA and send protocol fee to treasury", async () => {
+            expect(await mUSD.balanceOf(revenueBuyBack.address), "revenueBuyBack's mUSD Bal before").to.eq(musdRevenue)
+            expect(await bAsset1.balanceOf(mUSD.address), "mAsset's bAsset Bal before").to.eq(musdRevenue)
+            expect(await mUSD.balanceOf(await treasury.getAddress()), "treasury's mUSD Bal before").to.eq(0)
+
+            const tx = revenueBuyBack
+                .connect(sa.keeper.signer)
+                .buyBackRewards([mUSD.address], [bAsset1Amount], [musdRewardsAmount], [uniswapMusdBasset1Paths.encoded])
+            const treasuryBal = musdRevenue.mul(protocolFee).div(simpleToExactAmount(1))
+            const musdSold = musdRevenue.sub(treasuryBal)
+            await expect(tx)
+                .to.emit(revenueBuyBack, "BuyBackRewards")
+                .withArgs(mUSD.address, treasuryBal, musdSold, bAsset1Amount, musdRewardsAmount)
+
+            expect(await mUSD.balanceOf(revenueBuyBack.address), "revenueBuyBack's mUSD Bal after").to.eq(0)
+            expect(await mUSD.balanceOf(await treasury.getAddress()), "treasury's mUSD Bal after").to.gt(0)
+        })
+        it("should sell mBTC for MTA and send protocol fee to treasury", async () => {
+            expect(await mBTC.balanceOf(revenueBuyBack.address), "revenueBuyBack's mBTC Bal before").to.eq(mbtcRevenue)
+            expect(await bAsset2.balanceOf(mBTC.address), "mAsset's bAsset Bal before").to.eq(mbtcRevenue.div(1e12))
+            expect(await mUSD.balanceOf(await treasury.getAddress()), "treasury's mUSD Bal before").to.eq(0)
+
+            const tx = revenueBuyBack
+                .connect(sa.keeper.signer)
+                .buyBackRewards([mBTC.address], [bAsset2Amount], [mbtcRewardsAmount], [uniswapMbtcBasset2Paths.encoded])
+
+            const treasuryBal = mbtcRevenue.mul(protocolFee).div(simpleToExactAmount(1))
+            const mbtcSold = mbtcRevenue.sub(treasuryBal)
+            await expect(tx)
+                .to.emit(revenueBuyBack, "BuyBackRewards")
+                .withArgs(mBTC.address, treasuryBal, mbtcSold, bAsset2Amount, mbtcRewardsAmount)
+
+            expect(await mBTC.balanceOf(revenueBuyBack.address), "revenueBuyBack's mBTC Bal after").to.eq(0)
+            expect(await mBTC.balanceOf(await treasury.getAddress()), "treasury's mUSD Bal after").to.gt(0)
+        })
+        it("should sell mUSD and mBTC for MTA and send protocol fee to treasury", async () => {
+            const tx = revenueBuyBack
+                .connect(sa.keeper.signer)
+                .buyBackRewards(
+                    [mUSD.address, mBTC.address],
+                    [bAsset1Amount, bAsset2Amount],
+                    [musdRewardsAmount, mbtcRewardsAmount],
+                    [uniswapMusdBasset1Paths.encoded, uniswapMbtcBasset2Paths.encoded],
+                )
+
+            const musdTreasuryBal = musdRevenue.mul(protocolFee).div(simpleToExactAmount(1))
+            const musdSold = musdRevenue.sub(musdTreasuryBal)
+            await expect(tx)
+                .to.emit(revenueBuyBack, "BuyBackRewards")
+                .withArgs(mUSD.address, musdTreasuryBal, musdSold, bAsset1Amount, musdRewardsAmount)
+
+            const mbtcTreasuryBal = mbtcRevenue.mul(protocolFee).div(simpleToExactAmount(1))
+            const mbtcSold = mbtcRevenue.sub(mbtcTreasuryBal)
+            await expect(tx)
+                .to.emit(revenueBuyBack, "BuyBackRewards")
+                .withArgs(mBTC.address, mbtcTreasuryBal, mbtcSold, bAsset2Amount, mbtcRewardsAmount)
+
+            expect(await mUSD.balanceOf(revenueBuyBack.address), "revenueBuyBack's mUSD Bal after").to.eq(0)
+            expect(await mBTC.balanceOf(revenueBuyBack.address), "revenueBuyBack's mUSD Bal after").to.eq(0)
+            expect(await mUSD.balanceOf(await treasury.getAddress()), "treasury's mUSD Bal after").to.gt(0)
+            expect(await mBTC.balanceOf(await treasury.getAddress()), "treasury's mBTC Bal after").to.gt(0)
+        })
+        describe("should fail when", () => {
+            it("Not keeper or governor", async () => {
+                const tx = revenueBuyBack.buyBackRewards(
+                    [mUSD.address],
+                    [bAsset1Amount],
+                    [musdRewardsAmount],
+                    [uniswapMusdBasset1Paths.encoded],
+                )
+                await expect(tx).to.revertedWith("Only keeper or governor")
+            })
+            it("No mAssets", async () => {
+                const tx = revenueBuyBack.connect(sa.keeper.signer).buyBackRewards([], [], [], [])
+                await expect(tx).to.revertedWith("Invalid mAssets")
+            })
+            it("Not a mAsset", async () => {
+                const tx = revenueBuyBack
+                    .connect(sa.keeper.signer)
+                    .buyBackRewards([rewardsToken.address], [bAsset1Amount], [musdRewardsAmount], [uniswapMusdBasset1Paths.encoded])
+                await expect(tx).to.revertedWith("Invalid mAsset")
+            })
+            it("No minBassetsAmounts", async () => {
+                const tx = revenueBuyBack
+                    .connect(sa.keeper.signer)
+                    .buyBackRewards([mUSD.address], [], [musdRewardsAmount], [uniswapMusdBasset1Paths.encoded])
+                await expect(tx).to.revertedWith("Invalid minBassetsAmounts")
+            })
+            it("as minBassetsAmounts is too high", async () => {
+                const tx = revenueBuyBack
+                    .connect(sa.keeper.signer)
+                    .buyBackRewards([mUSD.address], [bAsset1Amount.add(1)], [musdRewardsAmount], [uniswapMusdBasset1Paths.encoded])
+                await expect(tx).to.revertedWith("bAsset qty < min qty")
+                expect(await rewardsToken.balanceOf(revenueBuyBack.address), "RevenueBuyBack MTA bal after").to.eq(0)
+            })
+            it("No minRewardsAmounts", async () => {
+                const tx = revenueBuyBack
+                    .connect(sa.keeper.signer)
+                    .buyBackRewards([mUSD.address], [bAsset1Amount], [], [uniswapMusdBasset1Paths.encoded])
+                await expect(tx).to.revertedWith("Invalid minRewardsAmounts")
+            })
+            it("as minRewardsAmounts is too high", async () => {
+                const tx = revenueBuyBack
+                    .connect(sa.keeper.signer)
+                    .buyBackRewards([mUSD.address], [bAsset1Amount], [musdRewardsAmount.add(1)], [uniswapMusdBasset1Paths.encoded])
+                await expect(tx).to.revertedWith("Too little received")
+                expect(await rewardsToken.balanceOf(revenueBuyBack.address), "RevenueBuyBack MTA bal after").to.eq(0)
+            })
+            it("No uniswapPaths", async () => {
+                const tx = revenueBuyBack.connect(sa.keeper.signer).buyBackRewards([mUSD.address], [bAsset1Amount], [musdRewardsAmount], [])
+                await expect(tx).to.revertedWith("Invalid uniswapPaths")
+                expect(await rewardsToken.balanceOf(revenueBuyBack.address), "RevenueBuyBack MTA bal after").to.eq(0)
+            })
+            describe("uniswap path", () => {
+                it("zero", async () => {
+                    const tx = revenueBuyBack
+                        .connect(sa.keeper.signer)
+                        .buyBackRewards([mUSD.address], [bAsset1Amount], [musdRewardsAmount], ["0x"])
+                    await expect(tx).to.revertedWith("Uniswap path too short")
+                })
+                it("from mAsset to rewards", async () => {
+                    const uniswapNewPaths = encodeUniswapPath([mUSD.address, DEAD_ADDRESS, rewardsToken.address], [3000, 3000])
+
+                    const tx = revenueBuyBack
+                        .connect(sa.keeper.signer)
+                        .buyBackRewards([mUSD.address], [bAsset1Amount], [musdRewardsAmount], [uniswapNewPaths.encoded])
+                    await expect(tx).to.revertedWith("Invalid uniswap path")
+                })
+                it("from bAsset to mAsset", async () => {
+                    const uniswapNewPaths = encodeUniswapPath([bAsset1.address, DEAD_ADDRESS, mUSD.address], [3000, 3000])
+                    const tx = revenueBuyBack
+                        .connect(sa.keeper.signer)
+                        .buyBackRewards([mUSD.address], [bAsset1Amount], [musdRewardsAmount], [uniswapNewPaths.encoded])
+                    await expect(tx).to.revertedWith("Invalid uniswap path")
+                })
+                it("is too short", async () => {
+                    const uniswapNewPaths = encodeUniswapPath([bAsset1.address, rewardsToken.address], [3000])
+                    const tx = revenueBuyBack
+                        .connect(sa.keeper.signer)
+                        .buyBackRewards([mUSD.address], [bAsset1Amount], [musdRewardsAmount], [uniswapNewPaths.encoded.slice(0, 42)])
+                    await expect(tx).to.revertedWith("Uniswap path too short")
+                })
+            })
+        })
+    })
+    describe("donate rewards to Emissions Controller", () => {
+        const totalRewards = simpleToExactAmount(40000)
+        beforeEach(async () => {
+            await setupRevenueBuyBack(protocolFee)
+        })
+        it("should donate rewards", async () => {
+            // Put some reward tokens in the RevenueBuyBack contract for donation to the Emissions Controller
+            await rewardsToken.transfer(revenueBuyBack.address, totalRewards)
+            expect(await rewardsToken.balanceOf(revenueBuyBack.address), "revenue buy back rewards before").to.eq(totalRewards)
+            const rewardsECbefore = await rewardsToken.balanceOf(emissionController.address)
+
+            const tx = revenueBuyBack.connect(sa.keeper.signer).donateRewards()
+
+            await expect(tx).to.emit(revenueBuyBack, "DonatedRewards").withArgs(totalRewards)
+            await expect(tx).to.emit(emissionController, "DonatedRewards").withArgs(1, totalRewards.div(4))
+            await expect(tx).to.emit(emissionController, "DonatedRewards").withArgs(0, totalRewards.mul(3).div(4))
+
+            expect(await rewardsToken.balanceOf(revenueBuyBack.address), "revenue buy back rewards after").to.eq(0)
+            expect(await rewardsToken.balanceOf(emissionController.address), "emission controller rewards after").to.eq(
+                rewardsECbefore.add(totalRewards),
+            )
+        })
+        describe("should fail when", () => {
+            it("no voting power", async () => {
+                await staking1.setTotalSupply(0)
+                await staking2.setTotalSupply(0)
+
+                const tx = revenueBuyBack.connect(sa.keeper.signer).donateRewards()
+                await expect(tx).to.revertedWith("No voting power")
+            })
+            it("no rewards to donate", async () => {
+                expect(await rewardsToken.balanceOf(revenueBuyBack.address), "revenue buy back rewards before").to.eq(0)
+
+                const tx = revenueBuyBack.connect(sa.keeper.signer).donateRewards()
+                await expect(tx).to.revertedWith("No rewards to donate")
+            })
+        })
+    })
+    describe("mapBasset", () => {
+        let newMasset: MockMasset
+        let newBasset: MockERC20
+        before(async () => {
+            newMasset = await new MockMasset__factory(sa.default.signer).deploy(
+                "EURO",
+                "mEUR",
+                18,
+                sa.default.address,
+                simpleToExactAmount(2000000),
+            )
+            newBasset = await mAssetMachine.loadBassetProxy("EUR bAsset", "bEUR", 18)
+        })
+        it("should map bAsset", async () => {
+            const tx = await revenueBuyBack.connect(sa.governor.signer).mapBasset(newMasset.address, newBasset.address)
+
+            await expect(tx).to.emit(revenueBuyBack, "MappedBasset").withArgs(newMasset.address, newBasset.address)
+
+            const bAsset = await revenueBuyBack.bassets(newMasset.address)
+            expect(bAsset, "bAsset").to.eq(newBasset.address)
+        })
+        context("should fail when", () => {
+            before(async () => {
+                await setupRevenueBuyBack(protocolFee)
+            })
+            it("not governor", async () => {
+                const tx = revenueBuyBack.mapBasset(newMasset.address, newBasset.address)
+
+                await expect(tx).to.revertedWith("Only governor can execute")
+            })
+            it("mAsset is zero", async () => {
+                const tx = revenueBuyBack.connect(sa.governor.signer).mapBasset(ZERO_ADDRESS, newBasset.address)
+                await expect(tx).to.revertedWith("mAsset token is zero")
+            })
+            it("bAsset is zero", async () => {
+                const tx = revenueBuyBack.connect(sa.governor.signer).mapBasset(newMasset.address, ZERO_ADDRESS)
+                await expect(tx).to.revertedWith("bAsset token is zero")
+            })
+        })
+    })
+    describe("set protocol fee", () => {
+        const newProtocolFee = simpleToExactAmount(2, 17)
+        it("should set protocol fee", async () => {
+            const tx = await revenueBuyBack.connect(sa.governor.signer).setProtocolFee(newProtocolFee)
+
+            await expect(tx).to.emit(revenueBuyBack, "ProtocolFeeChanged").withArgs(newProtocolFee)
+
+            expect(await revenueBuyBack.protocolFee(), "protocol fee").to.eq(newProtocolFee)
+        })
+        context("should fail when", () => {
+            before(async () => {
+                await setupRevenueBuyBack(protocolFee)
+            })
+            it("not governor", async () => {
+                const tx = revenueBuyBack.setProtocolFee(newProtocolFee)
+
+                await expect(tx).to.revertedWith("Only governor can execute")
+            })
+            it("protocol fee too small", async () => {
+                const tx = revenueBuyBack.connect(sa.governor.signer).setProtocolFee(simpleToExactAmount(9, 14))
+                await expect(tx).to.revertedWith("Invalid protocol fee")
+            })
+            it("protocol fee too big", async () => {
+                const tx = revenueBuyBack.connect(sa.governor.signer).setProtocolFee(simpleToExactAmount(101, 16))
+                await expect(tx).to.revertedWith("Invalid protocol fee")
+            })
+        })
+    })
+    describe("set treasury", () => {
+        let newTreasury: Wallet
+        before(async () => {
+            newTreasury = ethers.Wallet.createRandom()
+        })
+        it("should set treasury", async () => {
+            const tx = await revenueBuyBack.connect(sa.governor.signer).setTreasury(newTreasury.address)
+
+            await expect(tx).to.emit(revenueBuyBack, "TreasuryChanged").withArgs(newTreasury.address)
+
+            expect(await revenueBuyBack.treasury(), "bAsset").to.eq(newTreasury.address)
+        })
+        context("should fail when", () => {
+            before(async () => {
+                await setupRevenueBuyBack(protocolFee)
+            })
+            it("not governor", async () => {
+                const tx = revenueBuyBack.setTreasury(newTreasury.address)
+
+                await expect(tx).to.revertedWith("Only governor can execute")
+            })
+            it("treasury address is zero", async () => {
+                const tx = revenueBuyBack.connect(sa.governor.signer).setTreasury(ZERO_ADDRESS)
+                await expect(tx).to.revertedWith("Treasury is zero")
+            })
+        })
+    })
+    describe("addStakingContract", () => {
+        before(async () => {
+            await setupRevenueBuyBack(protocolFee)
+        })
+        context("should fail when", () => {
+            it("duplicate", async () => {
+                const tx = revenueBuyBack.connect(sa.governor.signer).addStakingContract(0)
+
+                await expect(tx).to.revertedWith("Staking dial id already exists")
+            })
+            it("invalid dial id", async () => {
+                const tx = revenueBuyBack.connect(sa.governor.signer).addStakingContract(3)
+
+                await expect(tx).to.revertedWith("reverted with panic code 0x32 (Array accessed at an out-of-bounds or negative index)")
+            })
+            it("not governor", async () => {
+                const tx = revenueBuyBack.addStakingContract(4)
+
+                await expect(tx).to.revertedWith("Only governor can execute")
+            })
+        })
+        it("should add staking contract", async () => {
+            const newStakingContract = await new MockStakingContract__factory(sa.default.signer).deploy()
+            await emissionController.connect(sa.governor.signer).addDial(newStakingContract.address, 10, true)
+            const newDialId = 2
+            expect(await emissionController.getDialRecipient(newDialId), "new dial added").to.eq(newStakingContract.address)
+
+            const tx = await revenueBuyBack.connect(sa.governor.signer).addStakingContract(newDialId)
+
+            await expect(tx).to.emit(revenueBuyBack, "AddedStakingContract").withArgs(newDialId)
+        })
+    })
+})


### PR DESCRIPTION
Forked `RevenueBuyBack` contract to `RevenueSplitBuyBack` that sends a portion of the mAssets revenue to treasury and the rest through a buy-back of reward tokens. The buy-back does a mAsset redeem to a bAsset and then a Uniswap V3 swap to the rewards token, eg MTA.

The buy-back moves the min amounts to parameters of the `buyBackRewards` function instead of being stored in contract storage. This is to better protect against sandwich attacks. Only the keeper or governor can now execute the `buyBackRewards` function as setting the min amounts needs to come from a trusted account.

Change details

* `buyBackRewards` has an array of `minBassetsAmounts`, `minRewardsAmounts` and `uniswapPaths` added as arguments to the existing array of `mAssets` argument.
* The portion of the revenue sent to the treasury account is set with `setTreasuryFee`.
* The treasury account is set with `setTreasury`
* `setMassetConfig` has been changed to just `mapBasset` as there's now just a mapping from mAssets to bAssets. The min bAsset and rewards prices along with the uniswap path are no longer stored in contract storage.

TODO
* fork tests