### PR TITLE
feat: adds new task  staked-time-all-users

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
                 enforceForRenamedProperties: false,
             },
         ],
+        "no-plusplus": ["error", { allowForLoopAfterthoughts: true }],
     },
     overrides: [
         {

--- a/contracts/governance/staking/StakedTokenBatcher.sol
+++ b/contracts/governance/staking/StakedTokenBatcher.sol
@@ -19,8 +19,11 @@ contract StakedTokenBatcher {
         IStakedToken stakedToken = IStakedToken(_stakedToken);
         uint256 len = _accounts.length;
         require(len > 0, "Invalid inputs");
-        for (uint256 i = 0; i < len; i++) {
+        for (uint256 i = 0; i < len; ) {
             stakedToken.reviewTimestamp(_accounts[i]);
+            unchecked {
+                ++i;
+            }
         }
     }
 }

--- a/contracts/governance/staking/StakedTokenBatcher.sol
+++ b/contracts/governance/staking/StakedTokenBatcher.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity 0.8.6;
+
+import { IStakedToken } from "./interfaces/IStakedToken.sol";
+
+/**
+ * @title StakedTokenBatcher
+ * @dev Batch transactions for staking a given staked token.
+ */
+contract StakedTokenBatcher {
+    /**
+     * @dev Called by anyone to poke the timestamp of an array of accounts. This allows users to
+     * effectively 'claim' any new timeMultiplier, but will revert if any of the accounts has no changes.
+     * It is recommend to validate off-chain the accounts before calling this function.
+     * @param _stakedToken Address of user the staked token.
+     * @param _accounts Array of account addresses to update.
+     */
+    function reviewTimestamp(address _stakedToken, address[] calldata _accounts) external {
+        IStakedToken stakedToken = IStakedToken(_stakedToken);
+        uint256 len = _accounts.length;
+        require(len > 0, "Invalid inputs");
+        for (uint256 i = 0; i < len; i++) {
+            stakedToken.reviewTimestamp(_accounts[i]);
+        }
+    }
+}

--- a/tasks/bridge.ts
+++ b/tasks/bridge.ts
@@ -4,7 +4,7 @@ import { subtask, task, types } from "hardhat/config"
 import { IChildToken__factory, IRootChainManager__factory } from "types/generated"
 import { simpleToExactAmount } from "@utils/math"
 import { ethers } from "ethers"
-import { logTxDetails, logger } from "./utils"
+import { logTxDetails } from "./utils"
 import { getSigner } from "./utils/signerFactory"
 import { getChain, resolveAddress } from "./utils/networkAddressFactory"
 

--- a/tasks/deployRewards.ts
+++ b/tasks/deployRewards.ts
@@ -4,7 +4,7 @@ import { task, types } from "hardhat/config"
 import { ONE_WEEK } from "@utils/constants"
 
 import { simpleToExactAmount } from "@utils/math"
-import { BoostedDualVault__factory, BoostDirectorV2__factory, BoostDirectorV2 } from "../types/generated"
+import { BoostedDualVault__factory, BoostDirectorV2__factory, BoostDirectorV2, StakedTokenBatcher__factory } from "../types/generated"
 import { getChain, getChainAddress, resolveAddress } from "./utils/networkAddressFactory"
 import { getSignerAccount, getSigner } from "./utils/signerFactory"
 import { deployContract, logTxDetails } from "./utils/deploy-utils"
@@ -99,4 +99,14 @@ task("StakedToken.deploy", "Deploys a Staked Token behind a proxy")
         await deployStakingToken(stakingTokenData, deployer, hre, taskArgs.proxy)
     })
 
+    task("StakedTokenBatcher.deploy", "Deploys a Staked Token Batcher")
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const signer = await getSigner(hre, taskArgs.speed)
+        const stakedTokenBatcher = await deployContract(new StakedTokenBatcher__factory(signer), "GaugeBriber", [])
+        await verifyEtherscan(hre, {
+            address: stakedTokenBatcher.address,
+            contract: "contracts/governance/staking/StakedTokenBatcher.sol:StakedTokenBatcher",
+        })
+    })    
 export {}

