### PR TITLE
chore: removed items covered in Notion

### DIFF
--- a/.github/ISSUE_TEMPLATE/deployment_task.md
+++ b/.github/ISSUE_TEMPLATE/deployment_task.md
@@ -18,13 +18,11 @@ The following tasks must be completed previous to the deployment.
 - [ ] Code Coverage passed at https://coveralls.io/ 
 - [ ] Deployment hardhat tasks created.
     - [ ] Double check constructor arguments, initialize functions.
-- [ ] MIP Created and approved 
 - [ ] Deployment 
   - [ ] Proposed upgrade to smart contract (write down encodeFunctionData)
   - [ ] Accept upgrade to smart contract 
 - [ ] Verify Etherscan
 - [ ] Request labels for Etherscan
-- [ ] Announce it on Discord
 
 
 ## Artifacts 


### PR DESCRIPTION
Removed some items that are part of the notion protocol rollout plan. This list should focus more on the deployment pre and post tasks.