### PR TITLE
feat: adds BalRewardsForwarder

### DIFF
--- a/contracts/emissions/BalRewardsForwarder.sol
+++ b/contracts/emissions/BalRewardsForwarder.sol
@@ -12,7 +12,7 @@ import { BasicRewardsForwarder } from "./BasicRewardsForwarder.sol";
 /**
  * @title  BalRewardsForwarder
  * @author mStable
- * @notice Transfers any received reward tokens to another contract or account.
+ * @notice Transfers any received reward tokens to another contract and notifies it.
  * @dev    VERSION: 1.0
  *         DATE:    2022-06-16
  */

--- a/contracts/emissions/BalRewardsForwarder.sol
+++ b/contracts/emissions/BalRewardsForwarder.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity 0.8.6;
+
+import { IChildChainStreamer } from "../peripheral/Balancer/IChildChainStreamer.sol";
+import { IRewardsDistributionRecipient } from "../interfaces/IRewardsDistributionRecipient.sol";
+import { InitializableRewardsDistributionRecipient } from "../rewards/InitializableRewardsDistributionRecipient.sol";
+import { Initializable } from "../shared/@openzeppelin-2.5/Initializable.sol";
+import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { BasicRewardsForwarder } from "./BasicRewardsForwarder.sol";
+
+/**
+ * @title  BalRewardsForwarder
+ * @author mStable
+ * @notice Transfers any received reward tokens to another contract or account.
+ * @dev    VERSION: 1.0
+ *         DATE:    2022-06-16
+ */
+contract BalRewardsForwarder is BasicRewardsForwarder {
+    using SafeERC20 for IERC20;
+
+    /**
+     * @param _nexus        mStable system Nexus address
+     * @param _rewardsToken Token that is being distributed as a reward. eg MTA
+     */
+    constructor(address _nexus, address _rewardsToken)
+        BasicRewardsForwarder(_nexus, _rewardsToken)
+    {}
+
+    /**
+     * @notice Called by the Emissions Controller to trigger the processing of the weekly BAL rewards.
+     * @dev    The Emissions Controller has already transferred the MTA to this contract.
+     * @param _rewards Units of reward tokens that were distributed to this contract
+     */
+    function notifyRewardAmount(uint256 _rewards)
+        external
+        override(BasicRewardsForwarder)
+        onlyRewardsDistributor
+    {
+        // Send the rewards to the end recipient
+        REWARDS_TOKEN.safeTransfer(endRecipient, _rewards);
+        // Notify the end recipient of the rewards
+        IChildChainStreamer(endRecipient).notify_reward_amount(address(REWARDS_TOKEN));
+        emit RewardsReceived(_rewards);
+    }
+}

--- a/contracts/emissions/BasicRewardsForwarder.sol
+++ b/contracts/emissions/BasicRewardsForwarder.sol
@@ -60,6 +60,7 @@ contract BasicRewardsForwarder is
      */
     function notifyRewardAmount(uint256 _rewards)
         external
+        virtual
         override(IRewardsDistributionRecipient)
         onlyRewardsDistributor
     {

--- a/contracts/peripheral/Balancer/IChildChainStreamer.sol
+++ b/contracts/peripheral/Balancer/IChildChainStreamer.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity 0.8.6;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IChildChainStreamer {
+    /**
+     * @notice Notifies reward tokens for `rewardToken`
+     * @param rewardToken Reward token to notify
+     */
+    function notify_reward_amount(address rewardToken) external;
+}

--- a/contracts/z_mocks/emissions/MockChildChainStreamer.sol
+++ b/contracts/z_mocks/emissions/MockChildChainStreamer.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IChildChainStreamer } from "../../peripheral/Balancer/IChildChainStreamer.sol";
+
+contract MockChildChainStreamer is IChildChainStreamer {
+    function notify_reward_amount(address token) external override {
+        // stream  it to the gauge
+    }
+}

--- a/tasks/deployEmissionsController.ts
+++ b/tasks/deployEmissionsController.ts
@@ -56,6 +56,7 @@ task("deploy-bridge-forwarder", "Deploys a BridgeForwarder contract on mainnet f
         undefined,
         types.string,
     )
