### PR TITLE
test: finish fork tests for IERC4626Vault

### DIFF
--- a/contracts/interfaces/ISavingsContract.sol
+++ b/contracts/interfaces/ISavingsContract.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.6;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC4626Vault } from "../interfaces/IERC4626Vault.sol";
 
 interface ISavingsContractV1 {
     function depositInterest(uint256 _amount) external;
@@ -103,4 +104,76 @@ interface ISavingsContractV3 {
         address _beneficiary,
         address _referrer
     ) external returns (uint256 creditsIssued); // V3
+}
+
+interface ISavingsContractV4 is
+    IERC4626Vault // V4
+{
+    // DEPRECATED but still backwards compatible
+    function redeem(uint256 _amount) external returns (uint256 massetReturned); // V1  (use IERC4626Vault.redeem)
+
+    function creditBalances(address) external view returns (uint256); // V1 & V2 (use balanceOf)
+
+    // --------------------------------------------
+    function depositInterest(uint256 _amount) external; // V1 & V2
+
+    /** @dev see IERC4626Vault.deposit(uint256 assets, address receiver)*/
+    function depositSavings(uint256 _amount) external returns (uint256 creditsIssued); // V1 & V2
+
+    /** @dev see IERC4626Vault.deposit(uint256 assets, address receiver)*/
+    function depositSavings(uint256 _amount, address _beneficiary)
+        external
+        returns (uint256 creditsIssued); // V2
+
+    /** @dev see IERC4626Vault.redeem(uint256 shares,address receiver,address owner)(uint256 assets);*/
+    function redeemCredits(uint256 _amount) external returns (uint256 underlyingReturned); // V2
+
+    /** @dev see IERC4626Vault.withdraw(uint256 assets,address receiver,address owner)(uint256 assets, address receiver)*/
+    function redeemUnderlying(uint256 _amount) external returns (uint256 creditsBurned); // V2
+
+    function exchangeRate() external view returns (uint256); // V1 & V2
+
+    function balanceOfUnderlying(address _user) external view returns (uint256 underlying); // V2
+
+    function underlyingToCredits(uint256 _underlying) external view returns (uint256 credits); // V2
+
+    function creditsToUnderlying(uint256 _credits) external view returns (uint256 underlying); // V2
+
+    /** @dev see IERC4626Vault.asset()(address assetTokenAddress);*/
+    function underlying() external view returns (IERC20 underlyingMasset); // V2
+
+    function redeemAndUnwrap(
+        uint256 _amount,
+        bool _isCreditAmt,
+        uint256 _minAmountOut,
+        address _output,
+        address _beneficiary,
+        address _router,
+        bool _isBassetOut
+    )
+        external
+        returns (
+            uint256 creditsBurned,
+            uint256 massetRedeemed,
+            uint256 outputQuantity
+        ); // V3
+
+    function depositSavings(
+        uint256 _underlying,
+        address _beneficiary,
+        address _referrer
+    ) external returns (uint256 creditsIssued); // V3
+
+    // -------------------------------------------- V4
+    function deposit(
+        uint256 assets,
+        address receiver,
+        address referrer
+    ) external returns (uint256 shares);
+
+    function mint(
+        uint256 shares,
+        address receiver,
+        address referrer
+    ) external returns (uint256 assets);
 }

--- a/contracts/legacy-upgraded/imbtc-mainnet-22.sol
+++ b/contracts/legacy-upgraded/imbtc-mainnet-22.sol
@@ -265,7 +265,7 @@ interface ISavingsManager {
     function collectAndDistributeInterest(address _mAsset) external;
 }
 
-interface ISavingsContractV3 {
+interface ISavingsContractV4 is IERC4626Vault {
     // DEPRECATED but still backwards compatible
     function redeem(uint256 _amount) external returns (uint256 massetReturned);
 
@@ -316,6 +316,18 @@ interface ISavingsContractV3 {
         address _beneficiary,
         address _referrer
     ) external returns (uint256 creditsIssued);
+
+    function deposit(
+        uint256 assets,
+        address receiver,
+        address referrer
+    ) external returns (uint256 shares);
+
+    function mint(
+        uint256 shares,
+        address receiver,
+        address referrer
+    ) external returns (uint256 assets);
 }
 
 /*
@@ -1076,8 +1088,7 @@ library StableMath {
  *          DATE:    2022-04-08
  */
 contract SavingsContract_imbtc_mainnet_22 is
-    ISavingsContractV3,
-    IERC4626Vault,
+    ISavingsContractV4,
     Initializable,
     InitializableToken,
     ImmutableModule
@@ -1886,7 +1897,7 @@ contract SavingsContract_imbtc_mainnet_22 is
         uint256 assets,
         address receiver,
         address referrer
-    ) external returns (uint256 shares) {
+    ) external override returns (uint256 shares) {
         shares = _transferAndMint(assets, receiver, true);
         emit Referral(referrer, receiver, assets);
     }