--- a/tasks/deployRewards.ts
+++ b/tasks/deployRewards.ts
@@ -99,14 +99,14 @@ task("StakedToken.deploy", "Deploys a Staked Token behind a proxy")
         await deployStakingToken(stakingTokenData, deployer, hre, taskArgs.proxy)
     })
 
-    task("StakedTokenBatcher.deploy", "Deploys a Staked Token Batcher")
+task("StakedTokenBatcher.deploy", "Deploys a Staked Token Batcher")
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
     .setAction(async (taskArgs, hre) => {
         const signer = await getSigner(hre, taskArgs.speed)
-        const stakedTokenBatcher = await deployContract(new StakedTokenBatcher__factory(signer), "GaugeBriber", [])
+        const stakedTokenBatcher = await deployContract(new StakedTokenBatcher__factory(signer), "StakedTokenBatcher", [])
         await verifyEtherscan(hre, {
             address: stakedTokenBatcher.address,
             contract: "contracts/governance/staking/StakedTokenBatcher.sol:StakedTokenBatcher",
         })
-    })    
+    })
 export {}

--- a/tasks/stakingV2.ts
+++ b/tasks/stakingV2.ts
@@ -3,12 +3,83 @@ import { StakedTokenBPT__factory, StakedTokenMTA__factory, StakedToken__factory 
 import { BN, simpleToExactAmount } from "@utils/math"
 import { formatUnits } from "@ethersproject/units"
 import { ONE_WEEK } from "@utils/constants"
+import { gql, GraphQLClient } from "graphql-request"
+import { Signer } from "ethers"
 import { getSigner } from "./utils/signerFactory"
 import { logTxDetails } from "./utils/deploy-utils"
 import { getChain, resolveAddress } from "./utils/networkAddressFactory"
 import { usdFormatter } from "./utils/quantity-formatters"
 import { getBlock } from "./utils/snap-utils"
 
+interface Account {
+    id: string
+    stakedTokenAccounts: Array<{ id: string }>
+}
+const NO_TIME_MULTIPLIER_UPDATE = "NO_TIME_MULTIPLIER_UPDATE"
+const BATCH_SIZE = 50
+const QUERY_SIZE = 1000
+
+async function fetchAllStakers(): Promise<Array<Account>> {
+    // TODO = it has a limit of 1000 accounts, it needs pagination to bring all accounts or find the way to pass "limit -1" to the query.
+    // https://dune.com/queries/161334/315606
+    const gqlClient = new GraphQLClient("https://api.thegraph.com/subgraphs/name/mstable/mstable-staking")
+    const query = gql`{
+        accounts(first: ${QUERY_SIZE}) {
+          id
+          stakedTokenAccounts {
+            id
+          }
+        }
+        _meta {
+          block {
+            number
+            hash
+          }
+        }
+      }`
+
+    const gqlData = await gqlClient.request(query)
+    const accounts = gqlData.accounts
+    // eslint-disable-next-line no-underscore-dangle
+    const blockNumber = gqlData._meta.block.number
+    console.log(`staked-time:: fetchAllStakersHolders for block number: ${blockNumber} accounts total: ${accounts.length}`)
+    return accounts
+}
+
+
+function filterAccountsByStakingToken(accounts: Array<Account>, stakingTokenAddress: string): Array<string> {
+
+    const isStakingTokenAccount = (account: Account) => account.stakedTokenAccounts.find(a => a.id.toLowerCase().includes(stakingTokenAddress))
+    const stakerHolders = accounts.filter(isStakingTokenAccount).map((a: Account) => a.id)
+
+    console.log(`staked-time:: filterAccountsByStakingToken accounts total: ${accounts.length}`)
+    return stakerHolders
+}
+async function filterAccountsTimeMultiplier(accounts: Array<string>, stakingTokenAddress: string, signer: Signer): Promise<Array<string>> {
+    const stakingToken = StakedToken__factory.connect(stakingTokenAddress, signer)
+
+    const tryReviewTimestamp = async (accountAddress: string): Promise<string> => stakingToken.callStatic.reviewTimestamp(accountAddress).then(() => accountAddress).catch(() => NO_TIME_MULTIPLIER_UPDATE)
+    const accountsToUpdate = []
+    let progress = BATCH_SIZE > accounts.length ? accounts.length : BATCH_SIZE
+    let promises = []
+    for (let i = 0; i < accounts.length; i++) {
+        const accountAddress = accounts[i]
+        promises.push(tryReviewTimestamp(accountAddress))
+        if (progress < i || i === accounts.length - 1) {
+            console.log(`staked-time:: filterAccountsTimeMultiplier validating: ${progress} out of ${accounts.length}`, new Date())
+            progress = progress + BATCH_SIZE > accounts.length ? accounts.length : progress + BATCH_SIZE
+            // eslint-disable-next-line no-await-in-loop
+            const resolved = (await Promise.all(promises)).filter(result => result !== NO_TIME_MULTIPLIER_UPDATE)
+            promises = [] // clean buffer of promises
+            accountsToUpdate.push(...resolved)
+        }
+    }
+    console.log(`staked-time:: filterAccountsTimeMultiplier ${accountsToUpdate.length} out of ${accounts.length}
+    accounts: 
+    ${accountsToUpdate.join(",")}`)
+
+    return accountsToUpdate
+}
 subtask("staked-snap", "Dumps a user's staking token details.")
     .addOptionalParam("asset", "Symbol of staking token. MTA or mBPT", "MTA", types.string)
     .addParam("user", "Address or contract name of user", undefined, types.string)
@@ -266,21 +337,74 @@ task("staked-fees").setAction(async (_, __, runSuper) => {
 })
 
 subtask("staked-time", "Updates a user's time multiplier.")
-    .addParam("user", "Address or contract name of user", undefined, types.string)
+    .addParam("user", "Address or contract name of users, separated by ',' ", undefined, types.string)
     .addOptionalParam("asset", "Symbol of staking token. MTA or mBPT", "MTA", types.string)
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "average", types.string)
     .setAction(async (taskArgs, hre) => {
         const signer = await getSigner(hre, taskArgs.speed, false)
         const chain = getChain(hre)
-
-        const stakingTokenAddress = resolveAddress("MTA", chain, "vault")
+        console.log(`staked-time user ${taskArgs.user} asset ${taskArgs.asset} speed ${taskArgs.speed}`)
+        const stakingTokenAddress = resolveAddress(taskArgs.asset, chain, "vault")
         const stakingToken = StakedToken__factory.connect(stakingTokenAddress, signer)
+        const users = taskArgs.user.split(",");
+        let totalTxCost = BN.from(0)
+        let progress = BATCH_SIZE > users.length ? users.length : BATCH_SIZE
+        let promises = []
+        const reviewTimestamp = async (accountAddress: string): Promise<BN> => {
+            const tx = await stakingToken.reviewTimestamp(accountAddress)
+            const receipt = await logTxDetails(tx, `update time multiplier for ${accountAddress}`)
+            return receipt.gasUsed.mul(tx.gasPrice ?? 0)
+        }
 
-        const userAddress = resolveAddress(taskArgs.user, chain)
-
-        const tx = await stakingToken.reviewTimestamp(userAddress)
-        await logTxDetails(tx, `update time multiplier`)
+        for (let i = 0; i < users.length; i++) {
+            promises.push(reviewTimestamp(users[i]))
+            if (progress < i || i === users.length - 1) {
+                console.log(`staked-time:: executing ${progress} out of ${users.length}`, new Date())
+                progress = progress + BATCH_SIZE > users.length ? users.length : progress + BATCH_SIZE
+                // eslint-disable-next-line no-await-in-loop
+                totalTxCost = totalTxCost.add((await Promise.all(promises)).reduce((a, b) => a.add(b)))
+                promises = [] // clean buffer of promises
+            }
+        }
+        console.log(`staked-time:: Time multiplier updated for  ${users.length} accounts, total gas ${formatUnits(totalTxCost)} Gwei`)
     })
 task("staked-time").setAction(async (_, __, runSuper) => {
+    await runSuper()
+})
+
+subtask("staked-time-all-users", "Updates all user's time multiplier.")
+    .addOptionalParam("assets", "Symbol of staking token. MTA or mBPT", "MTA,mBPT", types.string)
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "average", types.string)
+    .setAction(async (taskArgs, hre) => {
+        const chain = getChain(hre)
+        const signer = await getSigner(hre, taskArgs.speed, false)
+
+        const stakingTokens = taskArgs.assets.split(",")
+        const startDate = new Date()
+        console.log(`staked-time-all-user:: assets: ${taskArgs.assets} stakingTokens: ${stakingTokens} ${stakingTokens.length}  startDate: ${startDate}`)
+        const allStakers = await fetchAllStakers()
+        // for each stakingTokens call staked-time
+        for (let i = 0; i < stakingTokens.length; i++) {
+            const stakingTokenAddress = resolveAddress(stakingTokens[i], chain, "vault")
+            console.log(`staked-time:: stakingTokens: ${stakingTokens[i]} chain:${chain} stakingTokenAddress:${stakingTokenAddress}`)
+            let accounts = filterAccountsByStakingToken(allStakers, stakingTokenAddress.toLowerCase())
+            // eslint-disable-next-line no-await-in-loop
+            accounts = await filterAccountsTimeMultiplier(accounts, stakingTokenAddress, signer)
+            if (accounts.length > 0) {
+                // eslint-disable-next-line no-await-in-loop
+                await hre.run("staked-time",
+                    {
+                        user: accounts.join(","),
+                        asset: stakingTokens[i],
+                        speed: taskArgs.speed
+                    });
+            }
+        }
+        const endDate = new Date()
+        const diff = ((endDate.getTime() - startDate.getTime()) / 1000) / 60;
+
+        console.log(`staked-time-all-user:: startDate: ${startDate}, endDate: ${endDate}, process time: ${Math.abs(Math.round(diff))}`)
+    })
+task("staked-time-all-users").setAction(async (_, __, runSuper) => {
     await runSuper()
 })