+    .addOptionalParam("useProxy", "Deploy with proxy", true, types.boolean)
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
     .setAction(async (taskArgs, hre) => {
         const chain = getChain(hre)
@@ -63,7 +64,7 @@ task("deploy-bridge-forwarder", "Deploys a BridgeForwarder contract on mainnet f
 
         const l2Chain = chain === Chain.mainnet ? Chain.polygon : Chain.mumbai
         const bridgeRecipientAddress = resolveAddress(taskArgs.token, l2Chain, "bridgeRecipient")
-        await deployBridgeForwarder(signer, hre, bridgeRecipientAddress)
+        await deployBridgeForwarder(signer, hre, bridgeRecipientAddress, taskArgs.useProxy)
     })
 
 task("deploy-basic-forwarder", "Deploys a basic rewards forwarder from the emissions controller.")
@@ -131,7 +132,7 @@ task("deploy-bal-reward-forwarder", "Deploys a basic rewards forwarder from the 
         await deployBalRewardsForwarder(signer, emissionsControllerAddress, taskArgs.recipient, hre, taskArgs.owner)
     })
 
-task("deploy-bridge-recipient", "Deploys L2 Bridge Recipients for Polygon mUSD Vault and FRAX Farm")
+task("deploy-bridge-recipient", "Deploys L2 Bridge Recipients for Polygon")
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
     .setAction(async (taskArgs, hre) => {
         const signer = await getSigner(hre, taskArgs.speed)

--- a/tasks/rewards.ts
+++ b/tasks/rewards.ts
@@ -80,7 +80,7 @@ task("claim-comp").setAction(async (_, __, runSuper) => {
 
 task("claim-aave", "Call liquidator to claim stkAAVE")
     .addOptionalParam("basset", "Symbol of bAsset in AAVE. eg USDT, WBTC, BUSD or RAI", "USDT", types.string)
-    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
+    .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "average", types.string)
     .setAction(async (taskArgs, hre) => {
         const signer = await getSigner(hre, taskArgs.speed)
         const chain = getChain(hre)

--- a/tasks/utils/networkAddressFactory.ts
+++ b/tasks/utils/networkAddressFactory.ts
@@ -53,8 +53,9 @@ export const contractNames = [
     "CurveRegistryExchange",
     "Disperse",
     "DisperseForwarder",
+    "BalRewardsForwarder",
     "BpMTAStreamer",
-    "BpMTARewardsForwarder",
+    "BpMTABridgeRecipient",
     "QuickSwapRouter",
     "UniswapRouterV3",
     "UniswapQuoterV3",
@@ -250,10 +251,12 @@ export const getChainAddress = (contractName: ContractNames, chain: Chain): stri
                 return "0xD152f549545093347A162Dce210e7293f1452150"
             case "DisperseForwarder":
                 return "0x5783458E67B380d19a84514F11054ABDc326EB07"
+            case "BalRewardsForwarder":
+                return "0x1Ee5b5Acd5253f61FE29531ECE4a540c8b8D9eFB"
             case "BpMTAStreamer":
                 return "0xb061F502d84f00d1B26568888A8f741cBE352C23"
-            case "BpMTARewardsForwarder":
-                return "TODO-L2BridgeRecipient"
+            case "BpMTABridgeRecipient":
+                return "0x9A718E9B80F7D7006E891051ba4790C6fc839268"
             case "QuickSwapRouter":
                 return "0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff"
             case "MStableYieldSource":

--- a/tasks/utils/networkAddressFactory.ts
+++ b/tasks/utils/networkAddressFactory.ts
@@ -53,8 +53,8 @@ export const contractNames = [
     "CurveRegistryExchange",
     "Disperse",
     "DisperseForwarder",
-    "BP-MTA-Streamer",
-    "BP-MTA-RewardsForwarder",
+    "BpMTAStreamer",
+    "BpMTARewardsForwarder",
     "QuickSwapRouter",
     "UniswapRouterV3",
     "UniswapQuoterV3",
@@ -250,10 +250,10 @@ export const getChainAddress = (contractName: ContractNames, chain: Chain): stri
                 return "0xD152f549545093347A162Dce210e7293f1452150"
             case "DisperseForwarder":
                 return "0x5783458E67B380d19a84514F11054ABDc326EB07"
-            case "BP-MTA-Streamer":
+            case "BpMTAStreamer":
                 return "0xb061F502d84f00d1B26568888A8f741cBE352C23"
-            case "BP-MTA-RewardsForwarder":
-                return "TODO AFTER DEPLOYMENT"
+            case "BpMTARewardsForwarder":
+                return "TODO-L2BridgeRecipient"
             case "QuickSwapRouter":
                 return "0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff"
             case "MStableYieldSource":

--- a/tasks/utils/networkAddressFactory.ts
+++ b/tasks/utils/networkAddressFactory.ts
@@ -53,6 +53,8 @@ export const contractNames = [
     "CurveRegistryExchange",
     "Disperse",
     "DisperseForwarder",
+    "BP-MTA-Streamer",
+    "BP-MTA-RewardsForwarder",
     "QuickSwapRouter",
     "UniswapRouterV3",
     "UniswapQuoterV3",
@@ -248,6 +250,10 @@ export const getChainAddress = (contractName: ContractNames, chain: Chain): stri
                 return "0xD152f549545093347A162Dce210e7293f1452150"
             case "DisperseForwarder":
                 return "0x5783458E67B380d19a84514F11054ABDc326EB07"
+            case "BP-MTA-Streamer":
+                return "0xb061F502d84f00d1B26568888A8f741cBE352C23"
+            case "BP-MTA-RewardsForwarder":
+                return "TODO AFTER DEPLOYMENT"
             case "QuickSwapRouter":
                 return "0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff"
             case "MStableYieldSource":

--- a/tasks/utils/tokens.ts
+++ b/tasks/utils/tokens.ts
@@ -480,9 +480,10 @@ export const PBAL: Token = {
     chain: Chain.polygon,
     decimals: 18,
     quantityFormatter: "USD",
-    bridgeForwarder: "0x4e649Fa2f3C0Ff18b7695d1e1fa371a1999187Dc",
+    bridgeForwarder: "0x4e649Fa2f3C0Ff18b7695d1e1fa371a1999187Dc", // DEPLOY NEW BRIDGE FORWARDER
     // The DisperseForwarder contract on Polygon
-    bridgeRecipient: "0x5783458E67B380d19a84514F11054ABDc326EB07",
+    // bridgeRecipient: "0x5783458E67B380d19a84514F11054ABDc326EB07",
+    bridgeRecipient: "TODO_CHANGE_AFTER_DEPLOYMENT", // TODO - BALANCER
 }
 
 export const RBAL: Token = {

--- a/tasks/utils/tokens.ts
+++ b/tasks/utils/tokens.ts
@@ -480,9 +480,9 @@ export const PBAL: Token = {
     chain: Chain.polygon,
     decimals: 18,
     quantityFormatter: "USD",
-    bridgeForwarder: "0x4e649Fa2f3C0Ff18b7695d1e1fa371a1999187Dc", // DEPLOY NEW BRIDGE FORWARDER
+    bridgeForwarder: "0x4e649Fa2f3C0Ff18b7695d1e1fa371a1999187Dc",
     // The L2BridgeRecipient contract on Polygon
-    bridgeRecipient: "TODO-L2BridgeRecipient",
+    bridgeRecipient: "0x9A718E9B80F7D7006E891051ba4790C6fc839268",
 }
 
 export const RBAL: Token = {

--- a/tasks/utils/tokens.ts
+++ b/tasks/utils/tokens.ts
@@ -481,9 +481,8 @@ export const PBAL: Token = {
     decimals: 18,
     quantityFormatter: "USD",
     bridgeForwarder: "0x4e649Fa2f3C0Ff18b7695d1e1fa371a1999187Dc", // DEPLOY NEW BRIDGE FORWARDER
-    // The DisperseForwarder contract on Polygon
-    // bridgeRecipient: "0x5783458E67B380d19a84514F11054ABDc326EB07",
-    bridgeRecipient: "TODO_CHANGE_AFTER_DEPLOYMENT", // TODO - BALANCER
+    // The L2BridgeRecipient contract on Polygon
+    bridgeRecipient: "TODO-L2BridgeRecipient",
 }
 
 export const RBAL: Token = {

--- a/test-fork/emissions/emissions-mainnet-deployment.spec.ts
+++ b/test-fork/emissions/emissions-mainnet-deployment.spec.ts
@@ -148,7 +148,25 @@ describe("Fork test Emissions Controller on mainnet", async () => {
         it("Deploy bridgeForwarder for Polygon mUSD Vault", async () => {
             emissionsController = await deployEmissionsController(ops, hre)
             const bridgeRecipient = Wallet.createRandom()
-            const bridgeForwarder = await deployBridgeForwarder(ops, hre, bridgeRecipient.address, emissionsController.address)
+            const bridgeForwarder = await deployBridgeForwarder(ops, hre, bridgeRecipient.address, true, emissionsController.address)
+
+            expect(await bridgeForwarder.BRIDGE_RECIPIENT(), "Bridge Recipient").to.eq(bridgeRecipient.address)
+            expect(await bridgeForwarder.rewardsDistributor(), "Emissions Controller").to.eq(emissionsController.address)
+            expect(await bridgeForwarder.BRIDGE_TOKEN_LOCKER(), "Bridge token locker").to.eq("0x40ec5B33f54e0E8A33A975908C5BA1c14e5BbbDf")
+            expect(await bridgeForwarder.ROOT_CHAIN_MANAGER(), "RootChainMananger").to.eq("0xA0c68C638235ee32657e8f720a23ceC1bFc77C77")
+            expect(await bridgeForwarder.REWARDS_TOKEN(), "MTA").to.eq(MTA.address)
+            expect(await mta.allowance(bridgeForwarder.address, "0x40ec5B33f54e0E8A33A975908C5BA1c14e5BbbDf")).to.eq(MAX_UINT256)
+
+            const tx = await emissionsController.connect(governor).addDial(bridgeForwarder.address, 0, true)
+
+            await expect(tx).to.emit(emissionsController, "AddedDial").withArgs(11, bridgeForwarder.address)
+
+            expect(await emissionsController.getDialRecipient(11), "dial 10 Bridge Forwarder").to.eq(bridgeForwarder.address)
+        })
+        it("Upgrade a bridgeForwarder proxy", async () => {
+            // emissionsController = await deployEmissionsController(ops, hre)
+            const bridgeRecipient = Wallet.createRandom()
+            const bridgeForwarder = await deployBridgeForwarder(ops, hre, bridgeRecipient.address, true, emissionsController.address)
 
             expect(await bridgeForwarder.BRIDGE_RECIPIENT(), "Bridge Recipient").to.eq(bridgeRecipient.address)
             expect(await bridgeForwarder.rewardsDistributor(), "Emissions Controller").to.eq(emissionsController.address)

--- a/test/emissions/bal-rewards-forwarder.spec.ts
+++ b/test/emissions/bal-rewards-forwarder.spec.ts
@@ -1,0 +1,135 @@
+import { ethers } from "hardhat"
+import { expect } from "chai"
+
+import { simpleToExactAmount } from "@utils/math"
+import { MassetMachine, StandardAccounts } from "@utils/machines"
+
+import {
+    MockNexus__factory,
+    MockNexus,
+    BalRewardsForwarder,
+    BalRewardsForwarder__factory,
+    MockChildChainStreamer,
+    MockChildChainStreamer__factory,
+    MockERC20,
+} from "types/generated"
+import { MAX_UINT256, ZERO_ADDRESS } from "@utils/constants"
+import { Wallet } from "@ethersproject/wallet"
+import { Account } from "types/common"
+
+describe("BalRewardsForwarder", () => {
+    let sa: StandardAccounts
+    let mAssetMachine: MassetMachine
+    let nexus: MockNexus
+    let rewardsToken: MockERC20
+    let endRecipientAddress: string
+    let owner: Account
+    let emissionsController: Account
+    let forwarder: BalRewardsForwarder
+    let streamer: MockChildChainStreamer
+
+    /*
+        Test Data
+        mAssets: mUSD and mBTC with 18 decimals
+     */
+    const setup = async (): Promise<void> => {
+        // Deploy mock Nexus
+        nexus = await new MockNexus__factory(sa.default.signer).deploy(
+            sa.governor.address,
+            sa.mockSavingsManager.address,
+            sa.mockInterestValidator.address,
+        )
+
+        rewardsToken = await mAssetMachine.loadBassetProxy("Rewards Token", "RWD", 18)
+        owner = sa.dummy1
+        emissionsController = sa.dummy2
+        streamer = await new MockChildChainStreamer__factory(sa.default.signer).deploy()
+        endRecipientAddress = streamer.address
+
+        // Deploy RevenueForwarder
+        forwarder = await new BalRewardsForwarder__factory(owner.signer).deploy(nexus.address, rewardsToken.address)
+        await forwarder.initialize(emissionsController.address, endRecipientAddress)
+
+        await rewardsToken.transfer(emissionsController.address, simpleToExactAmount(10000))
+        await rewardsToken.connect(emissionsController.signer).approve(forwarder.address, MAX_UINT256)
+    }
+
+    before(async () => {
+        const accounts = await ethers.getSigners()
+        mAssetMachine = await new MassetMachine().initAccounts(accounts)
+        sa = mAssetMachine.sa
+
+        await setup()
+    })
+
+    describe("creating new instance", () => {
+        it("should have immutable variables set", async () => {
+            expect(await forwarder.nexus(), "Nexus").eq(nexus.address)
+            expect(await forwarder.REWARDS_TOKEN(), "rewards token").eq(rewardsToken.address)
+            expect(await forwarder.getRewardToken(), "rewards token").eq(rewardsToken.address)
+            expect(await forwarder.rewardsDistributor(), "Emissions controller").eq(emissionsController.address)
+            expect(await forwarder.endRecipient(), "End recipient").eq(endRecipientAddress)
+        })
+        describe("it should fail if zero", () => {
+            it("nexus", async () => {
+                const tx = new BalRewardsForwarder__factory(sa.default.signer).deploy(ZERO_ADDRESS, rewardsToken.address)
+                await expect(tx).to.revertedWith("Nexus address is zero")
+            })
+            it("rewards token", async () => {
+                const tx = new BalRewardsForwarder__factory(sa.default.signer).deploy(nexus.address, ZERO_ADDRESS)
+                await expect(tx).to.revertedWith("Rewards token is zero")
+            })
+            it("End recipient", async () => {
+                const newForwarder = await new BalRewardsForwarder__factory(sa.default.signer).deploy(nexus.address, rewardsToken.address)
+                const tx = newForwarder.initialize(emissionsController.address, ZERO_ADDRESS)
+                await expect(tx).to.revertedWith("Recipient address is zero")
+            })
+        })
+    })
+    describe("notify reward amount", () => {
+        it("should transfer rewards to forwarder", async () => {
+            const endRecipientBalBefore = await rewardsToken.balanceOf(endRecipientAddress)
+            const notificationAmount = simpleToExactAmount(100, 18)
+
+            // Simulate the emissions controller calling the forwarder
+            await rewardsToken.transfer(forwarder.address, notificationAmount)
+            const tx = await forwarder.connect(emissionsController.signer).notifyRewardAmount(notificationAmount)
+
+            await expect(tx).to.emit(forwarder, "RewardsReceived").withArgs(notificationAmount)
+
+            // check output balances: mAsset sender/recipient
+            expect(await rewardsToken.balanceOf(endRecipientAddress), "end recipient bal after").eq(
+                endRecipientBalBefore.add(notificationAmount),
+            )
+        })
+        describe("should fail if", () => {
+            it("not emissions controller", async () => {
+                const tx = forwarder.notifyRewardAmount(simpleToExactAmount(1))
+                await expect(tx).to.be.revertedWith("Caller is not reward distributor")
+            })
+        })
+    })
+    describe("setEndRecipient", () => {
+        const newEndRecipientAddress = Wallet.createRandom().address
+        it("owner should set new end recipient", async () => {
+            expect(await forwarder.endRecipient(), "end recipient before").to.eq(endRecipientAddress)
+
+            const tx = await forwarder.connect(owner.signer).setEndRecipient(newEndRecipientAddress)
+
+            await expect(tx).to.emit(forwarder, "RecipientChanged").withArgs(newEndRecipientAddress)
+            expect(await forwarder.endRecipient(), "end recipient after").to.eq(newEndRecipientAddress)
+        })
+        it("governor should fail to set new end recipient", async () => {
+            const tx = forwarder.connect(sa.governor.signer).setEndRecipient(newEndRecipientAddress)
+
+            await expect(tx).to.revertedWith("Ownable: caller is not the owner")
+        })
+        it("owner should fail to set same end recipient", async () => {
+            const currentEndRecipient = await forwarder.endRecipient()
+
+            const tx = forwarder.connect(owner.signer).setEndRecipient(currentEndRecipient)
+
+            await expect(tx).to.revertedWith("Same end recipient")
+        })
+    })
+})


### PR DESCRIPTION
Integrate MTA Emissions to Balancer's new gauges


# Changes

- [x] Unit test any new contract that forwards MTA rewards to the Balancer gauge.
- [x] Fork test receiving MTA rewards from the PoS bridge and having them added to the Balancer gauge as additional rewards.
- [x] Update the following process diagram https://github.com/mstable/mStable-process-docs/blob/main/emissions/README.md#distribution-to-balancer-pool-liquidity-providers-on-polygon
Updated with commit https://github.com/mstable/mStable-process-docs/commit/3538e7560a49bcc1f402f821958f136d3a3bf265
- [x] Replace the `Polygon - emissions-controller-07-disperse` Autotask with a job that forwards MTA to the Balancer gauge. 
Update with commit https://github.com/mstable/mStable-defender/pull/12 
- [ ] Disperse any MTA in the old [Polygon Disperse Forwarder ]( https://polygonscan.com/address/0x5783458E67B380d19a84514F11054ABDc326EB07) to a safe account and then send to the the Balancer gauge.

closes https://github.com/mstable/mstable-v1-backlog/issues/44