@@ -1936,7 +1947,7 @@ contract SavingsContract_imbtc_mainnet_22 is
         uint256 shares,
         address receiver,
         address referrer
-    ) external returns (uint256 assets) {
+    ) external override returns (uint256 assets) {
         (assets, ) = _creditsToUnderlying(shares);
         _transferAndMint(assets, receiver, true);
         emit Referral(referrer, receiver, assets);

--- a/contracts/legacy-upgraded/imbtc-mainnet-22.sol
+++ b/contracts/legacy-upgraded/imbtc-mainnet-22.sol
@@ -1322,7 +1322,6 @@ contract SavingsContract_imbtc_mainnet_22 is
         bool _collectInterest
     ) internal returns (uint256 creditsIssued) {
         creditsIssued = _transferAndMint(_underlying, _beneficiary, _collectInterest);
-        emit SavingsDeposited(_beneficiary, _underlying, creditsIssued);
     }
 
     /***************************************
@@ -1926,6 +1925,24 @@ contract SavingsContract_imbtc_mainnet_22 is
     }
 
     /**
+     * @notice Mint exact amount of vault shares to the receiver by transferring enough underlying asset tokens from the caller.
+     * @param shares The amount of vault shares to be minted.
+     * @param receiver The account the vault shares will be minted to.
+     * @param referrer  Referrer address for this deposit.
+     * @return assets The amount of underlying assets that were transferred from the caller.
+     * Emits a {Deposit}, {Referral} events
+     */
+    function mint(
+        uint256 shares,
+        address receiver,
+        address referrer
+    ) external returns (uint256 assets) {
+        (assets, ) = _creditsToUnderlying(shares);
+        _transferAndMint(assets, receiver, true);
+        emit Referral(referrer, receiver, assets);
+    }
+
+    /**
      *
      *  Returns Total number of underlying assets that caller can withdraw.
      */
@@ -2028,6 +2045,7 @@ contract SavingsContract_imbtc_mainnet_22 is
         // add credits to ERC20 balances
         _mint(receiver, shares);
         emit Deposit(msg.sender, receiver, assets, shares);
+        emit SavingsDeposited(receiver, assets, shares);
     }
 
     /*///////////////////////////////////////////////////////////////

--- a/contracts/legacy-upgraded/imusd-mainnet-21.sol
+++ b/contracts/legacy-upgraded/imusd-mainnet-21.sol
@@ -1186,7 +1186,7 @@ contract SavingsContract_imusd_mainnet_21 is
     uint256 private constant MAX_APY = 4e18;
     uint256 private constant SECONDS_IN_YEAR = 365 days;
     // Proxy contract for easy redemption
-    address public unwrapper; // TODO!!
+    address public constant unwrapper = 0xc1443Cb9ce81915fB914C270d74B0D57D1c87be0;
 
     // Add these constants to bytecode at deploytime
     function initialize(

--- a/contracts/legacy-upgraded/imusd-mainnet-22.sol
+++ b/contracts/legacy-upgraded/imusd-mainnet-22.sol
@@ -202,7 +202,7 @@ interface ISavingsContractV1 {
     function creditBalances(address) external view returns (uint256);
 }
 
-interface ISavingsContractV3 {
+interface ISavingsContractV4 {
     // DEPRECATED but still backwards compatible
     function redeem(uint256 _amount) external returns (uint256 massetReturned);
 
@@ -253,6 +253,19 @@ interface ISavingsContractV3 {
         address _beneficiary,
         address _referrer
     ) external returns (uint256 creditsIssued);
+
+    // -------------------------------------------- V4
+    function deposit(
+        uint256 assets,
+        address receiver,
+        address referrer
+    ) external returns (uint256 shares);
+
+    function mint(
+        uint256 shares,
+        address receiver,
+        address referrer
+    ) external returns (uint256 assets);
 }
 
 /*
@@ -1273,7 +1286,7 @@ library StableMath {
  */
 contract SavingsContract_imusd_mainnet_22 is
     ISavingsContractV1,
-    ISavingsContractV3,
+    ISavingsContractV4,
     IERC4626Vault,
     Initializable,
     InitializableToken,