--- a/tasks/utils/networkAddressFactory.ts
+++ b/tasks/utils/networkAddressFactory.ts
@@ -41,6 +41,7 @@ export const contractNames = [
     "QuestSigner",
     "StakedTokenMTA",
     "StakedTokenBPT",
+    "StakedTokenBatcher",
     "PlatformTokenVendorFactory",
     "BalancerVault",
     "BalancerRecipient",
@@ -67,7 +68,9 @@ export const contractNames = [
     "VisorRouter",
     "VotiumBribe",
     "VotiumForwarder",
+    "VisorForwarder",
     "IdleForwarder",
+    "TreasuryDAOForwarder",
 ] as const
 export type ContractNames = typeof contractNames[number]
 
@@ -162,6 +165,8 @@ export const getChainAddress = (contractName: ContractNames, chain: Chain): stri
                 return "0x8f2326316eC696F6d023E37A9931c2b2C177a3D7"
             case "StakedTokenBPT":
                 return "0xeFbe22085D9f29863Cfb77EEd16d3cC0D927b011"
+            case "StakedTokenBatcher":
+                return "TODO_AFTER_DEPLOYMENT"
             case "AaveIncentivesController":
                 return "0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5"
             case "AaveLendingPoolAddressProvider":
@@ -200,6 +205,10 @@ export const getChainAddress = (contractName: ContractNames, chain: Chain): stri
                 return "0x19bbc3463dd8d07f55438014b021fb457ebd4595"
             case "VotiumForwarder":
                 return "0xb6d519a0D616f6F5Fac2b1dBC5bcb92ea58EDa4a"
+            case "VisorForwarder":
+                return "0xceF5df9d514bF0619c2ee87e2dDF1Af93FfAc0F6"
+            case "TreasuryDAOForwarder":
+                return "0x4b27BaD829092229D2461633A3c08e284BdcBC3A"
             case "IdleForwarder":
                 return "0xD2192aa940588851541086D03942572E02CF71B4"
             default:

--- a/tasks/utils/networkAddressFactory.ts
+++ b/tasks/utils/networkAddressFactory.ts
@@ -166,7 +166,7 @@ export const getChainAddress = (contractName: ContractNames, chain: Chain): stri
             case "StakedTokenBPT":
                 return "0xeFbe22085D9f29863Cfb77EEd16d3cC0D927b011"
             case "StakedTokenBatcher":
-                return "TODO_AFTER_DEPLOYMENT"
+                return "0xB40DC45576Cb3B70A1a56E91A120768F76A82042"
             case "AaveIncentivesController":
                 return "0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5"
             case "AaveLendingPoolAddressProvider":

--- a/test/governance/staking/staked-token-batcher.spec.ts
+++ b/test/governance/staking/staked-token-batcher.spec.ts
@@ -1,0 +1,142 @@
+import { ethers } from "hardhat"
+import { MassetMachine, StandardAccounts } from "@utils/machines"
+import { MockNexus__factory } from "types/generated/factories/MockNexus__factory"
+import {
+    AssetProxy__factory,
+    QuestManager__factory,
+    MockERC20,
+    MockERC20__factory,
+    MockNexus,
+    PlatformTokenVendorFactory__factory,
+    SignatureVerifier__factory,
+    StakedToken,
+    StakedToken__factory,
+    StakedTokenBatcher,
+    StakedTokenBatcher__factory,
+
+} from "types"
+import { DEAD_ADDRESS } from "index"
+import { ONE_WEEK } from "@utils/constants"
+import { simpleToExactAmount } from "@utils/math"
+import { expect } from "chai"
+import { increaseTime } from "@utils/time"
+import { formatBytes32String } from "ethers/lib/utils"
+
+describe("Staked Token Batcher", () => {
+    let sa: StandardAccounts
+    let stakedTokenBatcher: StakedTokenBatcher
+    let stakedToken: StakedToken
+
+    let nexus: MockNexus
+    let rewardToken: MockERC20
+    const stakedAmount = simpleToExactAmount(1000)
+
+    async function deployStakedToken(): Promise<StakedToken> {
+        nexus = await new MockNexus__factory(sa.default.signer).deploy(sa.governor.address, DEAD_ADDRESS, DEAD_ADDRESS)
+        await nexus.setRecollateraliser(sa.mockRecollateraliser.address)
+        rewardToken = await new MockERC20__factory(sa.default.signer).deploy("Reward", "RWD", 18, sa.default.address, simpleToExactAmount(1000000))
+
+        const signatureVerifier = await new SignatureVerifier__factory(sa.default.signer).deploy()
+        const questManagerLibraryAddresses = {
+            "contracts/governance/staking/deps/SignatureVerifier.sol:SignatureVerifier": signatureVerifier.address,
+        }
+        const questManagerImpl = await new QuestManager__factory(questManagerLibraryAddresses, sa.default.signer).deploy(nexus.address)
+        let data = questManagerImpl.interface.encodeFunctionData("initialize", [sa.questMaster.address, sa.questSigner.address])
+        const questManagerProxy = await new AssetProxy__factory(sa.default.signer).deploy(questManagerImpl.address, DEAD_ADDRESS, data)
+
+        const platformTokenVendorFactory = await new PlatformTokenVendorFactory__factory(sa.default.signer).deploy()
+        const stakedTokenLibraryAddresses = {
+            "contracts/rewards/staking/PlatformTokenVendorFactory.sol:PlatformTokenVendorFactory": platformTokenVendorFactory.address,
+        }
+        const stakedTokenFactory = new StakedToken__factory(stakedTokenLibraryAddresses, sa.default.signer)
+        const stakedTokenImpl = await stakedTokenFactory.deploy(
+            nexus.address,
+            rewardToken.address,
+            questManagerProxy.address,
+            rewardToken.address,
+            ONE_WEEK,
+            false
+        )
+        data = stakedTokenImpl.interface.encodeFunctionData("__StakedToken_init", [
+            formatBytes32String("Staked Rewards"),
+            formatBytes32String("stkRWD"),
+            sa.mockRewardsDistributor.address,
+        ])
+        const stakedTokenProxy = await new AssetProxy__factory(sa.default.signer).deploy(stakedTokenImpl.address, DEAD_ADDRESS, data)
+        return stakedTokenFactory.attach(stakedTokenProxy.address) as StakedToken
+
+    }
+    before("Create Contract", async () => {
+        const accounts = await ethers.getSigners()
+        const mAssetMachine = await new MassetMachine().initAccounts(accounts)
+        sa = mAssetMachine.sa
+        stakedTokenBatcher = await new StakedTokenBatcher__factory(sa.default.signer ).deploy()
+        stakedToken = await deployStakedToken();
+        // Distribute reward token to multiple users 
+        await rewardToken.connect(sa.default.signer).approve(sa.dummy1.address, stakedAmount)
+        await rewardToken.connect(sa.default.signer).transfer(sa.dummy1.address, stakedAmount)
+
+        await rewardToken.connect(sa.default.signer).approve(sa.dummy2.address, stakedAmount)
+        await rewardToken.connect(sa.default.signer).transfer(sa.dummy2.address, stakedAmount)
+        
+        await rewardToken.connect(sa.default.signer).approve(sa.dummy3.address, stakedAmount)
+        await rewardToken.connect(sa.default.signer).transfer(sa.dummy3.address, stakedAmount)        
+    })
+
+    describe("reviewTimestamp", async () => {
+        before("Stake some tokens", async () => {
+            // Stake for default and user1
+            await rewardToken.connect(sa.default.signer).approve(stakedToken.address, stakedAmount)
+            const delegateAddress = sa.dummy1.address
+            await stakedToken.connect(sa.default.signer)["stake(uint256,address)"](stakedAmount, delegateAddress)
+
+            await rewardToken.connect(sa.dummy1.signer).approve(stakedToken.address, stakedAmount)
+            await stakedToken.connect(sa.dummy1.signer)["stake(uint256,address)"](stakedAmount, delegateAddress)
+
+            await rewardToken.connect(sa.dummy2.signer).approve(stakedToken.address, stakedAmount)
+            await stakedToken.connect(sa.dummy2.signer)["stake(uint256,address)"](stakedAmount, delegateAddress)            
+        })
+
+        it("fails if the input is wrong",async  () => {
+            await expect( stakedTokenBatcher.reviewTimestamp(stakedToken.address, [])).to.revertedWith("Invalid inputs")
+        })    
+        it("fails if one of the accounts reverts", async () => {
+            await expect( stakedTokenBatcher.reviewTimestamp(stakedToken.address, [sa.default.address])).to.revertedWith("Nothing worth poking here")
+        })     
+        it("updates the time multiplier for one account", async () => {
+             // 3 months = 1.2x
+            await increaseTime(ONE_WEEK.mul(13))
+
+            const accounts = [sa.default.address];
+            const balanceDataBefore  = await stakedToken.balanceData(sa.default.address)
+            await  stakedTokenBatcher.reviewTimestamp(stakedToken.address, accounts)
+            const balanceDataAfter  = await stakedToken.balanceData(sa.default.address)
+            expect(balanceDataAfter.timeMultiplier).to.not.be.equal(balanceDataBefore.timeMultiplier)
+            expect(balanceDataAfter.timeMultiplier).to.be.equal(20)
+        }) 
+        it("updates the time multiplier for multiple accounts", async () => {
+            // 6 months = 1.3x
+            await increaseTime(ONE_WEEK.mul(13))
+
+            const accounts = [sa.default.address, sa.dummy1.address,sa.dummy2.address];
+            const balanceDataBefore  = await Promise.all(accounts.map(async (account) => stakedToken.balanceData(account)))
+            await  stakedTokenBatcher.reviewTimestamp(stakedToken.address, accounts)
+            const balanceDataAfter  = await Promise.all(accounts.map(async (account) => stakedToken.balanceData(account)))
+
+            balanceDataBefore.forEach((dataBefore, i) => {
+                expect(dataBefore.timeMultiplier).to.not.be.equal(balanceDataAfter[i].timeMultiplier)    
+            });
+            
+        }) 
+        it("fails if one of the accounts reverts when multiple", async () => {
+            const accounts = [sa.default.address, sa.dummy1.address,  sa.dummy2.address, sa.dummy3.address];
+            await increaseTime(ONE_WEEK.mul(26))
+
+            await rewardToken.connect(sa.dummy3.signer).approve(stakedToken.address, stakedAmount)
+            await stakedToken.connect(sa.dummy3.signer)["stake(uint256,address)"](stakedAmount, sa.dummy3.address)  
+            await expect( stakedTokenBatcher.reviewTimestamp(stakedToken.address, accounts)).to.revertedWith("Nothing worth poking here")
+        })    
+    }) 
+
+
+})


### PR DESCRIPTION
Closes https://github.com/mstable/mstable-v1-backlog/issues/5

adds new task  **staked-time-all-users**, it does the following: 
- Get all the stakers accounts for both  MTA and mBPT vaults.
- Filter all accounts where the time multiplier does not need to be updated. 
- Invokes for each account `GamifiedToken.reviewTimestamp`  to update the time multiplier. 