--- a/contracts/legacy-upgraded/imusd-polygon-22.sol
+++ b/contracts/legacy-upgraded/imusd-polygon-22.sol
@@ -1368,7 +1368,6 @@ contract SavingsContract_imusd_polygon_22 is
         bool _collectInterest
     ) internal returns (uint256 creditsIssued) {
         creditsIssued = _transferAndMint(_underlying, _beneficiary, _collectInterest);
-        emit SavingsDeposited(_beneficiary, _underlying, creditsIssued);
     }
 
     /***************************************
@@ -1943,6 +1942,24 @@ contract SavingsContract_imusd_polygon_22 is
     }
 
     /**
+     * @notice Mint exact amount of vault shares to the receiver by transferring enough underlying asset tokens from the caller.
+     * @param shares The amount of vault shares to be minted.
+     * @param receiver The account the vault shares will be minted to.
+     * @param referrer  Referrer address for this deposit.
+     * @return assets The amount of underlying assets that were transferred from the caller.
+     * Emits a {Deposit}, {Referral} events
+     */
+    function mint(
+        uint256 shares,
+        address receiver,
+        address referrer
+    ) external returns (uint256 assets) {
+        (assets, ) = _creditsToUnderlying(shares);
+        _transferAndMint(assets, receiver, true);
+        emit Referral(referrer, receiver, assets);
+    }
+
+    /**
      *
      *  Returns Total number of underlying assets that caller can withdraw.
      */
@@ -2045,6 +2062,7 @@ contract SavingsContract_imusd_polygon_22 is
         // add credits to ERC20 balances
         _mint(receiver, shares);
         emit Deposit(msg.sender, receiver, assets, shares);
+        emit SavingsDeposited(receiver, assets, shares);
     }
 
     /*///////////////////////////////////////////////////////////////

--- a/contracts/legacy-upgraded/imusd-polygon-22.sol
+++ b/contracts/legacy-upgraded/imusd-polygon-22.sol
@@ -268,7 +268,9 @@ interface ISavingsManager {
     function lastBatchCollected(address _mAsset) external view returns (uint256);
 }
 
-interface ISavingsContractV3 {
+interface ISavingsContractV4 is
+    IERC4626Vault // V4
+{
     // DEPRECATED but still backwards compatible
     function redeem(uint256 _amount) external returns (uint256 massetReturned);
 
@@ -296,8 +298,6 @@ interface ISavingsContractV3 {
 
     function creditsToUnderlying(uint256 _underlying) external view returns (uint256 credits); // V2
 
-    // --------------------------------------------
-
     function redeemAndUnwrap(
         uint256 _amount,
         bool _isCreditAmt,
@@ -319,6 +319,19 @@ interface ISavingsContractV3 {
         address _beneficiary,
         address _referrer
     ) external returns (uint256 creditsIssued);
+
+    // -------------------------------------------- V4
+    function deposit(
+        uint256 assets,
+        address receiver,
+        address referrer
+    ) external returns (uint256 shares);
+
+    function mint(
+        uint256 shares,
+        address receiver,
+        address referrer
+    ) external returns (uint256 assets);
 }
 
 /*
@@ -1122,8 +1135,7 @@ library YieldValidator {
  *          DATE:    2022-04-08
  */
 contract SavingsContract_imusd_polygon_22 is
-    ISavingsContractV3,
-    IERC4626Vault,
+    ISavingsContractV4,
     Initializable,
     InitializableToken,
     ImmutableModule
@@ -1903,7 +1915,7 @@ contract SavingsContract_imusd_polygon_22 is
         uint256 assets,
         address receiver,
         address referrer
-    ) external returns (uint256 shares) {
+    ) external override returns (uint256 shares) {
         shares = _transferAndMint(assets, receiver, true);
         emit Referral(referrer, receiver, assets);
     }
@@ -1953,7 +1965,7 @@ contract SavingsContract_imusd_polygon_22 is
         uint256 shares,
         address receiver,
         address referrer
-    ) external returns (uint256 assets) {
+    ) external override returns (uint256 assets) {
         (assets, ) = _creditsToUnderlying(shares);
         _transferAndMint(assets, receiver, true);
         emit Referral(referrer, receiver, assets);

--- a/contracts/rewards/boosted-staking/BoostedDualVault.sol
+++ b/contracts/rewards/boosted-staking/BoostedDualVault.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.6;
 // Internal
 import { IRewardsRecipientWithPlatformToken } from "../../interfaces/IRewardsDistributionRecipient.sol";
 import { IBoostedDualVaultWithLockup } from "../../interfaces/IBoostedDualVaultWithLockup.sol";
-import { ISavingsContractV3 } from "../../interfaces/ISavingsContract.sol";
+import { ISavingsContractV4 } from "../../interfaces/ISavingsContract.sol";
 import { IRewardsDistributionRecipient, InitializableRewardsDistributionRecipient } from "../InitializableRewardsDistributionRecipient.sol";
 import { BoostedTokenWrapper } from "./BoostedTokenWrapper.sol";
 import { PlatformTokenVendor } from "../staking/PlatformTokenVendor.sol";
@@ -331,7 +331,7 @@ contract BoostedDualVault is
         _reduceRaw(_amount);
 
         // Unwrap `stakingToken` into `output` and send to `beneficiary`
-        (, , outputQuantity) = ISavingsContractV3(address(stakingToken)).redeemAndUnwrap(
+        (, , outputQuantity) = ISavingsContractV4(address(stakingToken)).redeemAndUnwrap(
             _amount,
             true,
             _minAmountOut,

--- a/contracts/rewards/boosted-staking/BoostedVault.sol
+++ b/contracts/rewards/boosted-staking/BoostedVault.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.6;
 
 // Internal
 import { IBoostedVaultWithLockup } from "../../interfaces/IBoostedVaultWithLockup.sol";
-import { ISavingsContractV3 } from "../../interfaces/ISavingsContract.sol";
+import { ISavingsContractV4 } from "../../interfaces/ISavingsContract.sol";
 import { InitializableRewardsDistributionRecipient } from "../InitializableRewardsDistributionRecipient.sol";
 import { BoostedTokenWrapper } from "./BoostedTokenWrapper.sol";
 import { Initializable } from "../../shared/@openzeppelin-2.5/Initializable.sol";
@@ -287,7 +287,7 @@ contract BoostedVault is
         _reduceRaw(_amount);
 
         // Unwrap `stakingToken` into `output` and send to `beneficiary`
-        (, , outputQuantity) = ISavingsContractV3(address(stakingToken)).redeemAndUnwrap(
+        (, , outputQuantity) = ISavingsContractV4(address(stakingToken)).redeemAndUnwrap(
             _amount,
             true,
             _minAmountOut,

--- a/contracts/rewards/staking/StakingRewards.sol
+++ b/contracts/rewards/staking/StakingRewards.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.6;
 // Internal
 import { StakingTokenWrapper } from "./StakingTokenWrapper.sol";
 import { InitializableRewardsDistributionRecipient } from "../InitializableRewardsDistributionRecipient.sol";
-import { ISavingsContractV3 } from "../../interfaces/ISavingsContract.sol";
+import { ISavingsContractV4 } from "../../interfaces/ISavingsContract.sol";
 import { StableMath } from "../../shared/StableMath.sol";
 
 // Libs
@@ -203,7 +203,7 @@ contract StakingRewards is
         _reduceRaw(_amount);
 
         // Unwrap `stakingToken` into `output` and send to `beneficiary`
-        (, , outputQuantity) = ISavingsContractV3(address(stakingToken)).redeemAndUnwrap(
+        (, , outputQuantity) = ISavingsContractV4(address(stakingToken)).redeemAndUnwrap(
             _amount,
             true,
             _minAmountOut,

--- a/contracts/rewards/staking/StakingRewardsWithPlatformToken.sol
+++ b/contracts/rewards/staking/StakingRewardsWithPlatformToken.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.6;
 import { IRewardsDistributionRecipient, IRewardsRecipientWithPlatformToken } from "../../interfaces/IRewardsDistributionRecipient.sol";
 import { IStakingRewardsWithPlatformToken } from "../../interfaces/IStakingRewardsWithPlatformToken.sol";
 import { InitializableRewardsDistributionRecipient } from "../InitializableRewardsDistributionRecipient.sol";
-import { ISavingsContractV3 } from "../../interfaces/ISavingsContract.sol";
+import { ISavingsContractV4 } from "../../interfaces/ISavingsContract.sol";
 import { StakingTokenWrapper } from "./StakingTokenWrapper.sol";
 import { PlatformTokenVendor } from "./PlatformTokenVendor.sol";
 import { StableMath } from "../../shared/StableMath.sol";
@@ -218,7 +218,7 @@ contract StakingRewardsWithPlatformToken is
         _reduceRaw(_amount);
 
         // Unwrap `stakingToken` into `output` and send to `beneficiary`
-        (, , outputQuantity) = ISavingsContractV3(address(stakingToken)).redeemAndUnwrap(
+        (, , outputQuantity) = ISavingsContractV4(address(stakingToken)).redeemAndUnwrap(
             _amount,
             true,
             _minAmountOut,

--- a/contracts/savings/SavingsContract.sol
+++ b/contracts/savings/SavingsContract.sol
@@ -281,7 +281,6 @@ contract SavingsContract is
         bool _collectInterest
     ) internal returns (uint256 creditsIssued) {
         creditsIssued = _transferAndMint(_underlying, _beneficiary, _collectInterest);
-        emit SavingsDeposited(_beneficiary, _underlying, creditsIssued);
     }
 
     /***************************************
@@ -859,6 +858,24 @@ contract SavingsContract is
     }
 
     /**
+     * @notice Mint exact amount of vault shares to the receiver by transferring enough underlying asset tokens from the caller.
+     * @param shares The amount of vault shares to be minted.
+     * @param receiver The account the vault shares will be minted to.
+     * @param referrer  Referrer address for this deposit.
+     * @return assets The amount of underlying assets that were transferred from the caller.
+     * Emits a {Deposit}, {Referral} events
+     */
+    function mint(
+        uint256 shares,
+        address receiver,
+        address referrer
+    ) external returns (uint256 assets) {
+        (assets, ) = _creditsToUnderlying(shares);
+        _transferAndMint(assets, receiver, true);
+        emit Referral(referrer, receiver, assets);
+    }
+
+    /**
      *
      *  Returns Total number of underlying assets that caller can withdraw.
      */
@@ -961,6 +978,7 @@ contract SavingsContract is
         // add credits to ERC20 balances
         _mint(receiver, shares);
         emit Deposit(msg.sender, receiver, assets, shares);
+        emit SavingsDeposited(receiver, assets, shares);
     }
 
     /*///////////////////////////////////////////////////////////////

--- a/contracts/savings/SavingsContract.sol
+++ b/contracts/savings/SavingsContract.sol
@@ -5,9 +5,8 @@ pragma solidity 0.8.6;
 import { ISavingsManager } from "../interfaces/ISavingsManager.sol";
 
 // Internal
-import { ISavingsContractV3 } from "../interfaces/ISavingsContract.sol";
+import { ISavingsContractV4 } from "../interfaces/ISavingsContract.sol";
 import { IUnwrapper } from "../interfaces/IUnwrapper.sol";
-import { IERC4626Vault } from "../interfaces/IERC4626Vault.sol";
 import { InitializableToken } from "../shared/InitializableToken.sol";
 import { ImmutableModule } from "../shared/ImmutableModule.sol";
 import { IConnector } from "./peripheral/IConnector.sol";
@@ -27,13 +26,7 @@ import { YieldValidator } from "../shared/YieldValidator.sol";
  * @dev     VERSION: 2.2
  *          DATE:    2022-04-08
  */
-contract SavingsContract is
-    ISavingsContractV3,
-    IERC4626Vault,
-    Initializable,
-    InitializableToken,
-    ImmutableModule
-{
+contract SavingsContract is ISavingsContractV4, Initializable, InitializableToken, ImmutableModule {
     using StableMath for uint256;
 
     // Core events for depositing and withdrawing
@@ -819,7 +812,7 @@ contract SavingsContract is
         uint256 assets,
         address receiver,
         address referrer
-    ) external returns (uint256 shares) {
+    ) external override returns (uint256 shares) {
         shares = _transferAndMint(assets, receiver, true);
         emit Referral(referrer, receiver, assets);
     }
@@ -869,7 +862,7 @@ contract SavingsContract is
         uint256 shares,
         address receiver,
         address referrer
-    ) external returns (uint256 assets) {
+    ) external override returns (uint256 assets) {
         (assets, ) = _creditsToUnderlying(shares);
         _transferAndMint(assets, receiver, true);
         emit Referral(referrer, receiver, assets);

--- a/contracts/savings/peripheral/SaveWrapper.sol
+++ b/contracts/savings/peripheral/SaveWrapper.sol
@@ -7,7 +7,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { IBoostedVaultWithLockup } from "../../interfaces/IBoostedVaultWithLockup.sol";
 import { IFeederPool } from "../../interfaces/IFeederPool.sol";
 import { IMasset } from "../../interfaces/IMasset.sol";
-import { ISavingsContractV3 } from "../../interfaces/ISavingsContract.sol";
+import { ISavingsContractV4 } from "../../interfaces/ISavingsContract.sol";
 import { IUniswapV2Router02 } from "../../peripheral/Uniswap/IUniswapV2Router02.sol";
 import { IBasicToken } from "../../shared/IBasicToken.sol";
 import { ImmutableModule } from "../../shared/ImmutableModule.sol";
@@ -306,19 +306,19 @@ contract SaveWrapper is ImmutableModule {
         address _referrer
     ) internal {
         if (_stake && _referrer != address(0)) {
-            uint256 credits = ISavingsContractV3(_save).depositSavings(
+            uint256 credits = ISavingsContractV4(_save).depositSavings(
                 _amount,
                 address(this),
                 _referrer
             );
             IBoostedVaultWithLockup(_vault).stake(msg.sender, credits);
         } else if (_stake && _referrer == address(0)) {
-            uint256 credits = ISavingsContractV3(_save).depositSavings(_amount, address(this));
+            uint256 credits = ISavingsContractV4(_save).depositSavings(_amount, address(this));
             IBoostedVaultWithLockup(_vault).stake(msg.sender, credits);
         } else if (!_stake && _referrer != address(0)) {
-            ISavingsContractV3(_save).depositSavings(_amount, msg.sender, _referrer);
+            ISavingsContractV4(_save).depositSavings(_amount, msg.sender, _referrer);
         } else {
-            ISavingsContractV3(_save).depositSavings(_amount, msg.sender);
+            ISavingsContractV4(_save).depositSavings(_amount, msg.sender);
         }
     }
 

--- a/contracts/savings/peripheral/Unwrapper.sol
+++ b/contracts/savings/peripheral/Unwrapper.sol
@@ -5,7 +5,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ImmutableModule } from "../../shared/ImmutableModule.sol";
 
-import { ISavingsContractV3 } from "../../interfaces/ISavingsContract.sol";
+import { ISavingsContractV4 } from "../../interfaces/ISavingsContract.sol";
 import { IUnwrapper } from "../../interfaces/IUnwrapper.sol";
 import { IMasset } from "../../interfaces/IMasset.sol";
 import { IFeederPool } from "../../interfaces/IFeederPool.sol";
@@ -36,7 +36,7 @@ contract Unwrapper is IUnwrapper, ImmutableModule {
         bool _inputIsCredit,
         address _output
     ) external view override returns (bool isBassetOut) {
-        address input = _inputIsCredit ? address(ISavingsContractV3(_input).underlying()) : _input;
+        address input = _inputIsCredit ? address(ISavingsContractV4(_input).underlying()) : _input;
         (BassetPersonal[] memory bAssets, ) = IMasset(input).getBassets();
         for (uint256 i = 0; i < bAssets.length; i++) {
             if (bAssets[i].addr == _output) return true;
@@ -66,13 +66,13 @@ contract Unwrapper is IUnwrapper, ImmutableModule {
         uint256 _amount
     ) external view override returns (uint256 outputQuantity) {
         uint256 amt = _inputIsCredit
-            ? ISavingsContractV3(_input).creditsToUnderlying(_amount)
+            ? ISavingsContractV4(_input).creditsToUnderlying(_amount)
             : _amount;
         if (_isBassetOut) {
             outputQuantity = IMasset(_router).getRedeemOutput(_output, amt);
         } else {
             address input = _inputIsCredit
-                ? address(ISavingsContractV3(_input).underlying())
+                ? address(ISavingsContractV4(_input).underlying())
                 : _input;
             outputQuantity = IFeederPool(_router).getSwapOutput(input, _output, amt);
         }

--- a/tasks/deploySavingsContract4626.ts
+++ b/tasks/deploySavingsContract4626.ts
@@ -1,0 +1,146 @@
+import "ts-node/register"
+import "tsconfig-paths/register"
+import { DEAD_ADDRESS } from "@utils/constants"
+import { task, types } from "hardhat/config"
+import { DelayedProxyAdmin__factory } from "types/generated"
+// Polygon imUSD Contract
+import { SavingsContractImusdPolygon22 } from "types/generated/SavingsContractImusdPolygon22"
+import { SavingsContractImusdPolygon22__factory } from "types/generated/factories/SavingsContractImusdPolygon22__factory"
+// Mainnet imBTC Contract
+import { SavingsContractImbtcMainnet22__factory } from "types/generated/factories/SavingsContractImbtcMainnet22__factory"
+import { SavingsContractImbtcMainnet22 } from "types/generated/SavingsContractImbtcMainnet22"
+// Mainnet imUSD Contract
+import { SavingsContractImusdMainnet22__factory } from "types/generated/factories/SavingsContractImusdMainnet22__factory"
+import { SavingsContractImusdMainnet22 } from "types/generated/SavingsContractImusdMainnet22"
+
+import { deployContract } from "./utils/deploy-utils"
+import { getSigner } from "./utils/signerFactory"
+import { getChain, resolveAddress, getChainAddress } from "./utils/networkAddressFactory"
+import { Chain } from "./utils/tokens"
+import { verifyEtherscan } from "./utils/etherscan"
+
+task("upgrade-imusd-polygon", "Upgrade Polygon imUSD save contract imUSD")
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const signer = await getSigner(hre, taskArgs.speed)
+        const chain = getChain(hre)
+
+        if (chain !== Chain.polygon) throw Error("Task can only run against polygon or a polygon fork")
+
+        const musdAddress = resolveAddress("mUSD", chain)
+        const imusdAddress = resolveAddress("mUSD", chain, "savings")
+        const delayedAdminAddress = getChainAddress("DelayedProxyAdmin", chain)
+        const nexusAddress = getChainAddress("Nexus", chain)
+        const unwrapperAddress = getChainAddress("Unwrapper", chain)
+        const constructorArguments = [nexusAddress, musdAddress, unwrapperAddress]
+
+        // Deploy step 1 - Save Vault
+        const saveContractImpl = await deployContract<SavingsContractImusdPolygon22>(
+            new SavingsContractImusdPolygon22__factory(signer),
+            "mStable: mUSD Savings Contract (imUSD)",
+            constructorArguments,
+        )
+        await verifyEtherscan(hre, {
+            address: saveContractImpl.address,
+            contract: "contracts/legacy-upgraded/imusd-polygon-22.sol:SavingsContract_imusd_polygon_22",
+            constructorArguments,
+        })
+
+        // Deploy step 2 - Propose upgrade
+        // Update the Save Contract proxy to point to the new implementation using the delayed proxy admin
+        const delayedProxyAdmin = DelayedProxyAdmin__factory.connect(delayedAdminAddress, signer)
+
+        // Update the  proxy to point to the new implementation using the delayed proxy admin
+        const upgradeData = []
+        const proposeUpgradeData = delayedProxyAdmin.interface.encodeFunctionData("proposeUpgrade", [
+            imusdAddress,
+            saveContractImpl.address,
+            upgradeData,
+        ])
+        console.log(`\ndelayedProxyAdmin.proposeUpgrade to ${delayedAdminAddress}, data:\n${proposeUpgradeData}`)
+    })
+
+task("upgrade-imusd-mainnet", "Upgrade Mainnet imUSD save contract imUSD")
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const signer = await getSigner(hre, taskArgs.speed)
+        const chain = getChain(hre)
+
+        if (chain !== Chain.mainnet) throw Error("Task can only run against mainnet or a mainnet fork")
+
+        const imusdAddress = resolveAddress("mUSD", chain, "savings")
+        const delayedAdminAddress = getChainAddress("DelayedProxyAdmin", chain)
+        const unwrapperAddress = getChainAddress("Unwrapper", chain)
+        const constructorArguments = []
+
+        // Deploy step 1 -  Save Contract
+        const saveContractImpl = await deployContract<SavingsContractImusdMainnet22>(
+            new SavingsContractImusdMainnet22__factory(signer),
+            "mStable: mUSD Savings Contract (imUSD)",
+            constructorArguments,
+        )
+        // Validate the unwrapper is set as constant on the save contract
+        if ((await saveContractImpl.unwrapper()) !== unwrapperAddress || unwrapperAddress === DEAD_ADDRESS)
+            throw Error("Unwrapper address not set on save contract")
+        await verifyEtherscan(hre, {
+            address: saveContractImpl.address,
+            contract: "contracts/legacy-upgraded/imusd-mainnet-22.sol:SavingsContract_imusd_mainnet_22",
+            constructorArguments,
+        })
+
+        // Deploy step 2 - Propose upgrade
+        // Update the Save Contract proxy to point to the new implementation using the delayed proxy admin
+        const delayedProxyAdmin = DelayedProxyAdmin__factory.connect(delayedAdminAddress, signer)
+
+        // Update the  proxy to point to the new implementation using the delayed proxy admin
+        const upgradeData = []
+        const proposeUpgradeData = delayedProxyAdmin.interface.encodeFunctionData("proposeUpgrade", [
+            imusdAddress,
+            saveContractImpl.address,
+            upgradeData,
+        ])
+        console.log(`\ndelayedProxyAdmin.proposeUpgrade to ${delayedAdminAddress}, data:\n${proposeUpgradeData}`)
+    })
+
+task("upgrade-imbtc-mainnet", "Upgrade Mainnet imBTC save contract imBTC")
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const signer = await getSigner(hre, taskArgs.speed)
+        const chain = getChain(hre)
+
+        if (chain !== Chain.mainnet) throw Error("Task can only run against mainnet or a mainnet fork")
+
+        const mbtcAddress = resolveAddress("mBTC", chain)
+        const imbtcAddress = resolveAddress("mBTC", chain, "savings")
+        const delayedAdminAddress = getChainAddress("DelayedProxyAdmin", chain)
+        const nexusAddress = getChainAddress("Nexus", chain)
+        const unwrapperAddress = getChainAddress("Unwrapper", chain)
+
+        const constructorArguments = [nexusAddress, mbtcAddress, unwrapperAddress]
+
+        // Deploy step 1 -  Save Contract
+        const saveContractImpl = await deployContract<SavingsContractImbtcMainnet22>(
+            new SavingsContractImbtcMainnet22__factory(signer),
+            "mStable: mBTC Savings Contract (imBTC)",
+            constructorArguments,
+        )
+        await verifyEtherscan(hre, {
+            address: saveContractImpl.address,
+            contract: "contracts/legacy-upgraded/imbtc-mainnet-22.sol:SavingsContract_imbtc_mainnet_22",
+            constructorArguments,
+        })
+
+        // Deploy step 2 - Propose upgrade
+        // Update the Save Contract proxy to point to the new implementation using the delayed proxy admin
+        const delayedProxyAdmin = DelayedProxyAdmin__factory.connect(delayedAdminAddress, signer)
+
+        // Update the  proxy to point to the new implementation using the delayed proxy admin
+        const upgradeData = []
+        const proposeUpgradeData = delayedProxyAdmin.interface.encodeFunctionData("proposeUpgrade", [
+            imbtcAddress,
+            saveContractImpl.address,
+            upgradeData,
+        ])
+        console.log(`\ndelayedProxyAdmin.proposeUpgrade to ${delayedAdminAddress}, data:\n${proposeUpgradeData}`)
+    })
+module.exports = {}

--- a/test-utils/fork.ts
+++ b/test-utils/fork.ts
@@ -1,5 +1,7 @@
-import { Signer } from "ethers"
+/* eslint-disable no-await-in-loop */
+import { Signer, utils } from "ethers"
 import { Account } from "types"
+import { BN } from "./math"
 
 // impersonates a specific account
 export const impersonate = async (addr: string, fund = true): Promise<Signer> => {
@@ -29,4 +31,62 @@ export const impersonateAccount = async (address: string, fund = true): Promise<
         signer,
         address,
     }
+}
+
+export const toBytes32 = (bn: BN): string => utils.hexlify(utils.zeroPad(bn.toHexString(), 32))
+
+export const setStorageAt = async (address: string, index: string, value: string): Promise<void> => {
+    const { ethers } = await import("hardhat")
+
+    await ethers.provider.send("hardhat_setStorageAt", [address, index, value])
+    await ethers.provider.send("evm_mine", []) // Just mines to the next block
+}
+/**
+ *
+ * Based on https://blog.euler.finance/brute-force-storage-layout-discovery-in-erc20-contracts-with-hardhat-7ff9342143ed
+ * @export
+ * @param {string} tokenAddress
+ * @return {*}  {Promise<number>}
+ */
+export const findBalancesSlot = async (tokenAddress: string): Promise<number> => {
+    const { ethers, network } = await import("hardhat")
+
+    const encode = (types, values) => ethers.utils.defaultAbiCoder.encode(types, values)
+
+    const account = ethers.constants.AddressZero
+    const probeA = encode(["uint"], [1])
+    const probeB = encode(["uint"], [2])
+    const token = await ethers.getContractAt("@openzeppelin/contracts/token/ERC20/ERC20.sol:ERC20", tokenAddress)
+
+    for (let i = 0; i < 100; i += 1) {
+        let probedSlot = ethers.utils.keccak256(encode(["address", "uint"], [account, i]))
+        // remove padding for JSON RPC
+        while (probedSlot.startsWith("0x0")) probedSlot = `0x${probedSlot.slice(3)}`
+
+        const prev = await network.provider.send("eth_getStorageAt", [tokenAddress, probedSlot, "latest"])
+        // make sure the probe will change the slot value
+        const probe = prev === probeA ? probeB : probeA
+
+        await network.provider.send("hardhat_setStorageAt", [tokenAddress, probedSlot, probe])
+
+        const balance = await token.balanceOf(account)
+        // reset to previous value
+        await network.provider.send("hardhat_setStorageAt", [tokenAddress, probedSlot, prev])
+        if (balance.eq(ethers.BigNumber.from(probe))) return i
+    }
+    throw new Error("Balances slot not found!")
+}
+
+export const setBalance = async (userAddress: string, tokenAddress: string, amount: BN, slotIndex?: string): Promise<void> => {
+    const balanceSlot = await findBalancesSlot(tokenAddress)
+    const index =
+        slotIndex === undefined
+            ? utils.solidityKeccak256(
+                  ["uint256", "uint256"],
+                  [userAddress, balanceSlot], // key, slot
+              )
+            : slotIndex
+
+    console.log(`Setting balance of user  ${userAddress} with token ${tokenAddress} at index ${index}`)
+    await setStorageAt(tokenAddress, toBytes32(BN.from(index)), toBytes32(amount).toString())
 }

--- a/test/shared/ERC4626.behaviour.ts
+++ b/test/shared/ERC4626.behaviour.ts
@@ -5,7 +5,6 @@ import { expect } from "chai"
 import { Account } from "types"
 import { ERC20, ERC205, IERC20Metadata, IERC4626Vault } from "types/generated"
 
-
 export interface IERC4626BehaviourContext {
     vault: IERC4626Vault
     asset: ERC20
@@ -77,7 +76,7 @@ export function shouldBehaveLikeERC4626(ctx: IERC4626BehaviourContext): void {
             expect(await ctx.vault.convertToShares(assets), "convertToShares").to.lte(shares)
             expect(await ctx.vault.convertToAssets(shares), "convertToShares").to.lte(assets)
 
-            const tx = await ctx.vault.connect(alice.signer).mint(shares, alice.address)
+            const tx = await ctx.vault.connect(alice.signer)["mint(uint256,address)"](shares, alice.address)
             // Verify events, storage change, balance, etc.
             await expect(tx).to.emit(ctx.vault, "Deposit").withArgs(alice.address, alice.address, assets, shares)
 


### PR DESCRIPTION
Amends the following peer review comments: 
- Emits double emit  events (old, new)  to keep compatibility. 
- Adds emit function with referral .
- Changes 2**256 - 1 in the imUSD contract that still uses Solidity 0.5.16. for a constant. 